### PR TITLE
Update and add service templates for development

### DIFF
--- a/samples/develop/huawei-compute-opentofu-dev.json
+++ b/samples/develop/huawei-compute-opentofu-dev.json
@@ -1,0 +1,11 @@
+{
+  "serviceName": "opentofu-ecs",
+  "version": "v1.0.0",
+  "csp": "huawei",
+  "category": "container",
+  "flavor": "2vCPUs-4GB-normal",
+  "region": "cn-southwest-2",
+  "customerServiceName": "default-opentofu-ecs",
+  "serviceHostingType": "self",
+  "serviceRequestProperties": {}
+}

--- a/samples/develop/huawei-compute-opentofu-dev.yml
+++ b/samples/develop/huawei-compute-opentofu-dev.yml
@@ -1,13 +1,13 @@
 # The version of the Xpanse description language
 version: 1.0
 # The category of the service.
-category: middleware
+category: compute
 # The Service provided by the ISV, the name will be shown on the console as a service.
-name: Kafka-cluster
+name: opentofu-ecs
 # The version of the service, the end-user can select the version they want to deploy.
-serviceVersion: v1.0.1
+serviceVersion: v1.0.0
 # For the users may have more than one service, the @namespace can be used to separate the clusters.
-description: This is an enhanced Kafka cluster services by ISV-A.
+description: This is an ehanced compute services by ISV-A.
 namespace: ISV-A
 # Icon for the service.
 icon: |
@@ -30,34 +30,36 @@ billing:
 serviceHostingType: self
 # The flavor of the service, the @category/@name/@version/@flavor can locate the specific service to be deployed.
 flavors:
-  - name: 1-zookeeper-with-3-worker-nodes-normal
+  - name: flavor-error-test
+    # The fixed price during the period (the price applied one shot whatever is the service use)
+    fixedPrice: 10
+    # Properties for the service, which can be used by the deployment.
+    properties:
+      flavor_id: s7.small.1
+  - name: 2vCPUs-4GB-normal
+    # The fixed price during the period (the price applied one shot whatever is the service use)
+    fixedPrice: 20
+    # Properties for the service, which can be used by the deployment.
+    properties:
+      flavor_id: s6.large.2
+  - name: 2vCPUs-8GB-normal
+    # The fixed price during the period (the price applied one shot whatever is the service use)
+    fixedPrice: 30
+    # Properties for the service, which can be used by the deployment.
+    properties:
+      flavor_id: s6.large.4
+  - name: 4vCPUs-8GB-normal
     # The fixed price during the period (the price applied one shot whatever is the service use)
     fixedPrice: 40
     # Properties for the service, which can be used by the deployment.
     properties:
-      worker_nodes_count: 3
-      flavor_id: c7.large.4
-  - name: 1-zookeeper-with-3-worker-nodes-performance
+      flavor_id: s6.xlarge.2
+  - name: 4vCPUs-16GB-normal
     # The fixed price during the period (the price applied one shot whatever is the service use)
-    fixedPrice: 60
+    fixedPrice: 50
     # Properties for the service, which can be used by the deployment.
     properties:
-      worker_nodes_count: 3
-      flavor_id: c7.xlarge.4
-  - name: 1-zookeeper-with-5-worker-nodes-normal
-    # The fixed price during the period (the price applied one shot whatever is the service use)
-    fixedPrice: 60
-    # Properties for the service, which can be used by the deployment.
-    properties:
-      worker_nodes_count: 5
-      flavor_id: c7.large.4
-  - name: 1-zookeeper-with-5-worker-nodes-performance
-    # The fixed price during the period (the price applied one shot whatever is the service use)
-    fixedPrice: 80
-    # Properties for the service, which can be used by the deployment.
-    properties:
-      worker_nodes_count: 5
-      flavor_id: c7.xlarge.4
+      flavor_id: s6.xlarge.4
 # The contact details of the service.
 serviceProviderContactDetails:
   email: [ "test@test.com" ]
@@ -74,7 +76,7 @@ deployment:
   # The parameters will be used to generate the API of the managed service.
   variables:
     - name: admin_passwd
-      description: The admin password of all nodes in the Kafka cluster. If the value is empty, will create a random password.
+      description: The admin password of the compute. If the value is empty, will create a random password.
       kind: variable
       dataType: string
       mandatory: false
