### PR TITLE
Automatically update data table field enumeration values based on code

### DIFF
--- a/modules/database/src/main/java/org/eclipse/xpanse/modules/database/DatabaseManager.java
+++ b/modules/database/src/main/java/org/eclipse/xpanse/modules/database/DatabaseManager.java
@@ -5,8 +5,6 @@
 
 package org.eclipse.xpanse.modules.database;
 
-import java.util.Arrays;
-import java.util.List;
 import org.eclipse.xpanse.modules.models.system.BackendSystemStatus;
 import org.eclipse.xpanse.modules.models.system.enums.BackendSystemType;
 import org.eclipse.xpanse.modules.models.system.enums.DatabaseType;
@@ -20,6 +18,9 @@ import org.springframework.stereotype.Component;
 @Component
 public class DatabaseManager {
 
+    @Value("${spring.datasource.name:h2}")
+    private String dataSourceName;
+
     @Value("${spring.datasource.url:jdbc:h2:file:./testdb}")
     private String dataSourceUrl;
 
@@ -29,23 +30,12 @@ public class DatabaseManager {
      * @return system status of database.
      */
     public BackendSystemStatus getDatabaseStatus() {
-        List<String> databaseUrlSplitList = Arrays.asList(dataSourceUrl.split(":"));
-        if (databaseUrlSplitList.contains(DatabaseType.H2DB.toValue())) {
-            BackendSystemStatus databaseStatus = new BackendSystemStatus();
-            databaseStatus.setBackendSystemType(BackendSystemType.DATABASE);
-            databaseStatus.setName(DatabaseType.H2DB.toValue());
-            databaseStatus.setHealthStatus(HealthStatus.OK);
-            databaseStatus.setEndpoint(dataSourceUrl);
-            return databaseStatus;
-        }
-        if (databaseUrlSplitList.contains(DatabaseType.MYSQL.toValue())) {
-            BackendSystemStatus databaseStatus = new BackendSystemStatus();
-            databaseStatus.setBackendSystemType(BackendSystemType.DATABASE);
-            databaseStatus.setName(DatabaseType.MYSQL.toValue());
-            databaseStatus.setHealthStatus(HealthStatus.OK);
-            databaseStatus.setEndpoint(dataSourceUrl);
-            return databaseStatus;
-        }
-        return null;
+        DatabaseType databaseType = DatabaseType.getByValue(dataSourceName);
+        BackendSystemStatus databaseStatus = new BackendSystemStatus();
+        databaseStatus.setBackendSystemType(BackendSystemType.DATABASE);
+        databaseStatus.setName(databaseType.toValue());
+        databaseStatus.setHealthStatus(HealthStatus.OK);
+        databaseStatus.setEndpoint(dataSourceUrl);
+        return databaseStatus;
     }
 }

--- a/modules/database/src/main/java/org/eclipse/xpanse/modules/database/EnumColumnAllowedValuesUpdater.java
+++ b/modules/database/src/main/java/org/eclipse/xpanse/modules/database/EnumColumnAllowedValuesUpdater.java
@@ -1,0 +1,157 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * SPDX-FileCopyrightText: Huawei Inc.
+ */
+
+package org.eclipse.xpanse.modules.database;
+
+import jakarta.annotation.Resource;
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityManagerFactory;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Table;
+import jakarta.persistence.metamodel.EntityType;
+import jakarta.persistence.metamodel.Metamodel;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.eclipse.xpanse.modules.database.enumcolumn.EnumColumnConstraintManage;
+import org.eclipse.xpanse.modules.models.system.enums.DatabaseType;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.ApplicationListener;
+import org.springframework.context.event.ContextRefreshedEvent;
+import org.springframework.stereotype.Component;
+import org.springframework.util.CollectionUtils;
+
+/**
+ * Service to update database tables column values by code generation automatically.
+ */
+@Slf4j
+@Component
+public class EnumColumnAllowedValuesUpdater implements
+        ApplicationListener<ContextRefreshedEvent> {
+
+    @Resource
+    private EntityManagerFactory entityManagerFactory;
+
+    @Resource
+    private EnumColumnConstraintManage enumColumnConstraintManage;
+
+    @Value("${spring.datasource.name:h2}")
+    private String dataSourceName;
+
+    /**
+     * Update the values of all enum columns in all tables.
+     */
+    @Override
+    public void onApplicationEvent(ContextRefreshedEvent event) {
+        DatabaseType activeDatabaseType = DatabaseType.getByValue(dataSourceName);
+        Map<Class<?>, String> map = getTableNamesMap();
+        for (Map.Entry<Class<?>, String> entry : map.entrySet()) {
+            List<Field> enumFields = getFieldsWithAnnotationEnum(entry.getKey());
+            String tableName = StringUtils.toRootUpperCase(entry.getValue());
+            for (Field field : enumFields) {
+                Class<?> filedClass = field.getType();
+                Column columnAnnotation = field.getAnnotation(Column.class);
+                String columnName = StringUtils.toRootUpperCase(Objects.nonNull(columnAnnotation)
+                        ? columnAnnotation.name() : field.getName());
+                if (filedClass.isEnum()) {
+                    List<String> enumNames = getEnumNames(filedClass);
+                    String enumNamesStr = StringUtils.toRootUpperCase(
+                            "'" + StringUtils.join(enumNames, "','") + "'");
+                    if (activeDatabaseType == DatabaseType.MYSQL) {
+                        updateTableColumnEnumValuesForMySql(tableName, columnName, enumNamesStr);
+                    }
+                    if (activeDatabaseType == DatabaseType.H2DB) {
+                        updateTableColumnEnumValuesForH2(tableName, columnName, enumNamesStr);
+                    }
+                }
+            }
+        }
+    }
+
+    private void updateTableColumnEnumValuesForMySql(String tableName, String columnName,
+                                                     String enumValuesStr) {
+        try {
+            if (enumColumnConstraintManage.queryTableColumnExisted(tableName, columnName)) {
+                enumColumnConstraintManage.updateTableEnumColumnValuesForMySql(tableName,
+                        columnName,
+                        enumValuesStr);
+                log.info("Update MySql table:{} enum column:{} to values:[{}] completed.",
+                        tableName, columnName, enumValuesStr);
+            }
+        } catch (RuntimeException e) {
+            log.error("Update MySql table:{} enum column:{} to values:[{}] failed. error:{}",
+                    tableName, columnName, enumValuesStr, e.getMessage());
+        }
+    }
+
+
+    private void updateTableColumnEnumValuesForH2(String tableName, String columnName,
+                                                  String enumValuesStr) {
+        try {
+            if (enumColumnConstraintManage.queryTableColumnExisted(tableName, columnName)) {
+                List<String> oldConstraintNames = enumColumnConstraintManage
+                        .queryConstraintForH2TableEnumColumn(tableName, columnName);
+                if (!CollectionUtils.isEmpty(oldConstraintNames)) {
+                    for (String constraintName : oldConstraintNames) {
+                        enumColumnConstraintManage
+                                .dropOldConstraintForH2TableEnumColumn(tableName, constraintName);
+                        enumColumnConstraintManage.addNewConstraintForH2TableEnumColumn(tableName,
+                                columnName, constraintName, enumValuesStr);
+                        log.info("Update MySql table:{} enum column:{} to values:[{}] completed.",
+                                tableName, columnName, enumValuesStr);
+                    }
+                }
+            }
+        } catch (RuntimeException e) {
+            log.error("Update H2 table:{} enum column:{} to values:[{}] failed. error:{}",
+                    tableName, columnName, enumValuesStr, e.getMessage());
+        }
+    }
+
+    private List<String> getEnumNames(Class<?> enumClass) {
+        List<String> enumNames = new ArrayList<>();
+        for (Object enumValue : enumClass.getEnumConstants()) {
+            Enum<?> enumConstant = (Enum<?>) enumValue;
+            String enumName = enumConstant.name();
+            enumNames.add(enumName);
+        }
+        return enumNames;
+    }
+
+
+    private Map<Class<?>, String> getTableNamesMap() {
+        Map<Class<?>, String> tableClassNameMap = new HashMap<>();
+        Metamodel metamodel = entityManagerFactory.getMetamodel();
+        for (EntityType<?> entityType : metamodel.getEntities()) {
+            Class<?> clazz = entityType.getJavaType();
+            if (Objects.nonNull(clazz)
+                    && Objects.nonNull(clazz.getAnnotation(Table.class).name())) {
+                tableClassNameMap.put(clazz, clazz.getAnnotation(Table.class).name());
+            }
+        }
+        return tableClassNameMap;
+    }
+
+
+    private List<Field> getFieldsWithAnnotationEnum(Class<?> clazz) {
+        List<Field> fields = new ArrayList<>();
+        if (Objects.isNull(clazz)) {
+            return fields;
+        }
+        for (Field field : clazz.getDeclaredFields()) {
+            if (field.isAnnotationPresent(Enumerated.class)) {
+                fields.add(field);
+            }
+        }
+        return fields;
+    }
+
+
+}

--- a/modules/database/src/main/java/org/eclipse/xpanse/modules/database/enumcolumn/EnumColumnConstraintManage.java
+++ b/modules/database/src/main/java/org/eclipse/xpanse/modules/database/enumcolumn/EnumColumnConstraintManage.java
@@ -1,0 +1,109 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * SPDX-FileCopyrightText: Huawei Inc.
+ *
+ */
+
+package org.eclipse.xpanse.modules.database.enumcolumn;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.CollectionUtils;
+
+/**
+ * Implementation of the EnumColumnConstraintManage.
+ */
+@Slf4j
+@Repository
+@Transactional
+public class EnumColumnConstraintManage {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    /**
+     * Query the table and column whether exists in the database.
+     *
+     * @param tableName  table name.
+     * @param columnName column name.
+     * @return true if the table and column exists in the database.
+     */
+    public boolean queryTableColumnExisted(String tableName, String columnName) {
+        String queryStatement = String.format(
+                "SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS"
+                        + " WHERE TABLE_NAME = '%s' AND COLUMN_NAME = '%s'",
+                tableName, columnName);
+        return !CollectionUtils.isEmpty(
+                entityManager.createNativeQuery(queryStatement).getResultList());
+    }
+
+    /**
+     * Update the enum column values in table for MySql.
+     *
+     * @param tableName        table name.
+     * @param columnName       column name.
+     * @param enumValuesString the string of enum values.
+     */
+    public void updateTableEnumColumnValuesForMySql(String tableName, String columnName,
+                                                    String enumValuesString) {
+
+        String ddlStatement = String.format("ALTER TABLE %s MODIFY COLUMN %s ENUM(%s)",
+                tableName, columnName, enumValuesString);
+        entityManager.createNativeQuery(ddlStatement).executeUpdate();
+    }
+
+
+    /**
+     * Query the constraints of enum column in table for H2.
+     *
+     * @param tableName  table name.
+     * @param columnName column name.
+     * @return the constraints of enum column in table for H2.
+     */
+    @SuppressWarnings("unchecked")
+    public List<String> queryConstraintForH2TableEnumColumn(String tableName, String columnName) {
+        String queryStatement = String.format(
+                "SELECT T2.CONSTRAINT_NAME FROM INFORMATION_SCHEMA.CONSTRAINT_COLUMN_USAGE T1,"
+                        + " INFORMATION_SCHEMA.CHECK_CONSTRAINTS T2 "
+                        + " WHERE T1.CONSTRAINT_NAME = T2.CONSTRAINT_NAME "
+                        + " AND TABLE_NAME = '%s' AND COLUMN_NAME = '%s'",
+                tableName, columnName);
+        return entityManager.createNativeQuery(queryStatement).getResultList();
+    }
+
+
+    /**
+     * Drop the old constraint of enum column in table for H2.
+     *
+     * @param tableName      table name.
+     * @param constraintName constraint name.
+     */
+    public void dropOldConstraintForH2TableEnumColumn(String tableName, String constraintName) {
+        String ddlStatement =
+                String.format("ALTER TABLE %s DROP CONSTRAINT %s", tableName, constraintName);
+        entityManager.createNativeQuery(ddlStatement).executeUpdate();
+    }
+
+
+    /**
+     * Add the new constraint of enum column in table for H2.
+     *
+     * @param tableName        table name.
+     * @param columnName       column name.
+     * @param constraintName   constraint name.
+     * @param enumValuesString the string of enum values.
+     */
+    public void addNewConstraintForH2TableEnumColumn(String tableName, String columnName,
+                                                     String constraintName,
+                                                     String enumValuesString) {
+        String constraintValue = String.format("\"%s\" IN (%s)", columnName, enumValuesString);
+        String ddlStatement = String.format("ALTER TABLE %s ADD CONSTRAINT %s CHECK(%s)",
+                tableName, constraintName, constraintValue);
+        entityManager.createNativeQuery(ddlStatement).executeUpdate();
+    }
+
+}

--- a/modules/database/src/main/java/org/eclipse/xpanse/modules/database/service/DatabaseDeployServiceStorage.java
+++ b/modules/database/src/main/java/org/eclipse/xpanse/modules/database/service/DatabaseDeployServiceStorage.java
@@ -6,8 +6,6 @@
 
 package org.eclipse.xpanse.modules.database.service;
 
-import jakarta.persistence.EntityManager;
-import jakarta.persistence.PersistenceContext;
 import jakarta.persistence.criteria.Predicate;
 import java.util.ArrayList;
 import java.util.List;
@@ -27,9 +25,6 @@ import org.springframework.transaction.annotation.Transactional;
 @Component
 @Transactional
 public class DatabaseDeployServiceStorage implements DeployServiceStorage {
-
-    @PersistenceContext
-    public EntityManager entityManager;
 
     private final DeployServiceRepository deployServiceRepository;
 

--- a/modules/database/src/main/java/org/eclipse/xpanse/modules/database/service/DeployServiceEntity.java
+++ b/modules/database/src/main/java/org/eclipse/xpanse/modules/database/service/DeployServiceEntity.java
@@ -94,6 +94,7 @@ public class DeployServiceEntity extends CreateModifiedTime {
      * The state of the Service.
      */
     @Enumerated(EnumType.STRING)
+    @Column(name = "SERVICE_DEPLOYMENT_STATE")
     private ServiceDeploymentState serviceDeploymentState;
 
     /**

--- a/modules/database/src/test/java/org/eclipse/xpanse/modules/database/service/DatabaseDeployServiceStorageTest.java
+++ b/modules/database/src/test/java/org/eclipse/xpanse/modules/database/service/DatabaseDeployServiceStorageTest.java
@@ -6,13 +6,11 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import jakarta.persistence.EntityManager;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.eclipse.xpanse.modules.models.service.common.enums.Category;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -27,16 +25,8 @@ class DatabaseDeployServiceStorageTest {
     @Mock
     private DeployServiceRepository mockDeployServiceRepository;
 
-    @Mock
-    private EntityManager entityManager;
-
     @InjectMocks
     private DatabaseDeployServiceStorage databaseDeployServiceStorageUnderTest;
-
-    @BeforeEach
-    void setUp() {
-        databaseDeployServiceStorageUnderTest.entityManager = entityManager;
-    }
 
     @Test
     void testStoreAndFlush() {

--- a/runtime/src/main/resources/application-mysql.properties
+++ b/runtime/src/main/resources/application-mysql.properties
@@ -3,6 +3,7 @@
 # SPDX-FileCopyrightText: Huawei Inc.
 #
 #
+spring.datasource.name=mysql
 spring.datasource.url=jdbc:mysql://localhost:3306/testdb?serverTimezone=UTC&useUnicode=true&characterEncoding=utf8&characterSetResults=utf8&useSSL=false&allowPublicKeyRetrieval=true
 spring.datasource.driverClassName=com.mysql.cj.jdbc.Driver
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL57Dialect

--- a/runtime/src/main/resources/application.properties
+++ b/runtime/src/main/resources/application.properties
@@ -9,6 +9,7 @@ server.shutdown=graceful
 spring.lifecycle.timeout-per-shutdown-phase=300s
 spring.profiles.active=zitadel,zitadel-testbed,terraform-boot
 spring.banner.location=classpath:banner.txt
+spring.datasource.name=h2
 spring.datasource.url=jdbc:h2:file:./testdb;DB_CLOSE_ON_EXIT=FALSE
 spring.datasource.driverClassName=org.h2.Driver
 spring.datasource.username=xpanse

--- a/runtime/src/test/java/org/eclipse/xpanse/runtime/modules/common/OpenApiGeneratorJarManageTest.java
+++ b/runtime/src/test/java/org/eclipse/xpanse/runtime/modules/common/OpenApiGeneratorJarManageTest.java
@@ -44,7 +44,6 @@ class OpenApiGeneratorJarManageTest {
     }
 
     @Test
-    @Disabled
     void testDownloadClientJar() throws IOException {
         // SetUp
         File jarFile = openApiGeneratorJarManage.getCliFile();


### PR DESCRIPTION
fixes https://github.com/eclipse-xpanse/xpanse/issues/1031
Before adding an enumeration value：
H2 DB:
![csp_no_change_h2](https://github.com/eclipse-xpanse/xpanse/assets/121531362/04622c4d-3d50-4448-bc1f-bfe9688cb6da)
MySQL DB:
![csp_no_change_mysql](https://github.com/eclipse-xpanse/xpanse/assets/121531362/b1b2015f-0a0c-42f4-8b34-a665dfa020c2)
After adding enumeration values and restarting：
H2 DB:
![csp_add_tenent_restart_h2](https://github.com/eclipse-xpanse/xpanse/assets/121531362/86271f45-2dba-4bde-a8c9-d0faf592901a)
MySQL DB:
![csp_add_tenent_restart_mysql](https://github.com/eclipse-xpanse/xpanse/assets/121531362/bbefae37-5f68-4a5f-9cc9-cf803b53e833)