### PR TITLE
update async task executor bean to unique name

### DIFF
--- a/modules/deployment/src/main/java/org/eclipse/xpanse/modules/deployment/DeployService.java
+++ b/modules/deployment/src/main/java/org/eclipse/xpanse/modules/deployment/DeployService.java
@@ -561,7 +561,7 @@ public class DeployService {
      * @param deployTask          deployTask
      * @param deployServiceEntity deployServiceEntity
      */
-    @Async("taskExecutor")
+    @Async("xpanseAsyncTaskExecutor")
     public void asyncPurgeService(Deployment deployment, DeployTask deployTask,
                                   DeployServiceEntity deployServiceEntity) {
         purgeService(deployment, deployTask, deployServiceEntity);
@@ -788,7 +788,7 @@ public class DeployService {
      * @param deployRequest deploy request.
      * @return new deployed service entity.
      */
-    @Async("taskExecutor")
+    @Async("xpanseAsyncTaskExecutor")
     public CompletableFuture<DeployServiceEntity> deployServiceById(UUID newId,
                                                                 String userId,
                                                                 DeployRequest deployRequest) {
@@ -808,7 +808,7 @@ public class DeployService {
     /**
      * Destroy service by deployed service id.
      */
-    @Async("taskExecutor")
+    @Async("xpanseAsyncTaskExecutor")
     public CompletableFuture<DeployServiceEntity> destroyServiceById(String id) {
         MDC.put(TASK_ID, id);
         DeployServiceEntity deployServiceEntity = getDeployServiceEntity(UUID.fromString(id));

--- a/modules/deployment/src/main/java/org/eclipse/xpanse/modules/deployment/async/TaskConfiguration.java
+++ b/modules/deployment/src/main/java/org/eclipse/xpanse/modules/deployment/async/TaskConfiguration.java
@@ -25,7 +25,7 @@ public class TaskConfiguration {
      *
      * @return executor
      */
-    @Bean("taskExecutor")
+    @Bean("xpanseAsyncTaskExecutor")
     public Executor taskExecutor() {
         ServiceThreadPoolTaskExecutor executor = new ServiceThreadPoolTaskExecutor();
         executor.setCorePoolSize(CPU_COUNT * 2);

--- a/modules/deployment/src/main/java/org/eclipse/xpanse/modules/deployment/deployers/terraform/TerraformDeployment.java
+++ b/modules/deployment/src/main/java/org/eclipse/xpanse/modules/deployment/deployers/terraform/TerraformDeployment.java
@@ -36,6 +36,7 @@ import org.eclipse.xpanse.modules.orchestrator.deployment.DeployTask;
 import org.eclipse.xpanse.modules.orchestrator.deployment.DeployValidationResult;
 import org.eclipse.xpanse.modules.orchestrator.deployment.Deployment;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.stereotype.Component;
 
@@ -63,8 +64,10 @@ public class TerraformDeployment implements Deployment {
     @Autowired
     public TerraformDeployment(
             DeployEnvironments deployEnvironments,
-            TerraformLocalConfig terraformLocalConfig, PluginManager pluginManager,
-            DeployService deployService, Executor taskExecutor) {
+            TerraformLocalConfig terraformLocalConfig,
+            PluginManager pluginManager,
+            DeployService deployService,
+            @Qualifier("xpanseAsyncTaskExecutor") Executor taskExecutor) {
         this.deployEnvironments = deployEnvironments;
         this.terraformLocalConfig = terraformLocalConfig;
         this.pluginManager = pluginManager;

--- a/modules/deployment/src/test/java/org/eclipse/xpanse/modules/deployment/deployers/terraform/TerraformDeploymentTest.java
+++ b/modules/deployment/src/test/java/org/eclipse/xpanse/modules/deployment/deployers/terraform/TerraformDeploymentTest.java
@@ -22,6 +22,7 @@ import java.util.UUID;
 import java.util.concurrent.Executor;
 import org.apache.commons.lang3.StringUtils;
 import org.eclipse.xpanse.modules.deployment.DeployService;
+import org.eclipse.xpanse.modules.deployment.async.TaskConfiguration;
 import org.eclipse.xpanse.modules.deployment.deployers.terraform.config.TerraformLocalConfig;
 import org.eclipse.xpanse.modules.deployment.utils.DeployEnvironments;
 import org.eclipse.xpanse.modules.models.service.common.enums.Csp;
@@ -53,7 +54,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 @ExtendWith({SpringExtension.class})
 @ContextConfiguration(classes = {TerraformDeployment.class, DeployEnvironments.class,
-        PluginManager.class, TerraformLocalConfig.class, DeployService.class, Executor.class})
+        PluginManager.class, TerraformLocalConfig.class, DeployService.class, TaskConfiguration.class})
 class TerraformDeploymentTest {
 
     private final UUID id = UUID.randomUUID();

--- a/modules/servicetemplate/src/main/java/org/eclipse/xpanse/modules/servicetemplate/utils/ServiceTemplateOpenApiGenerator.java
+++ b/modules/servicetemplate/src/main/java/org/eclipse/xpanse/modules/servicetemplate/utils/ServiceTemplateOpenApiGenerator.java
@@ -89,7 +89,7 @@ public class ServiceTemplateOpenApiGenerator {
      *
      * @param registerService Registered services.
      */
-    @Async("taskExecutor")
+    @Async("xpanseAsyncTaskExecutor")
     public void generateServiceApi(ServiceTemplateEntity registerService) {
         createServiceApi(registerService);
     }
@@ -99,7 +99,7 @@ public class ServiceTemplateOpenApiGenerator {
      *
      * @param registerService Registered services.
      */
-    @Async("taskExecutor")
+    @Async("xpanseAsyncTaskExecutor")
     public void updateServiceApi(ServiceTemplateEntity registerService) {
         File file =
                 new File(this.openApiGeneratorJarManage.getOpenApiWorkdir(),
@@ -115,7 +115,7 @@ public class ServiceTemplateOpenApiGenerator {
      *
      * @param id ID of registered service.
      */
-    @Async("taskExecutor")
+    @Async("xpanseAsyncTaskExecutor")
     public void deleteServiceApi(String id) {
         File file = new File(this.openApiGeneratorJarManage.getOpenApiWorkdir(),
                 id + OPENAPI_FILE_EXTENSION);

--- a/modules/workflow/src/main/java/org/eclipse/xpanse/modules/workflow/utils/WorkflowProcessUtils.java
+++ b/modules/workflow/src/main/java/org/eclipse/xpanse/modules/workflow/utils/WorkflowProcessUtils.java
@@ -58,7 +58,7 @@ public class WorkflowProcessUtils {
         return runtimeService.startProcessInstanceByKey(processKey, variable);
     }
 
-    @Async("taskExecutor")
+    @Async("xpanseAsyncTaskExecutor")
     public void asyncStartProcess(String processKey, Map<String, Object> variable) {
         startProcess(processKey, variable);
     }


### PR DESCRIPTION
Avoid bean name collisions. 