### PR TITLE
introduce approval status to service registration

### DIFF
--- a/modules/api/src/main/java/org/eclipse/xpanse/api/exceptions/handler/RegistrationExceptionHandler.java
+++ b/modules/api/src/main/java/org/eclipse/xpanse/api/exceptions/handler/RegistrationExceptionHandler.java
@@ -12,6 +12,7 @@ import org.eclipse.xpanse.modules.models.response.ResultType;
 import org.eclipse.xpanse.modules.models.servicetemplate.exceptions.IconProcessingFailedException;
 import org.eclipse.xpanse.modules.models.servicetemplate.exceptions.InvalidValueSchemaException;
 import org.eclipse.xpanse.modules.models.servicetemplate.exceptions.ServiceTemplateAlreadyRegistered;
+import org.eclipse.xpanse.modules.models.servicetemplate.exceptions.ServiceTemplateNotApproved;
 import org.eclipse.xpanse.modules.models.servicetemplate.exceptions.ServiceTemplateNotRegistered;
 import org.eclipse.xpanse.modules.models.servicetemplate.exceptions.ServiceTemplateUpdateNotAllowed;
 import org.eclipse.xpanse.modules.models.servicetemplate.exceptions.TerraformScriptFormatInvalidException;
@@ -103,5 +104,17 @@ public class RegistrationExceptionHandler {
             InvalidValueSchemaException ex) {
         return Response.errorResponse(ResultType.VARIABLE_SCHEMA_DEFINITION_INVALID,
                 ex.getInvalidValueSchemaKeys());
+    }
+
+    /**
+     * Exception handler for ServiceTemplateNotApproved.
+     */
+    @ExceptionHandler({ServiceTemplateNotApproved.class})
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ResponseBody
+    public Response handleServiceTemplateNotApproved(
+            ServiceTemplateNotApproved ex) {
+        return Response.errorResponse(ResultType.SERVICE_TEMPLATE_NOT_APPROVED,
+                Collections.singletonList(ex.getMessage()));
     }
 }

--- a/modules/api/src/test/java/org/eclipse/xpanse/api/exceptions/handler/RegistrationExceptionHandlerTest.java
+++ b/modules/api/src/test/java/org/eclipse/xpanse/api/exceptions/handler/RegistrationExceptionHandlerTest.java
@@ -16,6 +16,7 @@ import org.eclipse.xpanse.api.controllers.ServiceTemplateApi;
 import org.eclipse.xpanse.modules.models.servicetemplate.exceptions.IconProcessingFailedException;
 import org.eclipse.xpanse.modules.models.servicetemplate.exceptions.InvalidValueSchemaException;
 import org.eclipse.xpanse.modules.models.servicetemplate.exceptions.ServiceTemplateAlreadyRegistered;
+import org.eclipse.xpanse.modules.models.servicetemplate.exceptions.ServiceTemplateNotApproved;
 import org.eclipse.xpanse.modules.models.servicetemplate.exceptions.ServiceTemplateNotRegistered;
 import org.eclipse.xpanse.modules.models.servicetemplate.exceptions.ServiceTemplateUpdateNotAllowed;
 import org.eclipse.xpanse.modules.models.servicetemplate.exceptions.TerraformScriptFormatInvalidException;
@@ -96,6 +97,18 @@ class RegistrationExceptionHandlerTest {
                         post("/xpanse/service_templates/file").param("oclLocation", "file://test"))
                 .andExpect(status().is(400))
                 .andExpect(jsonPath("$.resultType").value("Service Template Not Registered"))
+                .andExpect(jsonPath("$.details[0]").value("test error"));
+    }
+
+    @Test
+    void testServiceTemplateNotApproved() throws Exception {
+        when(serviceTemplateManage.registerServiceTemplateByUrl(anyString()))
+                .thenThrow(new ServiceTemplateNotApproved("test error"));
+
+        this.mockMvc.perform(
+                        post("/xpanse/service_templates/file").param("oclLocation", "file://test"))
+                .andExpect(status().is(400))
+                .andExpect(jsonPath("$.resultType").value("Service Template Not Approved"))
                 .andExpect(jsonPath("$.details[0]").value("test error"));
     }
 

