### PR TITLE
handle all types in service deployment properties

### DIFF
--- a/modules/api/pom.xml
+++ b/modules/api/pom.xml
@@ -91,7 +91,6 @@
             <groupId>org.eclipse.xpanse.modules</groupId>
             <artifactId>workflow</artifactId>
             <version>${project.version}</version>
-            <scope>compile</scope>
         </dependency>
     </dependencies>
 </project>

--- a/modules/api/src/main/java/org/eclipse/xpanse/api/config/OpenApiCustomizerConfig.java
+++ b/modules/api/src/main/java/org/eclipse/xpanse/api/config/OpenApiCustomizerConfig.java
@@ -1,0 +1,46 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * SPDX-FileCopyrightText: Huawei Inc.
+ */
+
+package org.eclipse.xpanse.api.config;
+
+import io.swagger.v3.oas.models.media.MapSchema;
+import io.swagger.v3.oas.models.media.Schema;
+import java.util.Map;
+import org.springdoc.core.customizers.OpenApiCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * This customization is needed to work around an open issue in swagger-core which is used by
+ * spring-doc for generating the openapi schema.
+ * <a href="https://github.com/swagger-api/swagger-core/issues/4316">...</a>
+ * without this fix, the datatype for Object will be shown as Map always. So a
+ * {@code Map<String, Object>}`
+ * will be {@code Map<String, Map<String, Object>} and this causes issues in the client.
+ */
+@Configuration
+public class OpenApiCustomizerConfig {
+
+    @Bean
+    public OpenApiCustomizer enableArbitraryObjects() {
+        return openApi -> openApi.getComponents().getSchemas().values().forEach(
+                this::enableArbitraryObjects);
+    }
+
+    private void enableArbitraryObjects(Schema<Object> schema) {
+        if (schema instanceof MapSchema) {
+            if (schema.getAdditionalProperties() instanceof Schema
+                    && ((Schema<?>) schema.getAdditionalProperties()).getType()
+                            .equalsIgnoreCase("object")) {
+                schema.setAdditionalProperties(true);
+            }
+        } else if (schema.getType() != null && schema.getType().equalsIgnoreCase("object")
+                && schema.getProperties() != null) {
+            Map<String, Schema> properties = schema.getProperties();
+            properties.values().forEach(this::enableArbitraryObjects);
+        }
+    }
+
+}

--- a/modules/database/src/test/java/org/eclipse/xpanse/modules/database/utils/EntityTransUtilsTest.java
+++ b/modules/database/src/test/java/org/eclipse/xpanse/modules/database/utils/EntityTransUtilsTest.java
@@ -61,7 +61,7 @@ class EntityTransUtilsTest {
     @Test
     void testTransResourceEntity_emptyProperties() {
         deployResourceEntity.setProperties(properties);
-        deployResource.setProperties(properties);
+        deployResource.setProperties(new HashMap<>());
         List<DeployResourceEntity> entities = List.of(deployResourceEntity);
         final List<DeployResource> expectedResult = List.of(deployResource);
         final List<DeployResource> result = EntityTransUtils.transResourceEntity(entities);

--- a/modules/deployment/src/main/java/org/eclipse/xpanse/modules/deployment/DeployService.java
+++ b/modules/deployment/src/main/java/org/eclipse/xpanse/modules/deployment/DeployService.java
@@ -167,7 +167,7 @@ public class DeployService {
     }
 
     private void encodeDeployVariable(ServiceTemplateEntity serviceTemplate,
-                                      Map<String, String> serviceRequestProperties) {
+                                      Map<String, Object> serviceRequestProperties) {
         if (Objects.isNull(serviceTemplate.getOcl().getDeployment())
                 ||
                 CollectionUtils.isEmpty(serviceTemplate.getOcl().getDeployment().getVariables())
@@ -179,7 +179,8 @@ public class DeployService {
                     .equals(variable.getSensitiveScope().toValue())
                     && serviceRequestProperties.containsKey(variable.getName())) {
                 serviceRequestProperties.put(variable.getName(),
-                        aesUtil.encode(serviceRequestProperties.get(variable.getName())));
+                        aesUtil.encode(
+                                serviceRequestProperties.get(variable.getName()).toString()));
             }
         });
     }
@@ -570,10 +571,10 @@ public class DeployService {
         if (Objects.nonNull(deployServiceEntity.getDeployRequest().getServiceRequestProperties())) {
             for (DeployVariable deployVariable
                     : deployServiceEntity.getDeployRequest().getOcl().getDeployment()
-                            .getVariables()) {
+                    .getVariables()) {
                 if (deployVariable.getSensitiveScope() != SensitiveScope.NONE
                         && (deployServiceEntity.getDeployRequest().getServiceRequestProperties()
-                                .containsKey(deployVariable.getName()))) {
+                        .containsKey(deployVariable.getName()))) {
                     deployServiceEntity.getDeployRequest().getServiceRequestProperties()
                             .put(deployVariable.getName(), "********");
 

--- a/modules/deployment/src/main/java/org/eclipse/xpanse/modules/deployment/deployers/terraform/TerraformBootDeployment.java
+++ b/modules/deployment/src/main/java/org/eclipse/xpanse/modules/deployment/deployers/terraform/TerraformBootDeployment.java
@@ -131,7 +131,7 @@ public class TerraformBootDeployment implements Deployment {
                 new TerraformAsyncDestroyFromDirectoryRequest();
         request.setScripts(getFiles(task));
         request.setTfState(stateFile);
-        request.setVariables(getInputVariables(task));
+        request.setVariables(getInputVariables(task, false));
         request.setEnvVariables(getEnvironmentVariables(task));
         WebhookConfig hookConfig = new WebhookConfig();
         String callbackUrl = getClientRequestBaseUrl(port)
@@ -147,7 +147,7 @@ public class TerraformBootDeployment implements Deployment {
                 new TerraformAsyncDeployFromDirectoryRequest();
         request.setIsPlanOnly(false);
         request.setScripts(getFiles(task));
-        request.setVariables(getInputVariables(task));
+        request.setVariables(getInputVariables(task, true));
         request.setEnvVariables(getEnvironmentVariables(task));
         WebhookConfig hookConfig = new WebhookConfig();
         String callbackUrl = getClientRequestBaseUrl(port)
@@ -189,9 +189,9 @@ public class TerraformBootDeployment implements Deployment {
         return Arrays.asList(provider, deployer);
     }
 
-    private Map<String, Object> getInputVariables(DeployTask deployTask) {
+    private Map<String, Object> getInputVariables(DeployTask deployTask, boolean isDeployRequest) {
         Map<String, Object> inputVariables = new HashMap<>();
-        inputVariables.putAll(this.deployEnvironments.getVariables(deployTask));
+        inputVariables.putAll(this.deployEnvironments.getVariables(deployTask, isDeployRequest));
         inputVariables.putAll(this.deployEnvironments.getFlavorVariables(deployTask));
         return inputVariables;
     }

--- a/modules/deployment/src/main/java/org/eclipse/xpanse/modules/deployment/deployers/terraform/TerraformExecutor.java
+++ b/modules/deployment/src/main/java/org/eclipse/xpanse/modules/deployment/deployers/terraform/TerraformExecutor.java
@@ -40,7 +40,7 @@ public class TerraformExecutor {
     }
 
     private final Map<String, String> env;
-    private final Map<String, String> variables;
+    private final Map<String, Object> variables;
     private final String workspace;
 
     /**
@@ -50,7 +50,7 @@ public class TerraformExecutor {
      * @param variables variables for the terraform command line.
      * @param workspace workspace for the terraform command line.
      */
-    TerraformExecutor(Map<String, String> env, Map<String, String> variables,
+    TerraformExecutor(Map<String, String> env, Map<String, Object> variables,
                       String workspace) {
         this.env = env;
         this.variables = variables;
@@ -60,7 +60,7 @@ public class TerraformExecutor {
     /**
      * Executes terraform init command.
      *
-     * @return Returns result of SystemCmd executes.
+     * @return Returns result of SystemCmd executed.
      */
     public SystemCmdResult tfInit() {
         return execute("terraform init -no-color");
@@ -105,7 +105,7 @@ public class TerraformExecutor {
         command.append(" -var-file=");
         command.append(VARS_FILE_NAME);
         SystemCmdResult systemCmdResult = execute(command.toString());
-        cleanUpVariablesFile();
+        // cleanUpVariablesFile();
         return systemCmdResult;
     }
 

--- a/modules/deployment/src/test/java/org/eclipse/xpanse/modules/deployment/DeployServiceTest.java
+++ b/modules/deployment/src/test/java/org/eclipse/xpanse/modules/deployment/DeployServiceTest.java
@@ -130,7 +130,7 @@ class DeployServiceTest {
         deployVariable.setSensitiveScope(SensitiveScope.ALWAYS);
         deployment.setVariables(List.of(deployVariable));
 
-        Map<String, String> requestProperties = new HashMap<>();
+        Map<String, Object> requestProperties = new HashMap<>();
         requestProperties.put("test", "test");
         Ocl ocl = new Ocl();
         ocl.setName("oclName");

--- a/modules/deployment/src/test/java/org/eclipse/xpanse/modules/deployment/deployers/terraform/TerraformBootDeploymentTest.java
+++ b/modules/deployment/src/test/java/org/eclipse/xpanse/modules/deployment/deployers/terraform/TerraformBootDeploymentTest.java
@@ -85,7 +85,7 @@ class TerraformBootDeploymentTest {
                 .thenReturn("result");
 
         // Configure DeployEnvironments.getVariables(...).
-        final Map<String, String> stringStringMap = Map.ofEntries(Map.entry("value", "value"));
+        final Map<String, Object> stringStringMap = Map.ofEntries(Map.entry("value", "value"));
         final DeployTask task = new DeployTask();
         task.setId(UUID.fromString("800b6caa-5710-4064-8bae-cb446a351cc1"));
         final DeployRequest deployRequest1 = new DeployRequest();
@@ -103,7 +103,7 @@ class TerraformBootDeploymentTest {
         deployment1.setDeployer("deployer");
         ocl1.setDeployment(deployment1);
         task.setOcl(ocl1);
-        when(mockDeployEnvironments.getVariables(task)).thenReturn(stringStringMap);
+        when(mockDeployEnvironments.getVariables(task, true)).thenReturn(stringStringMap);
 
         // Configure DeployEnvironments.getFlavorVariables(...).
         final Map<String, String> stringStringMap1 = Map.ofEntries(Map.entry("value", "value"));
@@ -247,7 +247,7 @@ class TerraformBootDeploymentTest {
                 .thenReturn("result");
 
         // Configure DeployEnvironments.getVariables(...).
-        final Map<String, String> stringStringMap = Map.ofEntries(Map.entry("value", "value"));
+        final Map<String, Object> stringStringMap = Map.ofEntries(Map.entry("value", "value"));
         final DeployTask task1 = new DeployTask();
         task1.setId(UUID.fromString("800b6caa-5710-4064-8bae-cb446a351cc1"));
         final DeployRequest deployRequest1 = new DeployRequest();
@@ -265,7 +265,7 @@ class TerraformBootDeploymentTest {
         deployment1.setDeployer("deployer");
         ocl1.setDeployment(deployment1);
         task1.setOcl(ocl1);
-        when(mockDeployEnvironments.getVariables(task1)).thenReturn(stringStringMap);
+        when(mockDeployEnvironments.getVariables(task1, true)).thenReturn(stringStringMap);
 
         // Configure DeployEnvironments.getFlavorVariables(...).
         final Map<String, String> stringStringMap1 = Map.ofEntries(Map.entry("value", "value"));

--- a/modules/deployment/src/test/java/org/eclipse/xpanse/modules/deployment/deployers/terraform/TerraformDeploymentTest.java
+++ b/modules/deployment/src/test/java/org/eclipse/xpanse/modules/deployment/deployers/terraform/TerraformDeploymentTest.java
@@ -80,7 +80,7 @@ class TerraformDeploymentTest {
         deployRequest.setVersion(ocl.getServiceVersion());
         deployRequest.setFlavor(ocl.getFlavors().get(0).getName());
 
-        Map<String, String> property = new HashMap<>();
+        Map<String, Object> property = new HashMap<>();
         property.put("secgroup_id", "1234567890");
         deployRequest.setServiceRequestProperties(property);
 

--- a/modules/deployment/src/test/java/org/eclipse/xpanse/modules/deployment/utils/DeployEnvironmentsTest.java
+++ b/modules/deployment/src/test/java/org/eclipse/xpanse/modules/deployment/utils/DeployEnvironmentsTest.java
@@ -68,7 +68,7 @@ class DeployEnvironmentsTest {
 
     @BeforeEach
     void setUp() {
-        Map<String, String> serviceRequestProperties = new HashMap<>();
+        Map<String, Object> serviceRequestProperties = new HashMap<>();
         serviceRequestProperties.put("name", "value");
         serviceRequestProperties.put("key2", "value2");
         serviceRequestProperties.put("example", null);
@@ -170,7 +170,7 @@ class DeployEnvironmentsTest {
         expectedResult.put("key2", "value2");
         expectedResult.put("example", null);
 
-        final Map<String, String> result = deployEnvironmentsUnderTest.getVariables(task);
+        final Map<String, Object> result = deployEnvironmentsUnderTest.getVariables(task, true);
 
         // Verify the results
         assertThat(result).isEqualTo(expectedResult);

--- a/modules/models/src/main/java/org/eclipse/xpanse/modules/models/credential/AbstractCredentialInfo.java
+++ b/modules/models/src/main/java/org/eclipse/xpanse/modules/models/credential/AbstractCredentialInfo.java
@@ -34,8 +34,8 @@ public abstract class AbstractCredentialInfo {
      */
     @Getter
     @NotNull
-    @Schema(description = "The type of the credential,"
-            + "this field is provided by  he the plugin of cloud service provider.")
+    @Schema(description = "The type of the credential, "
+            + "this field is provided by the the plugin of cloud service provider.")
     CredentialType type;
 
     /**

--- a/modules/models/src/main/java/org/eclipse/xpanse/modules/models/service/deploy/DeployRequestBase.java
+++ b/modules/models/src/main/java/org/eclipse/xpanse/modules/models/service/deploy/DeployRequestBase.java
@@ -23,7 +23,7 @@ import org.eclipse.xpanse.modules.models.servicetemplate.Ocl;
 @Data
 public class DeployRequestBase implements Serializable {
     /**
-     * The id of user who ordered the Service.
+     * The id of the user who ordered the Service.
      */
     @Hidden
     private String userId;
@@ -90,5 +90,5 @@ public class DeployRequestBase implements Serializable {
      * The property of the Service.
      */
     @Schema(description = "The properties for the requested service")
-    private Map<String, String> serviceRequestProperties;
+    private Map<String, Object> serviceRequestProperties;
 }

--- a/modules/models/src/main/java/org/eclipse/xpanse/modules/models/service/utils/ServiceVariablesJsonSchemaValidator.java
+++ b/modules/models/src/main/java/org/eclipse/xpanse/modules/models/service/utils/ServiceVariablesJsonSchemaValidator.java
@@ -41,7 +41,7 @@ public class ServiceVariablesJsonSchemaValidator {
      * @param deployProperty  deploy property map
      */
     public void validateDeployVariables(List<DeployVariable> deployVariables,
-                                        Map<String, String> deployProperty,
+                                        Map<String, Object> deployProperty,
                                         JsonObjectSchema jsonObjectSchema) {
         if (!CollectionUtils.isEmpty(deployVariables) && !CollectionUtils.isEmpty(deployProperty)) {
             try {

--- a/modules/models/src/test/java/org/eclipse/xpanse/modules/models/service/deploy/DeployRequestTest.java
+++ b/modules/models/src/test/java/org/eclipse/xpanse/modules/models/service/deploy/DeployRequestTest.java
@@ -33,7 +33,7 @@ class DeployRequestTest {
     private static final Csp csp = Csp.AWS;
     private static final String flavor = "flavor";
     private static final Ocl ocl = new Ocl();
-    private static final Map<String, String> properties = Collections.singletonMap("key", "value");
+    private static final Map<String, Object> properties = Collections.singletonMap("key", "value");
     private static DeployRequest request;
 
     @BeforeEach

--- a/modules/models/src/test/java/org/eclipse/xpanse/modules/models/service/utils/ServiceVariablesJsonSchemaGeneratorAndValidatorTest.java
+++ b/modules/models/src/test/java/org/eclipse/xpanse/modules/models/service/utils/ServiceVariablesJsonSchemaGeneratorAndValidatorTest.java
@@ -53,7 +53,7 @@ public class ServiceVariablesJsonSchemaGeneratorAndValidatorTest {
         JsonObjectSchema jsonObjectSchema =
                 serviceVariablesJsonSchemaGenerator.buildJsonObjectSchema(variables);
 
-        Map<String, String> deployProperty = new HashMap<>();
+        Map<String, Object> deployProperty = new HashMap<>();
         deployProperty.put("admin_passwd", "123456@Qq");
 
         assertDoesNotThrow(() -> {
@@ -67,13 +67,13 @@ public class ServiceVariablesJsonSchemaGeneratorAndValidatorTest {
         JsonObjectSchema jsonObjectSchema =
                 serviceVariablesJsonSchemaGenerator.buildJsonObjectSchema(variables);
 
-        Map<String, String> validateMinLengthPro = new HashMap<>();
+        Map<String, Object> validateMinLengthPro = new HashMap<>();
         validateMinLengthPro.put("admin_passwd", "123456");
 
-        Map<String, String> validateMaxLengthPro = new HashMap<>();
+        Map<String, Object> validateMaxLengthPro = new HashMap<>();
         validateMaxLengthPro.put("admin_passwd", "1234566778980129342543654756768");
 
-        Map<String, String> validatePatternPro = new HashMap<>();
+        Map<String, Object> validatePatternPro = new HashMap<>();
         validatePatternPro.put("admin_passwd", "12335435@Q");
 
         assertThrows(VariableInvalidException.class, () -> {
@@ -102,7 +102,7 @@ public class ServiceVariablesJsonSchemaGeneratorAndValidatorTest {
         JsonObjectSchema jsonObjectSchema =
                 serviceVariablesJsonSchemaGenerator.buildJsonObjectSchema(variables);
 
-        Map<String, String> validateRequiredPro = new HashMap<>();
+        Map<String, Object> validateRequiredPro = new HashMap<>();
         validateRequiredPro.put("admin_passwd", "123456@Qq");
         validateRequiredPro.put("vpc_name", "123456");
         validateRequiredPro.put("subnet_name", "123456");
@@ -124,7 +124,7 @@ public class ServiceVariablesJsonSchemaGeneratorAndValidatorTest {
         JsonObjectSchema jsonObjectSchema =
                 serviceVariablesJsonSchemaGenerator.buildJsonObjectSchema(variables);
 
-        Map<String, String> validateRequiredPro = new HashMap<>();
+        Map<String, Object> validateRequiredPro = new HashMap<>();
         validateRequiredPro.put("admin_passwd", "123456@Qq");
 
         assertThrows(VariableInvalidException.class, () -> {

--- a/modules/models/src/test/java/org/eclipse/xpanse/modules/models/service/view/ServiceDetailVoTest.java
+++ b/modules/models/src/test/java/org/eclipse/xpanse/modules/models/service/view/ServiceDetailVoTest.java
@@ -11,6 +11,7 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import jakarta.validation.Valid;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -40,7 +41,7 @@ class ServiceDetailVoTest {
     private static final DeployResourceKind kind = DeployResourceKind.VM;
     private static final String resultSuccessMessage = "Deployment successful";
     private static DeployResource deployResource;
-    private static Map<String, String> properties;
+    private static Map<String, Object> properties;
     private static DeployRequest deployRequest;
     private static List<@Valid DeployResource> deployResources;
     private static Map<String, String> deployedServiceProperties;
@@ -66,7 +67,7 @@ class ServiceDetailVoTest {
         deployResource.setResourceId(uuid.toString());
         deployResource.setName(name);
         deployResource.setKind(kind);
-        deployResource.setProperties(properties);
+        deployResource.setProperties(new HashMap<>());
         deployResources.add(deployResource);
 
         deployedServiceProperties = new HashMap<>();
@@ -81,7 +82,7 @@ class ServiceDetailVoTest {
     }
 
     @Test
-    public void testGetterAndSetter() {
+    void testGetterAndSetter() {
         assertEquals(userId, deployRequest.getUserId());
         assertEquals(category, deployRequest.getCategory());
         assertEquals(serviceName, deployRequest.getServiceName());
@@ -95,7 +96,7 @@ class ServiceDetailVoTest {
         assertEquals(uuid.toString(), deployResource.getResourceId());
         assertEquals(name, deployResource.getName());
         assertEquals(kind, deployResource.getKind());
-        assertEquals(properties, deployResource.getProperties());
+        assertEquals(Collections.emptyMap(), deployResource.getProperties());
 
         assertEquals(deployRequest, serviceDetailVo.getDeployRequest());
         assertEquals(deployResources, serviceDetailVo.getDeployResources());
@@ -104,13 +105,12 @@ class ServiceDetailVoTest {
     }
 
     @Test
-    public void testEqualsAndHashCode() {
-        assertEquals(serviceDetailVo, serviceDetailVo);
+    void testEqualsAndHashCode() {
         assertEquals(serviceDetailVo.hashCode(), serviceDetailVo.hashCode());
 
         Object obj = new Object();
         assertNotEquals(serviceDetailVo, obj);
-        assertNotEquals(serviceDetailVo, null);
+        assertNotEquals(null, serviceDetailVo);
         assertNotEquals(serviceDetailVo.hashCode(), obj.hashCode());
 
         ServiceDetailVo serviceDetailVo1 = new ServiceDetailVo();

--- a/runtime/src/test/java/org/eclipse/xpanse/runtime/ServiceDeployerApiTest.java
+++ b/runtime/src/test/java/org/eclipse/xpanse/runtime/ServiceDeployerApiTest.java
@@ -261,7 +261,7 @@ class ServiceDeployerApiTest {
         deployRequest.setCategory(serviceTemplateDetailVo.getCategory());
         deployRequest.setFlavor(serviceTemplateDetailVo.getFlavors().get(0).getName());
         deployRequest.setRegion(serviceTemplateDetailVo.getRegions().get(0).toString());
-        Map<String, String> serviceRequestProperties = new HashMap<>();
+        Map<String, Object> serviceRequestProperties = new HashMap<>();
         serviceRequestProperties.put("secgroup_name", "secgroup_name");
         deployRequest.setServiceRequestProperties(serviceRequestProperties);
         String requestBody = objectMapper.writeValueAsString(deployRequest);

--- a/runtime/src/test/java/org/eclipse/xpanse/runtime/database/mysql/DeploymentWithMysqlTest.java
+++ b/runtime/src/test/java/org/eclipse/xpanse/runtime/database/mysql/DeploymentWithMysqlTest.java
@@ -61,7 +61,7 @@ class DeploymentWithMysqlTest extends AbstractMysqlIntegrationTest {
         deployRequest.setCategory(serviceTemplate.getCategory());
         deployRequest.setFlavor(serviceTemplate.getFlavors().get(0).toString());
         deployRequest.setRegion(serviceTemplate.getRegions().get(0).toString());
-        Map<String, String> serviceRequestProperties = new HashMap<>();
+        Map<String, Object> serviceRequestProperties = new HashMap<>();
         serviceRequestProperties.put("admin_passwd", "111111111@Qq");
         deployRequest.setServiceRequestProperties(serviceRequestProperties);
 


### PR DESCRIPTION
fixes https://github.com/eclipse-xpanse/xpanse/issues/962

`serviceRequestProperties` now accepts all possible datatypes.
```json
{
   "category":"middleware",
   "csp":"scs",
   "flavor":"1-zookeeper-with-3-worker-nodes-normal",
   "region":"RegionOne",
   "serviceName":"kafka-cluster",
   "version":"v1.0.0",
   "customerServiceName":"u500924-swaroopar",
   "serviceRequestProperties":{
      "secgroup_name_boolean":true,
      "subnet_name":"dfdfdfdf",
      "secgroup_name_integer":100
   }
}
```