### PR TITLE
remove wrong validator on enum field

### DIFF
--- a/modules/models/src/main/java/org/eclipse/xpanse/modules/models/view/ServiceVo.java
+++ b/modules/models/src/main/java/org/eclipse/xpanse/modules/models/view/ServiceVo.java
@@ -61,7 +61,6 @@ public class ServiceVo {
      * The csp of the Service.
      */
     @NotNull
-    @NotBlank
     @Schema(description = "The provider of the service")
     private Csp csp;
 


### PR DESCRIPTION
This is a bug. When we add Notblank on enums, the response validation fails. Notblank is only for strings.