### PR TITLE
fill default value field only for API calls

### DIFF
--- a/modules/api/src/main/java/org/eclipse/xpanse/api/CredentialManageApi.java
+++ b/modules/api/src/main/java/org/eclipse/xpanse/api/CredentialManageApi.java
@@ -15,7 +15,10 @@ import lombok.extern.slf4j.Slf4j;
 import org.eclipse.xpanse.modules.credential.CredentialCenter;
 import org.eclipse.xpanse.modules.models.credential.AbstractCredentialInfo;
 import org.eclipse.xpanse.modules.models.credential.CreateCredential;
+import org.eclipse.xpanse.modules.models.credential.CredentialVariable;
+import org.eclipse.xpanse.modules.models.credential.CredentialVariables;
 import org.eclipse.xpanse.modules.models.credential.enums.CredentialType;
+import org.eclipse.xpanse.modules.models.credential.enums.CredentialTypeMessage;
 import org.eclipse.xpanse.modules.models.service.common.enums.Csp;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.hateoas.Link;
@@ -88,7 +91,10 @@ public class CredentialManageApi {
             @PathVariable(name = "cspName") Csp csp,
             @Parameter(name = "type", description = "The type of credential.")
             @RequestParam(name = "type", required = false) CredentialType type) {
-        return credentialCenter.getCredentialCapabilitiesByCsp(csp, type);
+        List<AbstractCredentialInfo> abstractCredentialInfos =
+                credentialCenter.getCredentialCapabilitiesByCsp(csp, type);
+        getCredentialCapabilitiesValue(abstractCredentialInfos);
+        return abstractCredentialInfos;
     }
 
     /**
@@ -219,6 +225,21 @@ public class CredentialManageApi {
             @Parameter(name = "type", description = "The type of credential.")
             @RequestParam(name = "type") CredentialType type) {
         return credentialCenter.deleteCredential(csp, userName, type);
+    }
+
+    private void getCredentialCapabilitiesValue(
+            List<AbstractCredentialInfo> abstractCredentialInfoList) {
+
+        for (AbstractCredentialInfo abstractCredentialInfo : abstractCredentialInfoList) {
+            if (abstractCredentialInfo.getType() == CredentialType.VARIABLES) {
+                CredentialVariables credentialVariables =
+                        (CredentialVariables) abstractCredentialInfo;
+                for (CredentialVariable variable : credentialVariables.getVariables()) {
+                    variable.setValue(
+                            CredentialTypeMessage.getMessageByType(CredentialType.VARIABLES));
+                }
+            }
+        }
     }
 
 }

--- a/modules/credential/src/main/java/org/eclipse/xpanse/modules/credential/CredentialCenter.java
+++ b/modules/credential/src/main/java/org/eclipse/xpanse/modules/credential/CredentialCenter.java
@@ -18,7 +18,6 @@ import org.eclipse.xpanse.modules.models.credential.CreateCredential;
 import org.eclipse.xpanse.modules.models.credential.CredentialVariable;
 import org.eclipse.xpanse.modules.models.credential.CredentialVariables;
 import org.eclipse.xpanse.modules.models.credential.enums.CredentialType;
-import org.eclipse.xpanse.modules.models.credential.enums.CredentialTypeMessage;
 import org.eclipse.xpanse.modules.models.credential.exceptions.CredentialVariablesNotComplete;
 import org.eclipse.xpanse.modules.models.service.common.enums.Csp;
 import org.eclipse.xpanse.modules.orchestrator.OrchestratorPlugin;
@@ -80,37 +79,8 @@ public class CredentialCenter {
                                     Objects.equals(credential.getType(), type))
                             .collect(Collectors.toList());
         }
-        List<AbstractCredentialInfo>
-                abstractCredentialInfos;
-        abstractCredentialInfos = getCredentialCapabilitiesValue(abstractCredentialInfoList);
 
-        return abstractCredentialInfos;
-    }
-
-    /**
-     * List the credential capabilities by @abstractCredentialInfoList.
-     *
-     * @param abstractCredentialInfoList The list of  credential capabilities.
-     * @return Returns list of credential capabilities.
-     */
-    private List<AbstractCredentialInfo> getCredentialCapabilitiesValue(
-            List<AbstractCredentialInfo> abstractCredentialInfoList) {
-
-        List<AbstractCredentialInfo> abstractCredentialInfos = new ArrayList<>();
-        for (AbstractCredentialInfo abstractCredentialInfo : abstractCredentialInfoList) {
-            if (Objects.equals(abstractCredentialInfo.getType(), CredentialType.VARIABLES)) {
-                CredentialVariables credentialVariables =
-                        (CredentialVariables) abstractCredentialInfo;
-
-                for (CredentialVariable variable : credentialVariables.getVariables()) {
-                    variable.setValue(
-                            CredentialTypeMessage.getMessageByType(CredentialType.VARIABLES));
-                }
-                abstractCredentialInfos.add(credentialVariables);
-            }
-        }
-
-        return abstractCredentialInfos;
+        return abstractCredentialInfoList;
     }
 
     /**


### PR DESCRIPTION
Default value for the "value" field in credential definition must be filled only for the getCredentialCapabilitiesByCsp API method. 

In the current version, the value is set always and it is causing null checks to always fail.

Related to #423 