### PR TITLE
validate response beans with schema definition

### DIFF
--- a/modules/api/pom.xml
+++ b/modules/api/pom.xml
@@ -62,5 +62,9 @@
             <artifactId>junit-jupiter-engine</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-aop</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/modules/api/src/main/java/org/eclipse/xpanse/api/exceptions/CommonExceptionHandler.java
+++ b/modules/api/src/main/java/org/eclipse/xpanse/api/exceptions/CommonExceptionHandler.java
@@ -14,6 +14,7 @@ import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.eclipse.xpanse.api.response.Response;
 import org.eclipse.xpanse.api.response.ResultType;
+import org.eclipse.xpanse.modules.models.exceptions.ResponseInvalidException;
 import org.eclipse.xpanse.modules.models.exceptions.TerraformScriptFormatInvalidException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.converter.HttpMessageConversionException;
@@ -37,7 +38,7 @@ public class CommonExceptionHandler {
      * Exception handler for MethodArgumentNotValidException.
      */
     @ExceptionHandler({MethodArgumentNotValidException.class})
-    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ResponseStatus(HttpStatus.UNPROCESSABLE_ENTITY)
     @ResponseBody
     public Response handleMethodArgumentNotValidException(MethodArgumentNotValidException ex) {
         log.error("handleMethodArgumentNotValidException: ", ex);
@@ -46,7 +47,7 @@ public class CommonExceptionHandler {
         for (FieldError fieldError : bindingResult.getFieldErrors()) {
             errors.add(fieldError.getField() + ":" + fieldError.getDefaultMessage());
         }
-        return Response.errorResponse(ResultType.BAD_PARAMETERS, errors);
+        return Response.errorResponse(ResultType.UNPROCESSABLE_ENTITY, errors);
     }
 
     /**
@@ -131,5 +132,16 @@ public class CommonExceptionHandler {
     public Response handleTerraformScriptFormatInvalidException(
             TerraformScriptFormatInvalidException ex) {
         return Response.errorResponse(ResultType.TERRAFORM_SCRIPT_INVALID, ex.getErrorReasons());
+    }
+
+    /**
+     * Exception handler for ResponseInvalidException.
+     */
+    @ExceptionHandler({ResponseInvalidException.class})
+    @ResponseStatus(HttpStatus.UNPROCESSABLE_ENTITY)
+    @ResponseBody
+    public Response handleResponseInvalidException(
+            ResponseInvalidException ex) {
+        return Response.errorResponse(ResultType.INVALID_RESPONSE, ex.getErrorReasons());
     }
 }

--- a/modules/api/src/main/java/org/eclipse/xpanse/api/response/ResponseValidator.java
+++ b/modules/api/src/main/java/org/eclipse/xpanse/api/response/ResponseValidator.java
@@ -1,0 +1,67 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * SPDX-FileCopyrightText: Huawei Inc.
+ */
+
+package org.eclipse.xpanse.api.response;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validator;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.annotation.AfterReturning;
+import org.aspectj.lang.annotation.Aspect;
+import org.eclipse.xpanse.modules.models.exceptions.ResponseInvalidException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/**
+ * Response bean validation based on AspectJ.
+ */
+@Aspect
+@Component
+@Slf4j
+public class ResponseValidator {
+
+    private final Validator validator;
+
+    public ResponseValidator(@Autowired Validator validator) {
+        this.validator = validator;
+    }
+
+    @AfterReturning(
+            pointcut = "execution(public * org.eclipse.xpanse.api.OrchestratorApi.*(..))",
+            returning = "result")
+    public void validateResponseData(Object result) {
+        validateResponse(result);
+    }
+
+    private void validateResponse(Object object) {
+        List<String> errors = new ArrayList<>();
+        if (object instanceof Collection<?>) {
+            ((Collection<?>) object).forEach(item -> {
+                Set<ConstraintViolation<Object>> validationResults = validator.validate(item);
+                if (validationResults.size() > 0) {
+                    for (ConstraintViolation<Object> error : validationResults) {
+                        errors.add(error.getPropertyPath() + ":" + error.getMessage());
+                    }
+                }
+
+            });
+        } else {
+            Set<ConstraintViolation<Object>> validationResults = validator.validate(object);
+            if (validationResults.size() > 0) {
+                for (ConstraintViolation<Object> error : validationResults) {
+                    errors.add(error.getPropertyPath() + ":" + error.getMessage());
+                }
+            }
+        }
+
+        if (!errors.isEmpty()) {
+            throw new ResponseInvalidException(errors);
+        }
+    }
+}

--- a/modules/api/src/main/java/org/eclipse/xpanse/api/response/ResultType.java
+++ b/modules/api/src/main/java/org/eclipse/xpanse/api/response/ResultType.java
@@ -18,7 +18,9 @@ public enum ResultType {
     SUCCESS("Success"),
     RUNTIME_ERROR("Runtime Failure"),
     BAD_PARAMETERS("Parameters Invalid"),
-    TERRAFORM_SCRIPT_INVALID("Terraform Script Invalid");
+    TERRAFORM_SCRIPT_INVALID("Terraform Script Invalid"),
+    UNPROCESSABLE_ENTITY("Unprocessable Entity"),
+    INVALID_RESPONSE("Response Not Valid");
 
     private final String value;
 

--- a/modules/models/src/main/java/org/eclipse/xpanse/modules/models/exceptions/ResponseInvalidException.java
+++ b/modules/models/src/main/java/org/eclipse/xpanse/modules/models/exceptions/ResponseInvalidException.java
@@ -1,0 +1,23 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * SPDX-FileCopyrightText: Huawei Inc.
+ */
+
+package org.eclipse.xpanse.modules.models.exceptions;
+
+import java.util.List;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+/**
+ *  Exception thrown when response beans does not match our own data model.
+ */
+@EqualsAndHashCode(callSuper = true)
+@Data
+public class ResponseInvalidException extends RuntimeException {
+    private List<String> errorReasons;
+
+    public ResponseInvalidException(List<String> errorReasons) {
+        this.errorReasons = errorReasons;
+    }
+}

--- a/modules/models/src/main/java/org/eclipse/xpanse/modules/models/service/DeployResult.java
+++ b/modules/models/src/main/java/org/eclipse/xpanse/modules/models/service/DeployResult.java
@@ -7,6 +7,7 @@
 package org.eclipse.xpanse.modules.models.service;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import java.util.HashMap;
 import java.util.List;
@@ -39,7 +40,7 @@ public class DeployResult {
      */
     @NotNull
     @Schema(description = "The deployed resources of the service.")
-    private List<DeployResource> resources;
+    private List<@Valid DeployResource> resources;
 
     /**
      * The result property of the service task.

--- a/modules/models/src/main/java/org/eclipse/xpanse/modules/models/view/CategoryOclVo.java
+++ b/modules/models/src/main/java/org/eclipse/xpanse/modules/models/view/CategoryOclVo.java
@@ -8,6 +8,7 @@
 package org.eclipse.xpanse.modules.models.view;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
@@ -26,5 +27,5 @@ public class CategoryOclVo {
 
     @NotNull
     @Schema(description = "List of the registered service group by service version.")
-    private List<VersionOclVo> versions;
+    private List<@Valid VersionOclVo> versions;
 }

--- a/modules/models/src/main/java/org/eclipse/xpanse/modules/models/view/ProviderOclVo.java
+++ b/modules/models/src/main/java/org/eclipse/xpanse/modules/models/view/ProviderOclVo.java
@@ -7,6 +7,7 @@
 package org.eclipse.xpanse.modules.models.view;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
 import lombok.Data;
@@ -26,10 +27,10 @@ public class ProviderOclVo {
 
     @NotNull
     @Schema(description = "The regions of the Cloud Service Provider.")
-    private List<Region> regions;
+    private List<@Valid Region> regions;
 
     @NotNull
     @Schema(description = "The list of the available services.")
-    private List<UserAvailableServiceVo> details;
+    private List<@Valid UserAvailableServiceVo> details;
 
 }

--- a/modules/models/src/main/java/org/eclipse/xpanse/modules/models/view/ServiceDetailVo.java
+++ b/modules/models/src/main/java/org/eclipse/xpanse/modules/models/view/ServiceDetailVo.java
@@ -7,6 +7,7 @@
 package org.eclipse.xpanse.modules.models.view;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
 import java.util.Map;
@@ -27,7 +28,7 @@ public class ServiceDetailVo extends ServiceVo {
     private CreateRequest createRequest;
 
     @Schema(description = "The resource list of the deployed service.")
-    private List<DeployResource> deployResources;
+    private List<@Valid DeployResource> deployResources;
 
     @Schema(description = "The properties of the deployed service.")
     private Map<String, String> deployedServiceProperties;

--- a/modules/models/src/main/java/org/eclipse/xpanse/modules/models/view/UserAvailableServiceVo.java
+++ b/modules/models/src/main/java/org/eclipse/xpanse/modules/models/view/UserAvailableServiceVo.java
@@ -9,6 +9,7 @@ package org.eclipse.xpanse.modules.models.view;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
@@ -57,7 +58,7 @@ public class UserAvailableServiceVo extends RepresentationModel<UserAvailableSer
 
     @NotEmpty
     @Schema(description = "The regions of the Cloud Service Provider.")
-    private List<Region> regions;
+    private List<@Valid Region> regions;
 
     @NotNull
     @NotBlank
@@ -76,11 +77,11 @@ public class UserAvailableServiceVo extends RepresentationModel<UserAvailableSer
 
     @NotNull
     @Schema(description = "The variables for the deployment, which will be passed to the deployer.")
-    private List<DeployVariable> variables;
+    private List<@Valid DeployVariable> variables;
 
     @NotNull
     @Schema(description = "The flavors of the available service.")
-    private List<Flavor> flavors;
+    private List<@Valid Flavor> flavors;
 
     @NotNull
     @Schema(description = "The billing policy of the available service.")

--- a/modules/models/src/main/java/org/eclipse/xpanse/modules/models/view/VersionOclVo.java
+++ b/modules/models/src/main/java/org/eclipse/xpanse/modules/models/view/VersionOclVo.java
@@ -8,6 +8,7 @@
 package org.eclipse.xpanse.modules.models.view;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
@@ -26,6 +27,6 @@ public class VersionOclVo {
 
     @NotNull
     @Schema(description = "List of the registered services group by service version.")
-    private List<ProviderOclVo> cloudProvider;
+    private List<@Valid ProviderOclVo> cloudProvider;
 
 }


### PR DESCRIPTION
Fixes #300 

With this change, the API will not return anything that does not match to our own Schema. If response is bad we return the bean validation errors back. 
