### PR TITLE
update error message when policy validation failed

### DIFF
--- a/modules/api/src/test/java/org/eclipse/xpanse/api/exceptions/handler/PolicyManageExceptionHandlerTest.java
+++ b/modules/api/src/test/java/org/eclipse/xpanse/api/exceptions/handler/PolicyManageExceptionHandlerTest.java
@@ -57,8 +57,7 @@ class PolicyManageExceptionHandlerTest {
         this.mockMvc.perform(get("/xpanse/policies"))
                 .andExpect(status().is(400))
                 .andExpect(jsonPath("$.resultType").value("Policy Validation Failed"))
-                .andExpect(jsonPath("$.details[0]").value(
-                        "Policy is invalid. Error reasons: test error"));
+                .andExpect(jsonPath("$.details[0]").value("test error"));
     }
 
 

--- a/modules/models/src/main/java/org/eclipse/xpanse/modules/models/policy/exceptions/PoliciesValidationFailedException.java
+++ b/modules/models/src/main/java/org/eclipse/xpanse/modules/models/policy/exceptions/PoliciesValidationFailedException.java
@@ -19,7 +19,7 @@ public class PoliciesValidationFailedException extends RuntimeException {
     private final String errorReason;
 
     public PoliciesValidationFailedException(String errorReason) {
-        super(String.format("Policy is invalid. Error reasons: %s", errorReason));
+        super(errorReason);
         this.errorReason = errorReason;
     }
 


### PR DESCRIPTION
fixes #1037 
Before:
{
    "resultType": "Policy Validation Failed",
    "details": [
        "Policy is invalid. Error reasons: I/O error on POST request for \"http://localhost:8090/validate/policies\": Connection refused"
    ],
    "success": false
}

Updated :
{
  "resultType": "Policy Validation Failed",
  "details": [
    "I/O error on POST request for \"http://localhost:8090/validate/policies\": Connection refused: connect"
  ],
  "success": false
}