@@ -82,62 +84,69 @@ deployment:
         minLength: 8
         maxLength: 16
         pattern: ^(?=.*?[A-Z])(?=.*?[a-z])(?=.*?[0-9])(?=.*?[#?!@$%^&*-]).{8,16}$
+    - name: image_name
+      description: The image name of the compute. If the value is empty, will use the default value to create compute instance.
+      kind: variable
+      dataType: string
+      example: "Ubuntu 22.04 server 64bit"
+      mandatory: false
+      value: "Ubuntu 22.04 server 64bit"
     - name: vpc_name
-      description: The vpc name of all nodes in the Kafka cluster. If the value is empty, will use the default value to find or create VPC.
+      description: The vpc name of the compute. If the value is empty, will use the default value to find or create VPC.
       kind: variable
       dataType: string
-      example: "kafka-vpc-default"
+      example: "ecs-vpc-default"
       mandatory: false
-      value: "kafka-vpc-default"
+      value: "ecs-vpc-default"
     - name: subnet_name
-      description: The sub network name of all nodes in the Kafka cluster. If the value is empty, will use the default value to find or create subnet.
+      description: The sub network name of the compute. If the value is empty, will use the default value to find or create subnet.
       kind: variable
       dataType: string
-      example: "kafka-subnet-default"
+      example: "ecs-subnet-default"
       mandatory: false
-      value: "kafka-subnet-default"
+      value: "ecs-subnet-default"
     - name: secgroup_name
-      description: The security group name of all nodes in the Kafka cluster. If the value is empty, will use the default value to find or create security group.
+      description: The security group name of the compute. If the value is empty, will use the default value to find or create security group.
       kind: variable
       dataType: string
-      example: "kafka-secgroup-default"
+      example: "ecs-secgroup-default"
       mandatory: false
-      value: "kafka-secgroup-default"
+      value: "ecs-secgroup-default"
   deployer: |
     variable "flavor_id" {
       type        = string
-      default     = "c7.large.2"
-      description = "The flavor_id of all nodes in the Kafka cluster."
+      default     = "s6.large.2"
+      description = "The flavor_id of the compute."
     }
-
-    variable "worker_nodes_count" {
+    
+    variable "image_name" {
       type        = string
-      default     = 3
-      description = "The worker nodes count in the Kafka cluster."
+      default     = "Ubuntu 22.04 server 64bit"
+      description = "The image name of the compute."
     }
-
+    
     variable "admin_passwd" {
       type        = string
       default     = ""
-      description = "The root password of all nodes in the Kafka cluster."
+      description = "The root password of the compute."
     }
 
     variable "vpc_name" {
       type        = string
-      default     = "kafka-vpc-default"
-      description = "The vpc name of all nodes in the Kafka cluster."
+      default     = "ecs-vpc-default"
+      description = "The vpc name of the compute."
     }
-
+    
     variable "subnet_name" {
       type        = string
-      default     = "kafka-subnet-default"
-      description = "The subnet name of all nodes in the Kafka cluster."
+      default     = "ecs-subnet-default"
+      description = "The subnet name of the compute."
     }
 
     variable "secgroup_name" {
       type        = string
-      default     = "kafka-secgroup-default"
-      description = "The security group name of all nodes in the Kafka cluster."
+      default     = "ecs-secgroup-default"
+      description = "The security group name of the compute."
     }
 
     data "huaweicloud_vpcs" "existing" {
@@ -195,8 +204,8 @@ deployment:
       direction         = "ingress"
       ethertype         = "IPv4"
       protocol          = "tcp"
-      port_range_min    = 2181
-      port_range_max    = 2181
+      port_range_min    = 8080
+      port_range_max    = 8088
       remote_ip_prefix  = "121.37.117.211/32"
       security_group_id = local.secgroup_id
     }
@@ -206,8 +215,8 @@ deployment:
       direction         = "ingress"
       ethertype         = "IPv4"
       protocol          = "tcp"
-      port_range_min    = 9092
-      port_range_max    = 9093
+      port_range_min    = 9090
+      port_range_max    = 9099
       remote_ip_prefix  = "121.37.117.211/32"
       security_group_id = local.secgroup_id
     }
@@ -229,60 +238,68 @@ deployment:
     }
 
     resource "huaweicloud_kps_keypair" "keypair" {
-      name     = "keypair-kafka-${random_id.new.hex}"
+      name     = "keypair-ecs-${random_id.new.hex}"
       key_file = "keypair-kafka-${random_id.new.hex}.pem"
     }
 
     data "huaweicloud_images_image" "image" {
-      name        = "Kafka-v3.3.2_Ubuntu-20.04"
+      name_regex        = "^${var.image_name}"
       most_recent = true
     }
 
-    resource "huaweicloud_compute_instance" "zookeeper" {
+    resource "huaweicloud_compute_instance" "ecs-opentofu" {
       availability_zone  = data.huaweicloud_availability_zones.osc-az.names[0]
-      name               = "kafka-zookeeper-${random_id.new.hex}"
+      name               = "ecs-opentofu-${random_id.new.hex}"
       flavor_id          = var.flavor_id
       security_group_ids = [ local.secgroup_id ]
       image_id           = data.huaweicloud_images_image.image.id
       key_pair           = huaweicloud_kps_keypair.keypair.name
+      admin_pass       = local.admin_passwd
       network {
         uuid = local.subnet_id
       }
-      user_data = <<EOF
-        #!bin/bash
-        echo root:${local.admin_passwd} | sudo chpasswd
-        sudo systemctl start docker
-        sudo systemctl enable docker
-        sudo docker run -d --name zookeeper-server --privileged=true -p 2181:2181 -e ALLOW_ANONYMOUS_LOGIN=yes bitnami/zookeeper:3.8.1
-      EOF
     }
-
-    resource "huaweicloud_compute_instance" "kafka-broker" {
-      count              = var.worker_nodes_count
-      availability_zone  = data.huaweicloud_availability_zones.osc-az.names[0]
-      name               = "kafka-broker-${random_id.new.hex}-${count.index}"
-      flavor_id          = var.flavor_id
-      security_group_ids = [ local.secgroup_id ]
-      image_id           = data.huaweicloud_images_image.image.id
-      key_pair           = huaweicloud_kps_keypair.keypair.name
-      network {
-        uuid = local.subnet_id
+    
+    resource "huaweicloud_evs_volume" "volume" {
+      name              = "volume-${random_id.new.hex}"
+      description       = "my volume"
+      volume_type       = "SSD"
+      size              = 40
+      availability_zone = data.huaweicloud_availability_zones.osc-az.names[0]
+      tags = {
+        foo = "bar"
+        key = "value"
       }
-      user_data = <<EOF
-        #!bin/bash
-        echo root:${local.admin_passwd} | sudo chpasswd
-        sudo systemctl start docker
-        sudo systemctl enable docker
-        private_ip=$(ifconfig | grep -A1 "eth0" | grep 'inet' | awk -F ' ' ' {print $2}'|awk ' {print $1}')
-        sudo docker run -d --name kafka-server --restart always -p 9092:9092 -p 9093:9093  -e KAFKA_BROKER_ID=${count.index}  -e KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://$private_ip:9092 -e KAFKA_LISTENERS=PLAINTEXT://0.0.0.0:9092 -e ALLOW_PLAINTEXT_LISTENER=yes -e KAFKA_CFG_ZOOKEEPER_CONNECT=${huaweicloud_compute_instance.zookeeper.access_ip_v4}:2181 bitnami/kafka:3.3.2
-      EOF
-      depends_on = [
-        huaweicloud_compute_instance.zookeeper
-      ]
+    }
+    
+    resource "huaweicloud_compute_volume_attach" "attached" {
+      instance_id = huaweicloud_compute_instance.ecs-opentofu.id
+      volume_id   = huaweicloud_evs_volume.volume.id
+    }
+    
+    resource "huaweicloud_vpc_eip" "myeip" {
+       publicip {
+         type = "5_sbgp"
+      }
+      bandwidth {
+        name        = "mybandwidth"
+        size        = 5
+        share_type  = "PER"
+        charge_mode = "traffic"
+      }
+    }
+    
+    resource "huaweicloud_compute_eip_associate" "associated" {
+      public_ip   = huaweicloud_vpc_eip.myeip.address
+      instance_id = huaweicloud_compute_instance.ecs-opentofu.id
     }
 
-    output "zookeeper_server" {
-      value = "${huaweicloud_compute_instance.zookeeper.access_ip_v4}:2181"
+    output "ecs-host" {
+      value = huaweicloud_compute_instance.ecs-opentofu.access_ip_v4
+    }
+    
+    output "ecs-public-ip" {
+      value = huaweicloud_vpc_eip.myeip.address
     }
 
     output "admin_passwd" {

--- a/samples/develop/huawei-compute-terraform-dev.json
+++ b/samples/develop/huawei-compute-terraform-dev.json
@@ -1,0 +1,11 @@
+{
+  "serviceName": "terraform-ecs",
+  "version": "v1.0.0",
+  "csp": "huawei",
+  "category": "container",
+  "flavor": "2vCPUs-4GB-normal",
+  "region": "cn-southwest-2",
+  "customerServiceName": "default-terraform-ecs",
+  "serviceHostingType": "self",
+  "serviceRequestProperties": {}
+}

--- a/samples/develop/huawei-compute-terraform-dev.yml
+++ b/samples/develop/huawei-compute-terraform-dev.yml
@@ -1,17 +1,17 @@
 # The version of the Xpanse description language
 version: 1.0
 # The category of the service.
-category: container
+category: compute
 # The Service provided by the ISV, the name will be shown on the console as a service.
-name: K8S-cluster
+name: terraform-ecs
 # The version of the service, the end-user can select the version they want to deploy.
 serviceVersion: v1.0.0
 # For the users may have more than one service, the @namespace can be used to separate the clusters.
-description: This is an enhanced K8S cluster services by ISV-A.
+description: This is an ehanced compute services by ISV-A.
 namespace: ISV-A
 # Icon for the service.
 icon: |
-  data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACYAAAAmCAYAAACoPemuAAAACXBIWXMAAAsTAAALEwEAmpwYAAAEyUlEQVR4nO1XW2geVRA+52yrVrS2hGjFineleKNVSrHgXVD0RSWgVaoijVJaa0l2Zv+GslBERLw81Ae1XkB8ihaxlZhkZ3ZpUqOFasVLRVG0oGjVqFjx1ja/zNnN/tez+dNEC9KBJcnJmdlvbt/MKnVEDof4g+do5IcM8Hq1jk5Rh12Az9dILxmg/Qa5bB/gv+RMwP73gJAvtoCQD+SA6h/ggxq4V8Hggn8fEPBlGnmrQRpzAmoGEHmr8pNLpx2P58fXaOCkCIAG3qSRNrvv0JhGel0BLZ4inLL2/Ogmg/R2K5FRQIs9jG9t5a5GHlTIl08eEyTzDfKOltOFXDYB3W87cxI6GqlfrUnmtIxLIz07KVBoa2mFRtpwCHrrWwZmgL+org0D9GWB8T0a6FVVGmpXPp+ngbcYpG/dQGhf3d/bWkPVncyrK+o3pd400gu15zSgSvFS+V+DjY5ezwui6w3QO3Wp26zCZIZBHqpy/HfVuXPmhLg84FvqPPrDAIEKorYsxaMG6W57uWvgDI30sAZ6vlIG/JpNT4lOEtAmIBQCtpSxJpkjugbp1/rGmRCYBn7MkYJPVLjlWBWGJkt3SVg+67KteRkg7cpTFsSd9hCjE1TYe5QBHnHYfnBCYE5l5LLQQX6xFC81wJ9mwJ6uRIzeyO5LZO+sAOZlzu6UCVEoYXKMQf7TYWC31IcKonPz+2tHZmnkxw1QWBXxTTaC67adnN+zEeubbYC+d3Tm18XAJAqubvLjlRnwvQaop0Zv7cisinN9s6sbIovUcAb6EZd91cWnOXEZZN+p2NN/qod0c1Vd1IJrIl7AHeObh8JoYaHjAd/uNGQ7qnmof0w9pker2vxvGepWMRieq5H7LIUEUVsKytJFZR1CXq3C5DhnnSFvdEcM+DuH4mcZsGdkENuilrrJ9ainiqs25Aa7+SwDtEoAjzO8pZ/m73i3OaogObugaxJ7J0ypoiFlQNdl0TngYXxjUXoN0lsOytgvEW2iwMvrQvuk8JAQblNmLg21q266KC90TE5XQXRm/v+ugRNtFzdIWStIlng+XWWA7q2lI7664Xpt/XBZ+bRIVhPhGDvP/PgK5W8/3iB9VJWO0aYvD0NjgH4ar0/blenZbVZfVingFbY5aqIWP9AYMeB7nB2TRrDPOoC8seosJ1Y7VqpGS92G4tvxBPRh0Tu8ILq2McJhaOTlbkUas4o2avxBRgFXWt2OXs8AvW+A35Pf5UjupvVJbAd3XdqaOP6cckowPNcgfV5gYI/9POtO5mnkVypzk1ZVFfF9qaPJDA38ojiiSskFBunnArs71Oq+o1WhYHShQf6twMhu2SoqzkRttS+lH1L2z+0tNMjfFNjbK+StWpG0SN1hN8i/1MxMiaKQLSRLbLeOi0+LCngrpQhpqsmIc/3BrGthcIHxozs08FPyU+pNvqYMRHfJfibjS5qh0MFW1p0GsTVC3LxQqV8iVvjBa0dWMt8AbXcU+8vqkKU01G6Qvqrzcp899+OVE6RbnmVCvAKyDvQuu3ROSYL4kpo6Abu1LhdqaAHYUMqPNV/uozXNMxWRod0CiPKED/BBD+gGNZ1iixynCCwgVNMunTtnaqAn7J4v352Tez5O154mn3pH5P8u/wCL4t6vwR2T7QAAAABJRU5ErkJggg==
+  data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAGQAAACRAQMAAAAPc4+9AAAAAXNSR0IB2cksfwAAAAlwSFlzAAALEwAACxMBAJqcGAAAAAZQTFRF+/v7Hh8gVD0A0wAAAcVJREFUeJzNlc1twzAMhSX44KNH0CgaTd6gK3kUd4McDVTwq/hjiUyaIkV7qNA2/QCFIh+ppxB+svLNEqqBGTC0ANugBOwmCGDCFOAwIWGDOoqoODtN2BdL6wxD9NMTO9tXPa1PqL5M30W5p8lm5vNcF0t7ahSrVguqNqmMokRW4YQucVjBCBWH1Z2g3WDlW2skoYU+2x8JOtGedBF3k2iXMO0j16iUiI6gxzPdQhnU/s2G9pCO57QY2r6hvjPbKJHq7DRTRXT60avtuTRdbrFJI3mSZhNOqYjVbd99YyK1QKWzEqSWrE0k07U60uPaelflMzaaeu1KBuurHSsn572I1KWy2joX5ZBfWbS/VEt50H5P6aL4JxTuyJ/+QCNPX4PWF3Q8Xe1eF9FsLdD2VaOnaP2hWvs+zI58/7i3vH3nRFtDZpyTUNaZkON5XnBNsp8lrmDMrpvBr+b6pUl+4XbkQdndqnzYGzfuJm1JmIWimIbe6dndd/bk7gVce/cJdo3uIeLJl7+I2xTnPek67mjtDeppE7b03Ov+kSfDe3JweW53njxeGfXkaz28VeYd86+af/H8a7hgJKaebILaFzakLfxyfQLTxVB6K1K9KQAAAABJRU5ErkJggg==
 # Reserved for CSP, aws,azure,ali,huawei and ...
 cloudServiceProvider:
   name: huawei
@@ -30,37 +30,39 @@ billing:
 serviceHostingType: self
 # The flavor of the service, the @category/@name/@version/@flavor can locate the specific service to be deployed.
 flavors:
-  - name: 1-master-with-3-worker-nodes-normal
+  - name: flavor-error-test
+    # The fixed price during the period (the price applied one shot whatever is the service use)
+    fixedPrice: 10
+    # Properties for the service, which can be used by the deployment.
+    properties:
+      flavor_id: s7.small.1
+  - name: 2vCPUs-4GB-normal
+    # The fixed price during the period (the price applied one shot whatever is the service use)
+    fixedPrice: 20
+    # Properties for the service, which can be used by the deployment.
+    properties:
+      flavor_id: s6.large.2
+  - name: 2vCPUs-8GB-normal
+    # The fixed price during the period (the price applied one shot whatever is the service use)
+    fixedPrice: 30
+    # Properties for the service, which can be used by the deployment.
+    properties:
+      flavor_id: s6.large.4
+  - name: 4vCPUs-8GB-normal
     # The fixed price during the period (the price applied one shot whatever is the service use)
     fixedPrice: 40
     # Properties for the service, which can be used by the deployment.
     properties:
-      worker_nodes_count: 3
-      flavor_id: s6.large.4
-  - name: 1-master-with-3-worker-nodes-performance
+      flavor_id: s6.xlarge.2
+  - name: 4vCPUs-16GB-normal
     # The fixed price during the period (the price applied one shot whatever is the service use)
-    fixedPrice: 60
+    fixedPrice: 50
     # Properties for the service, which can be used by the deployment.
     properties:
-      worker_nodes_count: 3
-      flavor_id: s6.xlarge.4
-  - name: 1-master-with-5-worker-nodes-normal
-    # The fixed price during the period (the price applied one shot whatever is the service use)
-    fixedPrice: 60
-    # Properties for the service, which can be used by the deployment.
-    properties:
-      worker_nodes_count: 5
-      flavor_id: s6.large.4
-  - name: 1-master-with-5-worker-nodes-performance
-    # The fixed price during the period (the price applied one shot whatever is the service use)
-    fixedPrice: 80
-    # Properties for the service, which can be used by the deployment.
-    properties:
-      worker_nodes_count: 5
       flavor_id: s6.xlarge.4
 # The contact details of the service.
 serviceProviderContactDetails:
-  email: ["test@test.com"]
+  email: [ "test@test.com" ]
 deployment:
   # kind, Supported values are terraform, opentofu.
   kind: terraform
@@ -74,7 +76,7 @@ deployment:
   # The parameters will be used to generate the API of the managed service.
   variables:
     - name: admin_passwd
-      description: The admin password of all nodes in the K8S cluster. If the value is empty, will create a random password.
+      description: The admin password of the compute. If the value is empty, will create a random password.
       kind: variable
       dataType: string
       mandatory: false
@@ -82,62 +84,69 @@ deployment:
         minLength: 8
         maxLength: 16
         pattern: ^(?=.*?[A-Z])(?=.*?[a-z])(?=.*?[0-9])(?=.*?[#?!@$%^&*-]).{8,16}$
+    - name: image_name
+      description: The image name of the compute. If the value is empty, will use the default value to create compute instance.
+      kind: variable
+      dataType: string
+      example: "Ubuntu 22.04 server 64bit"
+      mandatory: false
+      value: "Ubuntu 22.04 server 64bit"
     - name: vpc_name
-      description: The vpc name of all nodes in the K8S cluster. If the value is empty, will use the default value to find or create VPC.
+      description: The vpc name of the compute. If the value is empty, will use the default value to find or create VPC.
       kind: variable
       dataType: string
-      example: "k8s-vpc-default"
+      example: "ecs-vpc-default"
       mandatory: false
-      value: "k8s-vpc-default"
+      value: "ecs-vpc-default"
     - name: subnet_name
-      description: The sub network name of all nodes in the K8S cluster. If the value is empty, will use the default value to find or create subnet.
+      description: The sub network name of the compute. If the value is empty, will use the default value to find or create subnet.
       kind: variable
       dataType: string
-      example: "k8s-subnet-default"
+      example: "ecs-subnet-default"
       mandatory: false
-      value: "k8s-subnet-default"
+      value: "ecs-subnet-default"
     - name: secgroup_name
-      description: The security group name of all nodes in the K8S cluster. If the value is empty, will use the default value to find or create security group.
+      description: The security group name of the compute. If the value is empty, will use the default value to find or create security group.
       kind: variable
       dataType: string
-      example: "k8s-secgroup-default"
+      example: "ecs-secgroup-default"
       mandatory: false
-      value: "k8s-secgroup-default"
+      value: "ecs-secgroup-default"
   deployer: |
     variable "flavor_id" {
       type        = string
       default     = "s6.large.2"
-      description = "The flavor_id of all nodes in the k8s cluster."
+      description = "The flavor_id of the compute."
     }
-
-    variable "worker_nodes_count" {
+    
+    variable "image_name" {
       type        = string
-      default     = 3
-      description = "The worker nodes count in the k8s cluster."
+      default     = "Ubuntu 22.04 server 64bit"
+      description = "The image name of the compute."
     }
-
+    
     variable "admin_passwd" {
       type        = string
       default     = ""
-      description = "The root password of all nodes in the k8s cluster."
+      description = "The root password of the compute."
     }
 
     variable "vpc_name" {
       type        = string
-      default     = "k8s-vpc-default"
-      description = "The vpc name of all nodes in the k8s cluster."
+      default     = "ecs-vpc-default"
+      description = "The vpc name of the compute."
     }
-
+    
     variable "subnet_name" {
       type        = string
-      default     = "k8s-subnet-default"
-      description = "The subnet name of all nodes in the k8s cluster."
+      default     = "ecs-subnet-default"
+      description = "The subnet name of the compute."
     }
 
     variable "secgroup_name" {
       type        = string
-      default     = "k8s-secgroup-default"
-      description = "The security group name of all nodes in the k8s cluster."
+      default     = "ecs-secgroup-default"
+      description = "The security group name of the compute."
     }
 
     data "huaweicloud_vpcs" "existing" {
@@ -176,7 +185,7 @@ deployment:
     resource "huaweicloud_networking_secgroup" "new" {
       count       = length(data.huaweicloud_networking_secgroups.existing.security_groups) == 0 ? 1 : 0
       name        = var.secgroup_name
-      description = "k8s cluster security group"
+      description = "Kafka cluster security group"
     }
 
     resource "huaweicloud_networking_secgroup_rule" "secgroup_rule_0" {
@@ -186,6 +195,28 @@ deployment:
       protocol          = "tcp"
       port_range_min    = 22
       port_range_max    = 22
+      remote_ip_prefix  = "121.37.117.211/32"
+      security_group_id = local.secgroup_id
+    }
+
+    resource "huaweicloud_networking_secgroup_rule" "secgroup_rule_1" {
+      count             = length(data.huaweicloud_networking_secgroups.existing.security_groups) == 0 ? 1 : 0
+      direction         = "ingress"
+      ethertype         = "IPv4"
+      protocol          = "tcp"
+      port_range_min    = 8080
+      port_range_max    = 8088
+      remote_ip_prefix  = "121.37.117.211/32"
+      security_group_id = local.secgroup_id
+    }
+
+    resource "huaweicloud_networking_secgroup_rule" "secgroup_rule_2" {
+      count             = length(data.huaweicloud_networking_secgroups.existing.security_groups) == 0 ? 1 : 0
+      direction         = "ingress"
+      ethertype         = "IPv4"
+      protocol          = "tcp"
+      port_range_min    = 9090
+      port_range_max    = 9099
       remote_ip_prefix  = "121.37.117.211/32"
       security_group_id = local.secgroup_id
     }
@@ -207,55 +238,68 @@ deployment:
     }
 
     resource "huaweicloud_kps_keypair" "keypair" {
-      name     = "keypair-k8s-${random_id.new.hex}"
+      name     = "keypair-ecs-${random_id.new.hex}"
       key_file = "keypair-kafka-${random_id.new.hex}.pem"
     }
 
     data "huaweicloud_images_image" "image" {
-      name        = "K8S-v1.26.2_Centos-7.9"
+      name_regex        = "^${var.image_name}"
       most_recent = true
     }
 
-    resource "huaweicloud_compute_instance" "k8s-master" {
+    resource "huaweicloud_compute_instance" "ecs-terraform" {
       availability_zone  = data.huaweicloud_availability_zones.osc-az.names[0]
-      name               = "k8s-master-${random_id.new.hex}"
+      name               = "ecs-terraform-${random_id.new.hex}"
       flavor_id          = var.flavor_id
       security_group_ids = [ local.secgroup_id ]
       image_id           = data.huaweicloud_images_image.image.id
       key_pair           = huaweicloud_kps_keypair.keypair.name
+      admin_pass       = local.admin_passwd
       network {
         uuid = local.subnet_id
       }
-      user_data = <<EOF
-        #!bin/bash
-        echo root:${local.admin_passwd} | sudo chpasswd
-        sudo sh /root/k8s-init.sh true ${local.admin_passwd} ${var.worker_nodes_count} > /root/init.log
-      EOF
     }
-
-    resource "huaweicloud_compute_instance" "k8s-node" {
-      count              = var.worker_nodes_count
-      availability_zone  = data.huaweicloud_availability_zones.osc-az.names[0]
-      name               = "k8s-node-${random_id.new.hex}-${count.index}"
-      flavor_id          = var.flavor_id
-      security_group_ids = [ local.secgroup_id ]
-      image_id           = data.huaweicloud_images_image.image.id
-      key_pair           = huaweicloud_kps_keypair.keypair.name
-      network {
-        uuid = local.subnet_id
+    
+    resource "huaweicloud_evs_volume" "volume" {
+      name              = "volume-${random_id.new.hex}"
+      description       = "my volume"
+      volume_type       = "SSD"
+      size              = 40
+      availability_zone = data.huaweicloud_availability_zones.osc-az.names[0]
+      tags = {
+        foo = "bar"
+        key = "value"
       }
-      user_data = <<EOF
-        #!bin/bash
-        echo root:${local.admin_passwd} | sudo chpasswd
-        sudo sh /root/k8s-init.sh false ${local.admin_passwd} ${var.worker_nodes_count} ${huaweicloud_compute_instance.k8s-master.access_ip_v4} > /root/init.log
-      EOF
-      depends_on = [
-        huaweicloud_compute_instance.k8s-master
-      ]
+    }
+    
+    resource "huaweicloud_compute_volume_attach" "attached" {
+      instance_id = huaweicloud_compute_instance.ecs-terraform.id
+      volume_id   = huaweicloud_evs_volume.volume.id
+    }
+    
+    resource "huaweicloud_vpc_eip" "myeip" {
+       publicip {
+         type = "5_sbgp"
+      }
+      bandwidth {
+        name        = "mybandwidth"
+        size        = 5
+        share_type  = "PER"
+        charge_mode = "traffic"
+      }
+    }
+    
+    resource "huaweicloud_compute_eip_associate" "associated" {
+      public_ip   = huaweicloud_vpc_eip.myeip.address
+      instance_id = huaweicloud_compute_instance.ecs-terraform.id
     }
 
-    output "k8s_master_host" {
-      value = huaweicloud_compute_instance.k8s-master.access_ip_v4
+    output "ecs-host" {
+      value = huaweicloud_compute_instance.ecs-terraform.access_ip_v4
+    }
+    
+    output "ecs-public-ip" {
+      value = huaweicloud_vpc_eip.myeip.address
     }
 
     output "admin_passwd" {

--- a/samples/flexibleEngine-K8S.yml
+++ b/samples/flexibleEngine-K8S.yml
@@ -62,7 +62,7 @@ flavors:
 serviceProviderContactDetails:
   email: ["test@test.com"]
 deployment:
-  # kind, Supported values are terraform, pulumi, crossplane.
+  # kind, Supported values are terraform, opentofu.
   kind: terraform
   # Context for deployment: the context including some kind of parameters for the deployment, such as fix_env, fix_variable, env, variable, env_env, env_variable.
   # - fix_env: Values for variable of this type are defined by the managed service provider in the OCL template. Runtime will inject it to deployer as environment variables. This variable is not visible to the end user.

--- a/samples/flexibleEngine-Kafka.yml
+++ b/samples/flexibleEngine-Kafka.yml
@@ -62,7 +62,7 @@ flavors:
 serviceProviderContactDetails:
   email: ["test@test.com"]
 deployment:
-  # kind, Supported values are terraform, pulumi, crossplane.
+  # kind, Supported values are terraform, opentofu.
   kind: terraform
   # Context for deployment: the context including some kind of parameters for the deployment, such as fix_env, fix_variable, env, variable, env_env, env_variable.
   # - fix_env: Values for variable of this type are defined by the managed service provider in the OCL template. Runtime will inject it to deployer as environment variables. This variable is not visible to the end user.

--- a/samples/huawei-Kafka-terraform_module.yml
+++ b/samples/huawei-Kafka-terraform_module.yml
@@ -36,33 +36,33 @@ flavors:
     # Properties for the service, which can be used by the deployment.
     properties:
       worker_nodes_count: 3
-      flavor_id: c7.large.4
+      flavor_id: s6.large.4
   - name: 1-zookeeper-with-3-worker-nodes-performance
     # The fixed price during the period (the price applied one shot whatever is the service use)
     fixedPrice: 60
     # Properties for the service, which can be used by the deployment.
     properties:
       worker_nodes_count: 3
-      flavor_id: c7.xlarge.4
+      flavor_id: s6.xlarge.4
   - name: 1-zookeeper-with-5-worker-nodes-normal
     # The fixed price during the period (the price applied one shot whatever is the service use)
     fixedPrice: 60
     # Properties for the service, which can be used by the deployment.
     properties:
       worker_nodes_count: 5
-      flavor_id: c7.large.4
+      flavor_id: s6.large.4
   - name: 1-zookeeper-with-5-worker-nodes-performance
     # The fixed price during the period (the price applied one shot whatever is the service use)
     fixedPrice: 80
     # Properties for the service, which can be used by the deployment.
     properties:
       worker_nodes_count: 5
-      flavor_id: c7.xlarge.4
+      flavor_id: s6.xlarge.4
 # The contact details of the service.
 serviceProviderContactDetails:
   email: ["test@test.com"]
 deployment:
-  # kind, Supported values are terraform, pulumi, crossplane.
+  # kind, Supported values are terraform, opentofu.
   kind: terraform
   # Context for deployment: the context including some kind of parameters for the deployment, such as fix_env, fix_variable, env, variable, env_env, env_variable.
   # - fix_env: Values for variable of this type are defined by the managed service provider in the OCL template. Runtime will inject it to deployer as environment variables. This variable is not visible to the end user.
@@ -103,7 +103,7 @@ deployment:
   deployer: |
     variable "flavor_id" {
       type        = string
-      default     = "c7.large.2"
+      default     = "s6.large.2"
       description = "The flavor_id of all nodes in the Kafka cluster."
     }
 
@@ -241,7 +241,7 @@ deployment:
         subnet_id                = local.subnet_id
         instance_name            = "kafka-broker-module${random_id.new.hex}-${count.index}"
         instance_flavor_id       = var.flavor_id
-        instance_image_id        = "60197a48-4452-4119-96b2-dc7ab245ecb1"
+        instance_image_id        = "60197a48-4452-4119-96b2-ds6ab245ecb1"
         security_group_ids       = [ local.secgroup_id ]
         system_disk_size         = 50
         admin_password           = local.admin_passwd

--- a/samples/huawei-Kafka.yml
+++ b/samples/huawei-Kafka.yml
@@ -36,33 +36,33 @@ flavors:
     # Properties for the service, which can be used by the deployment.
     properties:
       worker_nodes_count: 3
-      flavor_id: c7.large.4
+      flavor_id: s6.large.4
   - name: 1-zookeeper-with-3-worker-nodes-performance
     # The fixed price during the period (the price applied one shot whatever is the service use)
     fixedPrice: 60
     # Properties for the service, which can be used by the deployment.
     properties:
       worker_nodes_count: 3
-      flavor_id: c7.xlarge.4
+      flavor_id: s6.xlarge.4
   - name: 1-zookeeper-with-5-worker-nodes-normal
     # The fixed price during the period (the price applied one shot whatever is the service use)
     fixedPrice: 60
     # Properties for the service, which can be used by the deployment.
     properties:
       worker_nodes_count: 5
-      flavor_id: c7.large.4
+      flavor_id: s6.large.4
   - name: 1-zookeeper-with-5-worker-nodes-performance
     # The fixed price during the period (the price applied one shot whatever is the service use)
     fixedPrice: 80
     # Properties for the service, which can be used by the deployment.
     properties:
       worker_nodes_count: 5
-      flavor_id: c7.xlarge.4
+      flavor_id: s6.xlarge.4
 # The contact details of the service.
 serviceProviderContactDetails:
   email: ["test@test.com"]
 deployment:
-  # kind, Supported values are terraform, pulumi, crossplane.
+  # kind, Supported values are terraform, opentofu.
   kind: terraform
   # Context for deployment: the context including some kind of parameters for the deployment, such as fix_env, fix_variable, env, variable, env_env, env_variable.
   # - fix_env: Values for variable of this type are defined by the managed service provider in the OCL template. Runtime will inject it to deployer as environment variables. This variable is not visible to the end user.
@@ -106,7 +106,7 @@ deployment:
   deployer: |
     variable "flavor_id" {
       type        = string
-      default     = "c7.large.2"
+      default     = "s6.large.2"
       description = "The flavor_id of all nodes in the Kafka cluster."
     }
 

--- a/samples/openstack-Kafka.yml
+++ b/samples/openstack-Kafka.yml
@@ -62,7 +62,7 @@ flavors:
 serviceProviderContactDetails:
   email: ["test@test.com"]
 deployment:
-  # kind, Supported values are terraform, pulumi, crossplane.
+  # kind, Supported values are terraform, opentofu.
   kind: terraform
   # Context for deployment: the context including some kind of parameters for the deployment, such as fix_env, fix_variable, env, variable, env_env, env_variable.
   # - fix_env: Values for variable of this type are defined by the managed service provider in the OCL template. Runtime will inject it to deployer as environment variables. This variable is not visible to the end user.

--- a/samples/scs-Kafka.yml
+++ b/samples/scs-Kafka.yml
@@ -66,7 +66,7 @@ flavors:
 serviceProviderContactDetails:
   email: ["test@test.com"]
 deployment:
-  # kind, Supported values are terraform, pulumi, crossplane.
+  # kind, Supported values are terraform, opentofu.
   kind: terraform
   # Context for deployment: the context including some kind of parameters for the deployment, such as fix_env, fix_variable, env, variable, env_env, env_variable.
   # - fix_env: Values for variable of this type are defined by the managed service provider in the OCL template. Runtime will inject it to deployer as environment variables. This variable is not visible to the end user.


### PR DESCRIPTION
fixes #1342 
Contains all supported resource types:
![image](https://github.com/eclipse-xpanse/xpanse/assets/121531362/5b054014-4565-40e1-b269-64a5e0e66063)
Both of deployers `OpenTofu` and `Teraform`  are supporeed:
![image](https://github.com/eclipse-xpanse/xpanse/assets/121531362/4ef66fd3-bf40-4b2b-b2d8-af79e941a81b)
Deployment failed test:(chose flavor 'flavor-error-test')
![image](https://github.com/eclipse-xpanse/xpanse/assets/121531362/4913b844-c7e3-40fe-b5b3-864db78319ab)