--- a/modules/database/src/test/java/org/eclipse/xpanse/modules/database/servicetemplate/ServiceTemplateEntityTest.java
+++ b/modules/database/src/test/java/org/eclipse/xpanse/modules/database/servicetemplate/ServiceTemplateEntityTest.java
@@ -30,7 +30,7 @@ class ServiceTemplateEntityTest {
     private static final Csp CSP = Csp.HUAWEI;
     private static final Category CATEGORY = Category.MIDDLEWARE;
     private static final ServiceRegistrationState SERVICE_STATE =
-            ServiceRegistrationState.REGISTERED;
+            ServiceRegistrationState.APPROVED;
     private Ocl ocl;
     private JsonObjectSchema jsonObjectSchema;
     private ServiceProviderContactDetails serviceProviderContactDetails;

--- a/modules/models/src/main/java/org/eclipse/xpanse/modules/models/response/ResultType.java
+++ b/modules/models/src/main/java/org/eclipse/xpanse/modules/models/response/ResultType.java
@@ -36,6 +36,7 @@ public enum ResultType {
     SERVICE_TEMPLATE_ALREADY_REGISTERED("Service Template Already Registered"),
     ICON_PROCESSING_FAILED("Icon Processing Failed"),
     SERVICE_TEMPLATE_NOT_REGISTERED("Service Template Not Registered"),
+    SERVICE_TEMPLATE_NOT_APPROVED("Service Template Not Approved"),
     SERVICE_DEPLOYMENT_NOT_FOUND("Service Deployment Not Found"),
     RESOURCE_NOT_FOUND("Resource Not Found"),
     DEPLOYMENT_VARIABLE_INVALID("Deployment Variable Invalid"),

--- a/modules/models/src/main/java/org/eclipse/xpanse/modules/models/servicetemplate/enums/ServiceRegistrationState.java
+++ b/modules/models/src/main/java/org/eclipse/xpanse/modules/models/servicetemplate/enums/ServiceRegistrationState.java
@@ -14,9 +14,9 @@ import org.eclipse.xpanse.modules.models.common.exceptions.UnsupportedEnumValueE
  * Defines possible states of a managed service registration.
  */
 public enum ServiceRegistrationState {
-
-    REGISTERED("registered"),
-    UPDATED("updated");
+    APPROVAL_PENDING("approval pending"),
+    APPROVED("approved"),
+    REJECTED("rejected");
 
     private final String state;
 
@@ -28,9 +28,9 @@ public enum ServiceRegistrationState {
      * For ServiceRegistrationState deserialize.
      */
     @JsonCreator
-    public ServiceRegistrationState getByValue(String state) {
+    public static ServiceRegistrationState getByValue(String state) {
         for (ServiceRegistrationState serviceState : values()) {
-            if (serviceState.state.equals(StringUtils.lowerCase(state))) {
+            if (StringUtils.equalsIgnoreCase(serviceState.state, state)) {
                 return serviceState;
             }
         }

--- a/modules/models/src/main/java/org/eclipse/xpanse/modules/models/servicetemplate/exceptions/ServiceTemplateNotApproved.java
+++ b/modules/models/src/main/java/org/eclipse/xpanse/modules/models/servicetemplate/exceptions/ServiceTemplateNotApproved.java
@@ -1,0 +1,17 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * SPDX-FileCopyrightText: Huawei Inc.
+ */
+
+package org.eclipse.xpanse.modules.models.servicetemplate.exceptions;
+
+/**
+ * Exception thrown when the deployer mentioned in the service is not available.
+ */
+public class ServiceTemplateNotApproved extends RuntimeException {
+    public ServiceTemplateNotApproved(String message) {
+        super(message);
+    }
+
+}
+

--- a/modules/models/src/test/java/org/eclipse/xpanse/modules/models/servicetemplate/enums/ServiceRegistrationStateTest.java
+++ b/modules/models/src/test/java/org/eclipse/xpanse/modules/models/servicetemplate/enums/ServiceRegistrationStateTest.java
@@ -15,17 +15,22 @@ class ServiceRegistrationStateTest {
 
     @Test
     void testGetByValue() {
-        assertEquals(ServiceRegistrationState.REGISTERED,
-                ServiceRegistrationState.REGISTERED.getByValue("registered"));
-        assertEquals(ServiceRegistrationState.UPDATED,
-                ServiceRegistrationState.UPDATED.getByValue("updated"));
+        assertEquals(ServiceRegistrationState.APPROVED,
+                ServiceRegistrationState.getByValue("approved"));
+        assertEquals(ServiceRegistrationState.APPROVAL_PENDING,
+                ServiceRegistrationState.getByValue("approval pending"));
+        assertEquals(ServiceRegistrationState.REJECTED,
+                ServiceRegistrationState.getByValue("rejected"));
         assertThrows(UnsupportedEnumValueException.class,
-                () -> ServiceRegistrationState.UPDATED.getByValue("null"));
+                () -> ServiceRegistrationState.getByValue("error_value"));
+        assertThrows(UnsupportedEnumValueException.class,
+                () -> ServiceRegistrationState.getByValue(null));
     }
 
     @Test
     void testToValue() {
-        assertEquals("registered", ServiceRegistrationState.REGISTERED.toValue());
-        assertEquals("updated", ServiceRegistrationState.UPDATED.toValue());
+        assertEquals("approved", ServiceRegistrationState.APPROVED.toValue());
+        assertEquals("approval pending", ServiceRegistrationState.APPROVAL_PENDING.toValue());
+        assertEquals("rejected", ServiceRegistrationState.REJECTED.toValue());
     }
 }

--- a/modules/models/src/test/java/org/eclipse/xpanse/modules/models/servicetemplate/exceptions/ServiceTemplateNotApprovedTest.java
+++ b/modules/models/src/test/java/org/eclipse/xpanse/modules/models/servicetemplate/exceptions/ServiceTemplateNotApprovedTest.java
@@ -1,0 +1,71 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * SPDX-FileCopyrightText: Huawei Inc.
+ *
+ */
+
+package org.eclipse.xpanse.modules.models.servicetemplate.exceptions;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test of ServiceTemplateNotApproved.
+ */
+class ServiceTemplateNotApprovedTest {
+
+    private static final String message = "service not approved.";
+    private static ServiceTemplateNotApproved exception;
+
+    @BeforeEach
+    void setUp() {
+        exception = new ServiceTemplateNotApproved(message);
+    }
+
+    @Test
+    void testConstructorAndGetMessage() {
+        assertEquals(message, exception.getMessage());
+    }
+
+    @Test
+    void testEqualsAndHashCode() {
+        assertEquals(exception, exception);
+        assertEquals(exception.hashCode(), exception.hashCode());
+
+        Object obj = new Object();
+        assertNotEquals(exception, obj);
+        assertNotEquals(exception, null);
+        assertNotEquals(exception.hashCode(), obj.hashCode());
+
+        ServiceTemplateNotApproved exception1 =
+                new ServiceTemplateNotApproved(message);
+        ServiceTemplateNotApproved exception2 =
+                new ServiceTemplateNotApproved("different message");
+
+        assertNotEquals(exception, exception1);
+        assertNotEquals(exception, exception2);
+        assertNotEquals(exception1, exception2);
+        assertNotEquals(exception.hashCode(), exception1.hashCode());
+        assertNotEquals(exception.hashCode(), exception2.hashCode());
+        assertNotEquals(exception1.hashCode(), exception2.hashCode());
+    }
+
+    @Test
+    void testToString() {
+        String expectedToString = exception.getClass().getCanonicalName() + ": " + message;
+
+        assertEquals(expectedToString, exception.toString());
+    }
+
+    @Test
+    void testSuperClassMethods() {
+        String expectedSuperToString = exception.getClass().getCanonicalName() + ": " + message;
+        assertEquals(expectedSuperToString, exception.toString());
+
+        assertEquals(message, exception.getMessage());
+    }
+
+}

--- a/modules/models/src/test/java/org/eclipse/xpanse/modules/models/servicetemplate/view/ServiceTemplateDetailVoTest.java
+++ b/modules/models/src/test/java/org/eclipse/xpanse/modules/models/servicetemplate/view/ServiceTemplateDetailVoTest.java
@@ -43,7 +43,7 @@ class ServiceTemplateDetailVoTest {
     private static final OffsetDateTime createTime = OffsetDateTime.now();
     private static final OffsetDateTime lastModifiedTime = OffsetDateTime.now();
     private static final ServiceRegistrationState serviceRegistrationState =
-            ServiceRegistrationState.REGISTERED;
+            ServiceRegistrationState.APPROVED;
     private static ServiceProviderContactDetails serviceProviderContactDetails;
     private static List<@Valid Region> regions;
     private static List<@Valid DeployVariable> variables;

--- a/modules/servicetemplate/src/main/java/org/eclipse/xpanse/modules/servicetemplate/ServiceTemplateManage.java
+++ b/modules/servicetemplate/src/main/java/org/eclipse/xpanse/modules/servicetemplate/ServiceTemplateManage.java
@@ -102,7 +102,7 @@ public class ServiceTemplateManage {
         checkParams(existingService, ocl);
         validateTerraformScript(ocl);
         existingService.setOcl(ocl);
-        existingService.setServiceRegistrationState(ServiceRegistrationState.UPDATED);
+        existingService.setServiceRegistrationState(ServiceRegistrationState.APPROVAL_PENDING);
         JsonObjectSchema jsonObjectSchema =
                 serviceVariablesJsonSchemaGenerator.buildJsonObjectSchema(
                         existingService.getOcl().getDeployment().getVariables());
@@ -153,7 +153,7 @@ public class ServiceTemplateManage {
         entity.setCategory(ocl.getCategory());
         entity.setServiceHostingType(ocl.getServiceHostingType());
         entity.setOcl(ocl);
-        entity.setServiceRegistrationState(ServiceRegistrationState.REGISTERED);
+        entity.setServiceRegistrationState(ServiceRegistrationState.APPROVAL_PENDING);
         entity.setServiceProviderContactDetails(ocl.getServiceProviderContactDetails());
         return entity;
     }

--- a/modules/servicetemplate/src/test/java/org/eclipse/xpanse/modules/servicetemplate/ServiceTemplateManageTest.java
+++ b/modules/servicetemplate/src/test/java/org/eclipse/xpanse/modules/servicetemplate/ServiceTemplateManageTest.java
@@ -108,7 +108,7 @@ class ServiceTemplateManageTest {
         serviceTemplateEntity.setName(oclRegister.getName());
         serviceTemplateEntity.setId(UUID.randomUUID());
         serviceTemplateEntity.setCategory(oclRegister.getCategory());
-        serviceTemplateEntity.setServiceRegistrationState(ServiceRegistrationState.REGISTERED);
+        serviceTemplateEntity.setServiceRegistrationState(ServiceRegistrationState.APPROVAL_PENDING);
         serviceTemplateEntity.setVersion(oclRegister.getServiceVersion());
         serviceTemplateEntity.setCsp(oclRegister.getCloudServiceProvider().getName());
         serviceTemplateEntity.setServiceHostingType(oclRegister.getServiceHostingType());
@@ -152,7 +152,7 @@ class ServiceTemplateManageTest {
                 serviceTemplateManageTest.updateServiceTemplateByUrl(uuid.toString(),
                         oclLocation);
         log.error(ServiceTemplateEntityByUrl.toString());
-        Assertions.assertEquals(ServiceRegistrationState.UPDATED,
+        Assertions.assertEquals(ServiceRegistrationState.APPROVAL_PENDING,
                 ServiceTemplateEntityByUrl.getServiceRegistrationState());
         verify(serviceTemplateOpenApiGenerator).updateServiceApi(serviceTemplateEntity);
     }
@@ -196,7 +196,7 @@ class ServiceTemplateManageTest {
         when(identityProviderManager.getUserNamespace()).thenReturn(Optional.of("ISV-A"));
         ServiceTemplateEntity updateServiceTemplateEntity =
                 serviceTemplateManageTest.updateServiceTemplate(uuid.toString(), ocl);
-        Assertions.assertEquals(ServiceRegistrationState.UPDATED,
+        Assertions.assertEquals(ServiceRegistrationState.APPROVAL_PENDING,
                 updateServiceTemplateEntity.getServiceRegistrationState());
         verify(serviceTemplateOpenApiGenerator).updateServiceApi(serviceTemplateEntity);
     }
@@ -262,7 +262,7 @@ class ServiceTemplateManageTest {
 
         ServiceTemplateEntity savedServiceTemplateEntity =
                 serviceTemplateManageTest.registerServiceTemplate(oclRegister);
-        Assertions.assertEquals(ServiceRegistrationState.REGISTERED,
+        Assertions.assertEquals(ServiceRegistrationState.APPROVAL_PENDING,
                 savedServiceTemplateEntity.getServiceRegistrationState());
         verify(serviceTemplateOpenApiGenerator).generateServiceApi(savedServiceTemplateEntity);
     }
@@ -277,7 +277,7 @@ class ServiceTemplateManageTest {
         entity.setCategory(ocl.getCategory());
         entity.setServiceHostingType(ServiceHostingType.SELF);
         entity.setOcl(ocl);
-        entity.setServiceRegistrationState(ServiceRegistrationState.REGISTERED);
+        entity.setServiceRegistrationState(ServiceRegistrationState.APPROVAL_PENDING);
 
         ServiceTemplateEntity existedServiceTemplateEntity = getServiceTemplateEntity();
 
@@ -327,7 +327,7 @@ class ServiceTemplateManageTest {
 
         ServiceTemplateEntity savedServiceTemplateEntity =
                 serviceTemplateManageTest.registerServiceTemplateByUrl(oclLocation);
-        Assertions.assertEquals(ServiceRegistrationState.REGISTERED,
+        Assertions.assertEquals(ServiceRegistrationState.APPROVAL_PENDING,
                 savedServiceTemplateEntity.getServiceRegistrationState());
         verify(serviceTemplateOpenApiGenerator).generateServiceApi(savedServiceTemplateEntity);
     }

--- a/runtime/src/test/java/org/eclipse/xpanse/runtime/CspServiceTemplateApiTest.java
+++ b/runtime/src/test/java/org/eclipse/xpanse/runtime/CspServiceTemplateApiTest.java
@@ -93,7 +93,7 @@ class CspServiceTemplateApiTest {
 
         // Verify the results
         Assertions.assertEquals(HttpStatus.OK.value(), registerResponse.getStatus());
-        Assertions.assertEquals(ServiceRegistrationState.REGISTERED,
+        Assertions.assertEquals(ServiceRegistrationState.APPROVAL_PENDING,
                 serviceTemplateDetailVo.getServiceRegistrationState());
         Assertions.assertEquals(ocl.getCategory(), serviceTemplateDetailVo.getCategory());
         Assertions.assertEquals(ocl.getCloudServiceProvider().getName(),

--- a/runtime/src/test/java/org/eclipse/xpanse/runtime/ServiceTemplateApiTest.java
+++ b/runtime/src/test/java/org/eclipse/xpanse/runtime/ServiceTemplateApiTest.java
@@ -138,7 +138,7 @@ class ServiceTemplateApiTest {
 
         // Verify the results
         Assertions.assertEquals(HttpStatus.OK.value(), registerResponse.getStatus());
-        Assertions.assertEquals(ServiceRegistrationState.REGISTERED,
+        Assertions.assertEquals(ServiceRegistrationState.APPROVAL_PENDING,
                 serviceTemplateDetailVo.getServiceRegistrationState());
         Assertions.assertEquals(ocl.getCategory(), serviceTemplateDetailVo.getCategory());
         Assertions.assertEquals(ocl.getCloudServiceProvider().getName(),
@@ -225,7 +225,7 @@ class ServiceTemplateApiTest {
                         ServiceTemplateDetailVo.class);
         // Verify the results
         Assertions.assertEquals(HttpStatus.OK.value(), response.getStatus());
-        Assertions.assertEquals(ServiceRegistrationState.UPDATED,
+        Assertions.assertEquals(ServiceRegistrationState.APPROVAL_PENDING,
                 updatedServiceTemplateDetailVo.getServiceRegistrationState());
         Assertions.assertEquals(id, updatedServiceTemplateDetailVo.getId().toString());
         Assertions.assertEquals(updatedServiceTemplateDetailVo.getNamespace(),
@@ -457,7 +457,7 @@ class ServiceTemplateApiTest {
 
         // Verify the results
         Assertions.assertEquals(HttpStatus.OK.value(), fetchResponse.getStatus());
-        Assertions.assertEquals(ServiceRegistrationState.REGISTERED,
+        Assertions.assertEquals(ServiceRegistrationState.APPROVAL_PENDING,
                 serviceTemplateDetailVo.getServiceRegistrationState());
         Assertions.assertEquals(ocl.getCategory(), serviceTemplateDetailVo.getCategory());
         Assertions.assertEquals(ocl.getCloudServiceProvider().getName(),
@@ -482,7 +482,7 @@ class ServiceTemplateApiTest {
                         ServiceTemplateDetailVo.class);
         // Verify the results
         Assertions.assertEquals(HttpStatus.OK.value(), fetchUpdateResponse.getStatus());
-        Assertions.assertEquals(ServiceRegistrationState.UPDATED,
+        Assertions.assertEquals(ServiceRegistrationState.APPROVAL_PENDING,
                 updatedServiceTemplateDetailVo.getServiceRegistrationState());
         Assertions.assertEquals(id, updatedServiceTemplateDetailVo.getId().toString());
         Assertions.assertEquals(updatedServiceTemplateDetailVo.getNamespace(),

--- a/runtime/src/test/java/org/eclipse/xpanse/runtime/modules/servicetemplate/utils/ServiceTemplateOpenApiGeneratorTest.java
+++ b/runtime/src/test/java/org/eclipse/xpanse/runtime/modules/servicetemplate/utils/ServiceTemplateOpenApiGeneratorTest.java
@@ -59,7 +59,7 @@ class ServiceTemplateOpenApiGeneratorTest {
         serviceTemplateEntity.setCsp(Csp.HUAWEI);
         serviceTemplateEntity.setCategory(Category.MIDDLEWARE);
         serviceTemplateEntity.setOcl(ocl);
-        serviceTemplateEntity.setServiceRegistrationState(ServiceRegistrationState.REGISTERED);
+        serviceTemplateEntity.setServiceRegistrationState(ServiceRegistrationState.APPROVAL_PENDING);
         serviceTemplateEntity.setJsonObjectSchema(jsonObjectSchema);
         OpenApiUrlManage openApiUrlManage = new OpenApiUrlManage(OPENAPI_PATH, SERVICER_PORT);
         OpenApiGeneratorJarManage openApiGeneratorJarManage =
@@ -90,7 +90,7 @@ class ServiceTemplateOpenApiGeneratorTest {
         serviceTemplateEntity.setCsp(Csp.HUAWEI);
         serviceTemplateEntity.setCategory(Category.AI);
         serviceTemplateEntity.setOcl(ocl);
-        serviceTemplateEntity.setServiceRegistrationState(ServiceRegistrationState.UPDATED);
+        serviceTemplateEntity.setServiceRegistrationState(ServiceRegistrationState.APPROVAL_PENDING);
         serviceTemplateEntity.setJsonObjectSchema(jsonObjectSchema);
         OpenApiUrlManage openApiUrlManage = new OpenApiUrlManage(OPENAPI_PATH, SERVICER_PORT);
         OpenApiGeneratorJarManage openApiGeneratorJarManage =

--- a/samples/develop/huawei-compute-opentofu-dev.json
+++ b/samples/develop/huawei-compute-opentofu-dev.json
@@ -2,7 +2,7 @@
   "serviceName": "opentofu-ecs",
   "version": "v1.0.0",
   "csp": "huawei",
-  "category": "container",
+  "category": "compute",
   "flavor": "2vCPUs-4GB-normal",
   "region": "cn-southwest-2",
   "customerServiceName": "default-opentofu-ecs",

--- a/samples/develop/huawei-compute-terraform-dev.json
+++ b/samples/develop/huawei-compute-terraform-dev.json
@@ -2,7 +2,7 @@
   "serviceName": "terraform-ecs",
   "version": "v1.0.0",
   "csp": "huawei",
-  "category": "container",
+  "category": "compute",
   "flavor": "2vCPUs-4GB-normal",
   "region": "cn-southwest-2",
   "customerServiceName": "default-terraform-ecs",


### PR DESCRIPTION
fixes #1382 
ISV user view details of registered service template:
![image](https://github.com/eclipse-xpanse/xpanse/assets/121531362/da8bbf48-cdf3-4a82-81a6-3775f1ec0827)
End user view details of registered service template:
![image](https://github.com/eclipse-xpanse/xpanse/assets/121531362/6669b2ad-cc82-4402-be99-69f9944c8c04)
End user deploy service when found service template not approved:
![image](https://github.com/eclipse-xpanse/xpanse/assets/121531362/ff98ef06-0fa8-4565-b5b1-f9cadcbdb433)



