### PR TITLE
extend opentofu deployer to support deploymentScripts from GitRepo

### DIFF
--- a/modules/api/src/main/java/org/eclipse/xpanse/api/controllers/OpenTofuMakerWebhookApi.java
+++ b/modules/api/src/main/java/org/eclipse/xpanse/api/controllers/OpenTofuMakerWebhookApi.java
@@ -26,7 +26,7 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 /**
- * Webhook class for openTofu-boot. These API methods are not exposed to the end user.
+ * Webhook class for tofu-maker. These API methods are not exposed to the end user.
  * They are only for machine-to-machine communication.
  * This class implements the callback methods described in the tofu-maker specifications.
  */

--- a/modules/deployment/src/main/java/org/eclipse/xpanse/modules/deployment/deployers/opentofu/callbacks/OpenTofuDeploymentResultCallbackManager.java
+++ b/modules/deployment/src/main/java/org/eclipse/xpanse/modules/deployment/deployers/opentofu/callbacks/OpenTofuDeploymentResultCallbackManager.java
@@ -73,8 +73,8 @@ public class OpenTofuDeploymentResultCallbackManager {
                             .getDeployment().getKind()).handler(deployResult);
         }
         DeployServiceEntity updatedDeployServiceEntity =
-                deployResultManager.updateDeployServiceEntityWithDeployResult(deployResult,
-                        deployServiceEntity);
+                deployResultManager.updateDeployServiceEntityWithDeployResult(
+                        deployResult, deployServiceEntity);
         if (ServiceDeploymentState.DEPLOY_FAILED
                 == updatedDeployServiceEntity.getServiceDeploymentState()) {
             DeployTask deployTask =

--- a/modules/deployment/src/main/java/org/eclipse/xpanse/modules/deployment/deployers/opentofu/opentofulocal/OpenTofuLocalExecutor.java
+++ b/modules/deployment/src/main/java/org/eclipse/xpanse/modules/deployment/deployers/opentofu/opentofulocal/OpenTofuLocalExecutor.java
@@ -9,6 +9,7 @@ package org.eclipse.xpanse.modules.deployment.deployers.opentofu.opentofulocal;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.annotation.Nullable;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -27,7 +28,7 @@ import org.eclipse.xpanse.modules.orchestrator.deployment.DeploymentScriptValida
  * An executor for OpenTofu.
  */
 @Slf4j
-public class OpenTofuExecutor {
+public class OpenTofuLocalExecutor {
 
     private static final String VARS_FILE_NAME = "variables.tfvars.json";
     private static final String STATE_FILE_NAME = "terraform.tfstate";
@@ -50,11 +51,16 @@ public class OpenTofuExecutor {
      * @param variables variables for the open tofu command line.
      * @param workspace workspace for the open tofu command line.
      */
-    OpenTofuExecutor(Map<String, String> env, Map<String, Object> variables,
-                     String workspace) {
+    OpenTofuLocalExecutor(Map<String, String> env, 
+                           Map<String, Object> variables,
+                           String workspace,
+                           @Nullable String subDirectory) {
         this.env = env;
         this.variables = variables;
-        this.workspace = workspace;
+        this.workspace =
+                Objects.nonNull(subDirectory)
+                        ? workspace + File.separator + subDirectory
+                        : workspace;
     }
 
     /**

--- a/modules/deployment/src/main/java/org/eclipse/xpanse/modules/deployment/deployers/opentofu/opentofulocal/config/OpenTofuLocalConfig.java
+++ b/modules/deployment/src/main/java/org/eclipse/xpanse/modules/deployment/deployers/opentofu/opentofulocal/config/OpenTofuLocalConfig.java
@@ -1,7 +1,6 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  * SPDX-FileCopyrightText: Huawei Inc.
- *
  */
 
 package org.eclipse.xpanse.modules.deployment.deployers.opentofu.opentofulocal.config;

--- a/modules/deployment/src/main/java/org/eclipse/xpanse/modules/deployment/deployers/opentofu/opentofumaker/OpenTofuMakerDeployment.java
+++ b/modules/deployment/src/main/java/org/eclipse/xpanse/modules/deployment/deployers/opentofu/opentofumaker/OpenTofuMakerDeployment.java
@@ -5,6 +5,7 @@
 
 package org.eclipse.xpanse.modules.deployment.deployers.opentofu.opentofumaker;
 
+import java.util.Objects;
 import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
 import org.eclipse.xpanse.modules.models.servicetemplate.Ocl;
@@ -34,11 +35,11 @@ public class OpenTofuMakerDeployment implements Deployer {
      * Initializes the OpenTofuBoot deployer.
      */
     @Autowired
-    public OpenTofuMakerDeployment(
-            OpenTofuMakerScriptValidator openTofuMakerScriptValidator,
-            OpenTofuMakerDeploymentPlanManage openTofuMakerDeploymentPlanManage,
-            OpenTofuMakerServiceDeployer openTofuMakerServiceDeployer,
-            OpenTofuMakerServiceDestroyer openTofuMakerServiceDestroyer) {
+    public OpenTofuMakerDeployment(OpenTofuMakerScriptValidator openTofuMakerScriptValidator,
+                                   OpenTofuMakerDeploymentPlanManage
+                                           openTofuMakerDeploymentPlanManage,
+                                   OpenTofuMakerServiceDeployer openTofuMakerServiceDeployer,
+                                   OpenTofuMakerServiceDestroyer openTofuMakerServiceDestroyer) {
         this.openTofuMakerServiceDestroyer = openTofuMakerServiceDestroyer;
         this.openTofuMakerScriptValidator = openTofuMakerScriptValidator;
         this.openTofuMakerDeploymentPlanManage = openTofuMakerDeploymentPlanManage;
@@ -47,12 +48,18 @@ public class OpenTofuMakerDeployment implements Deployer {
 
     @Override
     public DeployResult deploy(DeployTask deployTask) {
-        return openTofuMakerServiceDeployer.deployFromScripts(deployTask);
+        if (Objects.nonNull(deployTask.getOcl().getDeployment().getDeployer())) {
+            return openTofuMakerServiceDeployer.deployFromScripts(deployTask);
+        }
+        return openTofuMakerServiceDeployer.deployFromGitRepo(deployTask);
     }
 
     @Override
     public DeployResult destroy(DeployTask deployTask) {
-        return openTofuMakerServiceDestroyer.destroyFromScripts(deployTask);
+        if (Objects.nonNull(deployTask.getOcl().getDeployment().getDeployer())) {
+            return openTofuMakerServiceDestroyer.destroyFromScripts(deployTask);
+        }
+        return openTofuMakerServiceDestroyer.destroyFromGitRepo(deployTask);
     }
 
     /**
@@ -76,12 +83,22 @@ public class OpenTofuMakerDeployment implements Deployer {
      */
     @Override
     public DeploymentScriptValidationResult validate(Ocl ocl) {
-        return openTofuMakerScriptValidator.validateOpenTofuScripts(ocl);
+        DeploymentScriptValidationResult result = null;
+        if (Objects.nonNull(ocl.getDeployment().getDeployer())) {
+            result = openTofuMakerScriptValidator.validateOpenTofuScripts(ocl);
+        }
+        if (Objects.nonNull(ocl.getDeployment().getScriptsRepo())) {
+            result = openTofuMakerScriptValidator.validateOpenTofuScriptsFromGitRepo(ocl);
+        }
+        return result;
     }
 
     @Override
     public String getDeploymentPlanAsJson(DeployTask task) {
-        return openTofuMakerDeploymentPlanManage.getOpenTofuPlanFromScripts(task).getPlan();
+        if (Objects.nonNull(task.getOcl().getDeployment().getDeployer())) {
+            return openTofuMakerDeploymentPlanManage.getOpenTofuPlanFromScripts(task).getPlan();
+        }
+        return openTofuMakerDeploymentPlanManage.getOpenTofuPlanFromGitRepo(task).getPlan();
     }
 
 }

--- a/modules/deployment/src/main/java/org/eclipse/xpanse/modules/deployment/deployers/opentofu/opentofumaker/OpenTofuMakerDeploymentPlanManage.java
+++ b/modules/deployment/src/main/java/org/eclipse/xpanse/modules/deployment/deployers/opentofu/opentofumaker/OpenTofuMakerDeploymentPlanManage.java
@@ -5,8 +5,10 @@
 
 package org.eclipse.xpanse.modules.deployment.deployers.opentofu.opentofumaker;
 
+import org.eclipse.xpanse.modules.deployment.deployers.opentofu.opentofumaker.generated.api.OpenTofuFromGitRepoApi;
 import org.eclipse.xpanse.modules.deployment.deployers.opentofu.opentofumaker.generated.api.OpenTofuFromScriptsApi;
 import org.eclipse.xpanse.modules.deployment.deployers.opentofu.opentofumaker.generated.model.OpenTofuPlan;
+import org.eclipse.xpanse.modules.deployment.deployers.opentofu.opentofumaker.generated.model.OpenTofuPlanFromGitRepoRequest;
 import org.eclipse.xpanse.modules.deployment.deployers.opentofu.opentofumaker.generated.model.OpenTofuPlanWithScriptsRequest;
 import org.eclipse.xpanse.modules.orchestrator.deployment.DeployTask;
 import org.springframework.context.annotation.Profile;
@@ -20,14 +22,17 @@ import org.springframework.stereotype.Component;
 public class OpenTofuMakerDeploymentPlanManage {
 
     private final OpenTofuFromScriptsApi openTofuFromScriptsApi;
+    private final OpenTofuFromGitRepoApi openTofuFromGitRepoApi;
     private final OpenTofuMakerHelper openTofuMakerHelper;
 
     /**
-     * constructor for OpenTofuBootDeploymentPlanManage.
+     * constructor for OpenTofuMakerDeploymentPlanManage.
      */
     public OpenTofuMakerDeploymentPlanManage(OpenTofuFromScriptsApi openTofuFromScriptsApi,
+                                             OpenTofuFromGitRepoApi openTofuFromGitRepoApi,
                                              OpenTofuMakerHelper openTofuMakerHelper) {
         this.openTofuFromScriptsApi = openTofuFromScriptsApi;
+        this.openTofuFromGitRepoApi = openTofuFromGitRepoApi;
         this.openTofuMakerHelper = openTofuMakerHelper;
     }
 
@@ -40,11 +45,31 @@ public class OpenTofuMakerDeploymentPlanManage {
                 deployTask.getId());
     }
 
+    /**
+     * Method to get openTofu plan from scripts provided in GIT repo.
+     */
+    public OpenTofuPlan getOpenTofuPlanFromGitRepo(DeployTask deployTask) {
+        openTofuMakerHelper.setHeaderTokenByProfiles();
+        return openTofuFromGitRepoApi.planFromGitRepo(getPlanFromGitRepoRequest(deployTask),
+                deployTask.getId());
+    }
+
     private OpenTofuPlanWithScriptsRequest getPlanWithScriptsRequest(DeployTask task) {
         OpenTofuPlanWithScriptsRequest request = new OpenTofuPlanWithScriptsRequest();
         request.setScripts(openTofuMakerHelper.getFiles(task));
         request.setVariables(openTofuMakerHelper.getInputVariables(task, true));
         request.setEnvVariables(openTofuMakerHelper.getEnvironmentVariables(task));
+        return request;
+    }
+
+    private OpenTofuPlanFromGitRepoRequest getPlanFromGitRepoRequest(DeployTask task) {
+        OpenTofuPlanFromGitRepoRequest request = new OpenTofuPlanFromGitRepoRequest();
+        request.setVariables(openTofuMakerHelper.getInputVariables(task, true));
+        request.setEnvVariables(openTofuMakerHelper.getEnvironmentVariables(task));
+        request.setGitRepoDetails(
+                openTofuMakerHelper.convertOpenTofuScriptGitRepoDetailsFromDeployFromGitRepo(
+                        task.getOcl().getDeployment().getScriptsRepo()));
+        request.getVariables().put("region", task.getDeployRequest().getRegion());
         return request;
     }
 }

--- a/modules/deployment/src/main/java/org/eclipse/xpanse/modules/deployment/deployers/opentofu/opentofumaker/OpenTofuMakerServiceDeployer.java
+++ b/modules/deployment/src/main/java/org/eclipse/xpanse/modules/deployment/deployers/opentofu/opentofumaker/OpenTofuMakerServiceDeployer.java
@@ -7,7 +7,9 @@ package org.eclipse.xpanse.modules.deployment.deployers.opentofu.opentofumaker;
 
 import lombok.extern.slf4j.Slf4j;
 import org.eclipse.xpanse.modules.deployment.deployers.opentofu.exceptions.OpenTofuMakerRequestFailedException;
+import org.eclipse.xpanse.modules.deployment.deployers.opentofu.opentofumaker.generated.api.OpenTofuFromGitRepoApi;
 import org.eclipse.xpanse.modules.deployment.deployers.opentofu.opentofumaker.generated.api.OpenTofuFromScriptsApi;
+import org.eclipse.xpanse.modules.deployment.deployers.opentofu.opentofumaker.generated.model.OpenTofuAsyncDeployFromGitRepoRequest;
 import org.eclipse.xpanse.modules.deployment.deployers.opentofu.opentofumaker.generated.model.OpenTofuAsyncDeployFromScriptsRequest;
 import org.eclipse.xpanse.modules.orchestrator.deployment.DeployResult;
 import org.eclipse.xpanse.modules.orchestrator.deployment.DeployTask;
@@ -24,14 +26,17 @@ import org.springframework.web.client.RestClientException;
 public class OpenTofuMakerServiceDeployer {
 
     private final OpenTofuFromScriptsApi openTofuFromScriptsApi;
+    private final OpenTofuFromGitRepoApi openTofuFromGitRepoApi;
     private final OpenTofuMakerHelper openTofuMakerHelper;
 
     /**
      * Constructor for OpenTofuMakerServiceDeployer bean.
      */
     public OpenTofuMakerServiceDeployer(OpenTofuFromScriptsApi openTofuFromScriptsApi,
+                                        OpenTofuFromGitRepoApi openTofuFromGitRepoApi,
                                         OpenTofuMakerHelper openTofuMakerHelper) {
         this.openTofuFromScriptsApi = openTofuFromScriptsApi;
+        this.openTofuFromGitRepoApi = openTofuFromGitRepoApi;
         this.openTofuMakerHelper = openTofuMakerHelper;
     }
 
@@ -53,6 +58,24 @@ public class OpenTofuMakerServiceDeployer {
         }
     }
 
+    /**
+     * method to perform service deployment using scripts form GIT repo.
+     */
+    public DeployResult deployFromGitRepo(DeployTask deployTask) {
+        DeployResult result = new DeployResult();
+        OpenTofuAsyncDeployFromGitRepoRequest request = getDeployFromGitRepoRequest(deployTask);
+        try {
+            openTofuMakerHelper.setHeaderTokenByProfiles();
+            openTofuFromGitRepoApi.asyncDeployFromGitRepo(request, deployTask.getId());
+            result.setId(deployTask.getId());
+            return result;
+        } catch (RestClientException e) {
+            log.error("tofu-maker deploy service failed. service id: {} , error:{} ",
+                    deployTask.getId(), e.getMessage());
+            throw new OpenTofuMakerRequestFailedException(e.getMessage());
+        }
+    }
+
     private OpenTofuAsyncDeployFromScriptsRequest getDeployFromScriptsRequest(DeployTask task) {
         OpenTofuAsyncDeployFromScriptsRequest request =
                 new OpenTofuAsyncDeployFromScriptsRequest();
@@ -61,6 +84,20 @@ public class OpenTofuMakerServiceDeployer {
         request.setVariables(openTofuMakerHelper.getInputVariables(task, true));
         request.setEnvVariables(openTofuMakerHelper.getEnvironmentVariables(task));
         request.setWebhookConfig(openTofuMakerHelper.getWebhookConfig(task, false));
+        return request;
+    }
+
+    private OpenTofuAsyncDeployFromGitRepoRequest getDeployFromGitRepoRequest(DeployTask task) {
+        OpenTofuAsyncDeployFromGitRepoRequest request =
+                new OpenTofuAsyncDeployFromGitRepoRequest();
+        request.setIsPlanOnly(false);
+        request.setVariables(openTofuMakerHelper.getInputVariables(task, true));
+        request.setEnvVariables(openTofuMakerHelper.getEnvironmentVariables(task));
+        request.setWebhookConfig(openTofuMakerHelper.getWebhookConfig(task, false));
+        request.setGitRepoDetails(
+                openTofuMakerHelper.convertOpenTofuScriptGitRepoDetailsFromDeployFromGitRepo(
+                        task.getOcl().getDeployment().getScriptsRepo())
+        );
         return request;
     }
 }

--- a/modules/deployment/src/main/java/org/eclipse/xpanse/modules/deployment/deployers/opentofu/opentofumaker/OpenTofuMakerServiceDestroyer.java
+++ b/modules/deployment/src/main/java/org/eclipse/xpanse/modules/deployment/deployers/opentofu/opentofumaker/OpenTofuMakerServiceDestroyer.java
@@ -9,7 +9,9 @@ import lombok.extern.slf4j.Slf4j;
 import org.eclipse.xpanse.modules.database.service.DeployServiceEntity;
 import org.eclipse.xpanse.modules.deployment.DeployServiceEntityHandler;
 import org.eclipse.xpanse.modules.deployment.deployers.opentofu.exceptions.OpenTofuMakerRequestFailedException;
+import org.eclipse.xpanse.modules.deployment.deployers.opentofu.opentofumaker.generated.api.OpenTofuFromGitRepoApi;
 import org.eclipse.xpanse.modules.deployment.deployers.opentofu.opentofumaker.generated.api.OpenTofuFromScriptsApi;
+import org.eclipse.xpanse.modules.deployment.deployers.opentofu.opentofumaker.generated.model.OpenTofuAsyncDestroyFromGitRepoRequest;
 import org.eclipse.xpanse.modules.deployment.deployers.opentofu.opentofumaker.generated.model.OpenTofuAsyncDestroyFromScriptsRequest;
 import org.eclipse.xpanse.modules.deployment.deployers.opentofu.utils.TfResourceTransUtils;
 import org.eclipse.xpanse.modules.orchestrator.deployment.DeployResult;
@@ -27,6 +29,7 @@ import org.springframework.web.client.RestClientException;
 public class OpenTofuMakerServiceDestroyer {
 
     private final OpenTofuFromScriptsApi openTofuFromScriptsApi;
+    private final OpenTofuFromGitRepoApi openTofuFromGitRepoApi;
     private final OpenTofuMakerHelper openTofuMakerHelper;
     private final DeployServiceEntityHandler deployServiceEntityHandler;
 
@@ -34,9 +37,11 @@ public class OpenTofuMakerServiceDestroyer {
      * Constructor for OpenTofuMakerServiceDestroyer bean.
      */
     public OpenTofuMakerServiceDestroyer(OpenTofuFromScriptsApi openTofuFromScriptsApi,
+                                         OpenTofuFromGitRepoApi openTofuFromGitRepoApi,
                                          OpenTofuMakerHelper openTofuMakerHelper,
                                          DeployServiceEntityHandler deployServiceEntityHandler) {
         this.openTofuFromScriptsApi = openTofuFromScriptsApi;
+        this.openTofuFromGitRepoApi = openTofuFromGitRepoApi;
         this.openTofuMakerHelper = openTofuMakerHelper;
         this.deployServiceEntityHandler = deployServiceEntityHandler;
     }
@@ -63,6 +68,28 @@ public class OpenTofuMakerServiceDestroyer {
         }
     }
 
+    /**
+     * method to perform service destroy using scripts form GIT repo.
+     */
+    public DeployResult destroyFromGitRepo(DeployTask deployTask) {
+        DeployServiceEntity deployServiceEntity =
+                this.deployServiceEntityHandler.getDeployServiceEntity(deployTask.getId());
+        String resourceState = TfResourceTransUtils.getStoredStateContent(deployServiceEntity);
+        DeployResult result = new DeployResult();
+        OpenTofuAsyncDestroyFromGitRepoRequest request =
+                getDestroyFromGitRepoRequest(deployTask, resourceState);
+        try {
+            openTofuMakerHelper.setHeaderTokenByProfiles();
+            openTofuFromGitRepoApi.asyncDestroyFromGitRepo(request, deployTask.getId());
+            result.setId(deployTask.getId());
+            return result;
+        } catch (RestClientException e) {
+            log.error("tofu-maker deploy service failed. service id: {} , error:{} ",
+                    deployTask.getId(), e.getMessage());
+            throw new OpenTofuMakerRequestFailedException(e.getMessage());
+        }
+    }
+
     private OpenTofuAsyncDestroyFromScriptsRequest getDestroyFromScriptsRequest(DeployTask task,
                                                                                 String stateFile)
             throws OpenTofuMakerRequestFailedException {
@@ -78,4 +105,20 @@ public class OpenTofuMakerServiceDestroyer {
                         task.getDestroyScenario().toValue()));
         return request;
     }
+
+    private OpenTofuAsyncDestroyFromGitRepoRequest getDestroyFromGitRepoRequest(DeployTask task,
+                                                                                String stateFile)
+            throws OpenTofuMakerRequestFailedException {
+        OpenTofuAsyncDestroyFromGitRepoRequest request =
+                new OpenTofuAsyncDestroyFromGitRepoRequest();
+        request.setTfState(stateFile);
+        request.setVariables(openTofuMakerHelper.getInputVariables(task, false));
+        request.setEnvVariables(openTofuMakerHelper.getEnvironmentVariables(task));
+        request.setWebhookConfig(openTofuMakerHelper.getWebhookConfig(task, true));
+        request.setDestroyScenario(
+                OpenTofuAsyncDestroyFromGitRepoRequest.DestroyScenarioEnum.fromValue(
+                        task.getDestroyScenario().toValue()));
+        return request;
+    }
+
 }

--- a/modules/deployment/src/main/java/org/eclipse/xpanse/modules/deployment/deployers/terraform/terraformboot/TerraformBootHelper.java
+++ b/modules/deployment/src/main/java/org/eclipse/xpanse/modules/deployment/deployers/terraform/terraformboot/TerraformBootHelper.java
@@ -42,19 +42,16 @@ public class TerraformBootHelper {
 
     private static final String ZITADEL_PROFILE_NAME = "zitadel";
     private static final String SPLIT = "/";
-
-    @Value("${spring.profiles.active}")
-    private String profiles;
-
-    @Value("${server.port}")
-    private String port;
-
     private final TerraformBootConfig terraformBootConfig;
     private final TerraformProviderHelper terraformProviderHelper;
     private final TerraformFromScriptsApi terraformFromScriptsApi;
     private final TerraformFromGitRepoApi terraformFromGitRepoApi;
     private final DeployEnvironments deployEnvironments;
     private final AdminApi adminApi;
+    @Value("${spring.profiles.active}")
+    private String profiles;
+    @Value("${server.port}")
+    private String port;
 
     /**
      * Constructor for TerraformBootHelper.

--- a/modules/deployment/src/main/java/org/eclipse/xpanse/modules/deployment/deployers/terraform/terraformboot/TerraformBootServiceDestroyer.java
+++ b/modules/deployment/src/main/java/org/eclipse/xpanse/modules/deployment/deployers/terraform/terraformboot/TerraformBootServiceDestroyer.java
@@ -62,7 +62,7 @@ public class TerraformBootServiceDestroyer {
             result.setId(deployTask.getId());
             return result;
         } catch (RestClientException e) {
-            log.error("terraform-boot deploy service failed. service id: {} , error:{} ",
+            log.error("terraform-boot destroy service failed. service id: {} , error:{} ",
                     deployTask.getId(), e.getMessage());
             throw new TerraformBootRequestFailedException(e.getMessage());
         }

--- a/modules/deployment/src/test/java/org/eclipse/xpanse/modules/deployment/deployers/opentofu/opentofulocal/OpenTofuLocalDeploymentTest.java
+++ b/modules/deployment/src/test/java/org/eclipse/xpanse/modules/deployment/deployers/opentofu/opentofulocal/OpenTofuLocalDeploymentTest.java
@@ -6,7 +6,7 @@
 
 package org.eclipse.xpanse.modules.deployment.deployers.opentofu.opentofulocal;
 
-import static org.eclipse.xpanse.modules.deployment.deployers.opentofu.opentofulocal.OpenTofuDeployment.STATE_FILE_NAME;
+import static org.eclipse.xpanse.modules.deployment.deployers.opentofu.opentofulocal.OpenTofuLocalDeployment.STATE_FILE_NAME;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.when;
@@ -23,8 +23,8 @@ import org.eclipse.xpanse.modules.deployment.DeployService;
 import org.eclipse.xpanse.modules.deployment.DeployServiceEntityHandler;
 import org.eclipse.xpanse.modules.deployment.ResourceHandlerManager;
 import org.eclipse.xpanse.modules.deployment.deployers.opentofu.callbacks.OpenTofuDeploymentResultCallbackManager;
-import org.eclipse.xpanse.modules.deployment.deployers.opentofu.exceptions.OpenTofuExecutorException;
 import org.eclipse.xpanse.modules.deployment.deployers.opentofu.opentofulocal.config.OpenTofuLocalConfig;
+import org.eclipse.xpanse.modules.deployment.deployers.opentofu.exceptions.OpenTofuExecutorException;
 import org.eclipse.xpanse.modules.deployment.deployers.opentofu.utils.OpenTofuProviderHelper;
 import org.eclipse.xpanse.modules.deployment.deployers.opentofu.utils.TfResourceTransUtils;
 import org.eclipse.xpanse.modules.deployment.utils.DeployEnvironments;
@@ -52,20 +52,20 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 /**
- * Test for OpenTofuDeploy.
+ * Test for OpenTofuDeployment.
  */
 
 @ExtendWith({SpringExtension.class})
-@ContextConfiguration(classes = {OpenTofuDeployment.class, DeployEnvironments.class,
+@ContextConfiguration(classes = {OpenTofuLocalDeployment.class, DeployEnvironments.class,
         PluginManager.class, OpenTofuLocalConfig.class, DeployService.class,
         TaskConfiguration.class, ResourceHandlerManager.class, OpenTofuProviderHelper.class,
         ScriptsGitRepoManage.class})
-class OpenTofuDeploymentTest {
+class OpenTofuLocalDeploymentTest {
 
     private final UUID id = UUID.randomUUID();
     private final String errorDeployer = "error_deployer";
     @Autowired
-    OpenTofuDeployment openTofuDeployment;
+    OpenTofuLocalDeployment openTofuLocalDeployment;
     @MockBean
     DeployEnvironments deployEnvironments;
     @MockBean
@@ -128,7 +128,7 @@ class OpenTofuDeploymentTest {
         deployTask.setId(id);
         deployTask.setOcl(ocl);
         deployTask.setDeployRequest(deployRequest);
-        deployResult = openTofuDeployment.deploy(deployTask);
+        deployResult = openTofuLocalDeployment.deploy(deployTask);
         Assertions.assertNotNull(deployResult);
         Assertions.assertNotNull(deployResult.getPrivateProperties());
         tfState = deployResult.getPrivateProperties().get(STATE_FILE_NAME);
@@ -150,7 +150,7 @@ class OpenTofuDeploymentTest {
         when(this.deployEnvironments.getFlavorVariables(any(DeployTask.class))).thenReturn(
                 new HashMap<>());
         Assertions.assertThrows(ServiceNotDeployedException.class,
-                () -> openTofuDeployment.destroy(deployTask));
+                () -> openTofuLocalDeployment.destroy(deployTask));
     }
 
     @Test
@@ -158,7 +158,7 @@ class OpenTofuDeploymentTest {
     void testDeleteTaskWorkspace() {
         String workspacePath = System.getProperty("java.io.tmpdir") + File.separator
                 + openTofuLocalConfig.getWorkspaceDirectory() + File.separator + id;
-        this.openTofuDeployment.deleteTaskWorkspace(id);
+        this.openTofuLocalDeployment.deleteTaskWorkspace(id);
         Assertions.assertFalse(new File(workspacePath).exists());
     }
 
@@ -178,7 +178,7 @@ class OpenTofuDeploymentTest {
         deployTask.setId(UUID.randomUUID());
         deployTask.setOcl(ocl);
         deployTask.setDeployRequest(deployRequest);
-        DeployResult deployResult = this.openTofuDeployment.deploy(deployTask);
+        DeployResult deployResult = this.openTofuLocalDeployment.deploy(deployTask);
         Assertions.assertNull(deployResult.getState());
         Assertions.assertNotEquals(DeployerTaskStatus.DEPLOY_SUCCESS.toValue(),
                 deployResult.getMessage());
@@ -196,7 +196,7 @@ class OpenTofuDeploymentTest {
             deployTask.setId(id);
             deployTask.setOcl(ocl);
             deployTask.setDeployRequest(deployRequest);
-            DeployResult deployResult = this.openTofuDeployment.destroy(deployTask);
+            DeployResult deployResult = this.openTofuLocalDeployment.destroy(deployTask);
             Assertions.assertTrue(deployResult.getProperties().isEmpty());
             Assertions.assertNull(deployResult.getState());
             Assertions.assertNotEquals(DeployerTaskStatus.DESTROY_FAILED.toValue(),
@@ -206,7 +206,7 @@ class OpenTofuDeploymentTest {
 
     @Test
     void testGetDeployerKind() {
-        DeployerKind deployerKind = openTofuDeployment.getDeployerKind();
+        DeployerKind deployerKind = openTofuLocalDeployment.getDeployerKind();
 
         Assertions.assertEquals(DeployerKind.OPEN_TOFU, deployerKind);
     }
@@ -229,7 +229,7 @@ class OpenTofuDeploymentTest {
         deployTask.setOcl(ocl);
         deployTask.setDeployRequest(deployRequest);
 
-        String deployPlanJson = openTofuDeployment.getDeploymentPlanAsJson(deployTask);
+        String deployPlanJson = openTofuLocalDeployment.getDeploymentPlanAsJson(deployTask);
         Assertions.assertNotNull(deployPlanJson);
 
     }
@@ -242,10 +242,10 @@ class OpenTofuDeploymentTest {
         deployTask.setId(UUID.randomUUID());
         deployTask.setOcl(ocl);
         deployTask.setDeployRequest(deployRequest);
-        deployResult = this.openTofuDeployment.deploy(deployTask);
+        deployResult = this.openTofuLocalDeployment.deploy(deployTask);
 
         Assertions.assertThrows(OpenTofuExecutorException.class,
-                () -> this.openTofuDeployment.getDeploymentPlanAsJson(deployTask));
+                () -> this.openTofuLocalDeployment.getDeploymentPlanAsJson(deployTask));
 
     }
 

--- a/modules/deployment/src/test/java/org/eclipse/xpanse/modules/deployment/deployers/opentofu/opentofulocal/OpenTofuLocalExecutorTest.java
+++ b/modules/deployment/src/test/java/org/eclipse/xpanse/modules/deployment/deployers/opentofu/opentofulocal/OpenTofuLocalExecutorTest.java
@@ -1,7 +1,7 @@
 package org.eclipse.xpanse.modules.deployment.deployers.opentofu.opentofulocal;
 
-import static org.eclipse.xpanse.modules.deployment.deployers.opentofu.opentofulocal.OpenTofuDeployment.SCRIPT_FILE_NAME;
-import static org.eclipse.xpanse.modules.deployment.deployers.opentofu.opentofulocal.OpenTofuDeployment.VERSION_FILE_NAME;
+import static org.eclipse.xpanse.modules.deployment.deployers.opentofu.opentofulocal.OpenTofuLocalDeployment.SCRIPT_FILE_NAME;
+import static org.eclipse.xpanse.modules.deployment.deployers.opentofu.opentofulocal.OpenTofuLocalDeployment.VERSION_FILE_NAME;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -15,7 +15,6 @@ import java.net.URI;
 import java.util.Map;
 import java.util.UUID;
 import org.eclipse.xpanse.common.systemcmd.SystemCmdResult;
-import org.eclipse.xpanse.modules.deployment.deployers.opentofu.opentofulocal.OpenTofuExecutor;
 import org.eclipse.xpanse.modules.deployment.deployers.opentofu.resources.TfState;
 import org.eclipse.xpanse.modules.models.servicetemplate.Ocl;
 import org.eclipse.xpanse.modules.models.servicetemplate.utils.OclLoader;
@@ -31,7 +30,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
-class OpenTofuExecutorTest {
+class OpenTofuLocalExecutorTest {
     private static final String workspace =
             System.getProperty("java.io.tmpdir") + "/opentofu_workspace/" + UUID.randomUUID();
     private static final String version = "~> 1.51.0";
@@ -39,7 +38,7 @@ class OpenTofuExecutorTest {
     private Map<String, String> mockEnv;
     @Mock
     private Map<String, Object> mockVariables;
-    private OpenTofuExecutor openTofuExecutorUnderTest;
+    private OpenTofuLocalExecutor openTofuLocalExecutorUnderTest;
 
     @BeforeAll
     static void initWorkSpace() throws Exception {
@@ -74,14 +73,15 @@ class OpenTofuExecutorTest {
 
     @BeforeEach
     void setUp() {
-        openTofuExecutorUnderTest = new OpenTofuExecutor(mockEnv, mockVariables, workspace);
+        openTofuLocalExecutorUnderTest = new OpenTofuLocalExecutor(mockEnv, mockVariables,
+                workspace, null);
     }
 
     @Test
     @Order(1)
     void testTfInit() {
         // Run the test
-        final SystemCmdResult result = openTofuExecutorUnderTest.tfInit();
+        final SystemCmdResult result = openTofuLocalExecutorUnderTest.tfInit();
         // Verify the results
         assertTrue(result.isCommandSuccessful());
         assertEquals(result.getCommandStdError(), "");
@@ -91,14 +91,14 @@ class OpenTofuExecutorTest {
     @Test
     @Order(2)
     void testGetOpenTofuPlanAsJson() {
-        assertNotNull(openTofuExecutorUnderTest.getOpenTofuPlanAsJson());
+        assertNotNull(openTofuLocalExecutorUnderTest.getOpenTofuPlanAsJson());
     }
 
     @Test
     @Order(3)
     void testTfPlan() {
         // Run the test
-        final SystemCmdResult result = openTofuExecutorUnderTest.tfPlan();
+        final SystemCmdResult result = openTofuLocalExecutorUnderTest.tfPlan();
         // Verify the results
         assertTrue(result.isCommandSuccessful());
         assertEquals(result.getCommandStdError(), "");
@@ -111,7 +111,7 @@ class OpenTofuExecutorTest {
     void testTfPlanWithOutput() {
         // Setup
         // Run the test
-        final SystemCmdResult result = openTofuExecutorUnderTest.tfPlanWithOutput();
+        final SystemCmdResult result = openTofuLocalExecutorUnderTest.tfPlanWithOutput();
         // Verify the results
         assertTrue(result.isCommandSuccessful());
         assertEquals(result.getCommandStdError(), "");
@@ -123,7 +123,7 @@ class OpenTofuExecutorTest {
     @Order(5)
     void testTfApply() {
         // Run the test
-        final SystemCmdResult result = openTofuExecutorUnderTest.tfApply();
+        final SystemCmdResult result = openTofuLocalExecutorUnderTest.tfApply();
         // Verify the results
         assertTrue(result.isCommandSuccessful());
         assertEquals(result.getCommandStdError(), "");
@@ -135,7 +135,7 @@ class OpenTofuExecutorTest {
     @Order(6)
     void testTfDestroy() {
         // Run the test
-        final SystemCmdResult result = openTofuExecutorUnderTest.tfDestroy();
+        final SystemCmdResult result = openTofuLocalExecutorUnderTest.tfDestroy();
         // Verify the results
         assertTrue(result.isCommandSuccessful());
         assertEquals(result.getCommandStdError(), "");
@@ -149,10 +149,10 @@ class OpenTofuExecutorTest {
     void testDeploy() throws JsonProcessingException {
         // Setup
         // Run the test
-        openTofuExecutorUnderTest.deploy();
+        openTofuLocalExecutorUnderTest.deploy();
         // Verify the results
         TfState tfState =
-                new ObjectMapper().readValue(openTofuExecutorUnderTest.getTerraformState(),
+                new ObjectMapper().readValue(openTofuLocalExecutorUnderTest.getTerraformState(),
                         TfState.class);
         assertFalse(tfState.getOutputs().isEmpty());
     }
@@ -162,10 +162,10 @@ class OpenTofuExecutorTest {
     void testDestroy() throws JsonProcessingException {
         // Setup
         // Run the test
-        openTofuExecutorUnderTest.destroy();
+        openTofuLocalExecutorUnderTest.destroy();
         // Verify the results
         TfState tfState =
-                new ObjectMapper().readValue(openTofuExecutorUnderTest.getTerraformState(),
+                new ObjectMapper().readValue(openTofuLocalExecutorUnderTest.getTerraformState(),
                         TfState.class);
         assertTrue(tfState.getOutputs().isEmpty());
     }
@@ -175,7 +175,8 @@ class OpenTofuExecutorTest {
     void testGetImportantFilesContent() {
         // Setup
         // Run the test
-        final Map<String, String> result = openTofuExecutorUnderTest.getImportantFilesContent();
+        final Map<String, String> result =
+                openTofuLocalExecutorUnderTest.getImportantFilesContent();
         // Verify the results
         assertTrue(result.containsKey("terraform.tfstate.backup"));
     }

--- a/modules/deployment/src/test/java/org/eclipse/xpanse/modules/deployment/deployers/terraform/exceptions/TerraformExecutorExceptionTest.java
+++ b/modules/deployment/src/test/java/org/eclipse/xpanse/modules/deployment/deployers/terraform/exceptions/TerraformExecutorExceptionTest.java
@@ -14,7 +14,7 @@ import org.junit.jupiter.api.Test;
 /**
  * Test of TerraformExecutorException.
  */
-class TerraformLocalExecutorExceptionTest {
+class TerraformExecutorExceptionTest {
 
     private static final String message = "terraformExecutor exception.";
     private static final Throwable cause = new RuntimeException("Root cause");

--- a/modules/deployment/src/test/java/org/eclipse/xpanse/modules/deployment/deployers/terraform/terraformlocal/TerraformLocalDeploymentTest.java
+++ b/modules/deployment/src/test/java/org/eclipse/xpanse/modules/deployment/deployers/terraform/terraformlocal/TerraformLocalDeploymentTest.java
@@ -26,9 +26,8 @@ import org.eclipse.xpanse.modules.deployment.DeployService;
 import org.eclipse.xpanse.modules.deployment.DeployServiceEntityHandler;
 import org.eclipse.xpanse.modules.deployment.ResourceHandlerManager;
 import org.eclipse.xpanse.modules.deployment.deployers.terraform.callbacks.TerraformDeploymentResultCallbackManager;
-import org.eclipse.xpanse.modules.deployment.deployers.terraform.terraformlocal.config.TerraformLocalConfig;
 import org.eclipse.xpanse.modules.deployment.deployers.terraform.exceptions.TerraformExecutorException;
-import org.eclipse.xpanse.modules.deployment.deployers.terraform.terraformlocal.TerraformLocalDeployment;
+import org.eclipse.xpanse.modules.deployment.deployers.terraform.terraformlocal.config.TerraformLocalConfig;
 import org.eclipse.xpanse.modules.deployment.deployers.terraform.utils.TerraformProviderHelper;
 import org.eclipse.xpanse.modules.deployment.deployers.terraform.utils.TfResourceTransUtils;
 import org.eclipse.xpanse.modules.deployment.utils.DeployEnvironments;
@@ -58,14 +57,14 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 /**
- * Test for TerraformDeploy.
+ * Test for TerraformDeployment.
  */
 
 @ExtendWith({SpringExtension.class})
 @ContextConfiguration(classes = {TerraformLocalDeployment.class, DeployEnvironments.class,
         PluginManager.class, TerraformLocalConfig.class, DeployService.class,
-        TaskConfiguration.class,
-        ResourceHandlerManager.class, TerraformProviderHelper.class, ScriptsGitRepoManage.class})
+        TaskConfiguration.class, ResourceHandlerManager.class, TerraformProviderHelper.class,
+        ScriptsGitRepoManage.class})
 class TerraformLocalDeploymentTest {
 
     private final UUID id = UUID.randomUUID();


### PR DESCRIPTION
fixes #1335
Register service template:
![image](https://github.com/eclipse-xpanse/xpanse/assets/121531362/9ab4aba0-67be-42d3-9687-f2a9610b5abc)
Deploy service instance:
![image](https://github.com/eclipse-xpanse/xpanse/assets/121531362/d599e49b-5f7a-49d2-abd5-3863836e04e1)

