### PR TITLE
Filter Csp user managed service templates with csp value in metadata

### DIFF
--- a/modules/api/src/main/java/org/eclipse/xpanse/api/controllers/CspServiceTemplateApi.java
+++ b/modules/api/src/main/java/org/eclipse/xpanse/api/controllers/CspServiceTemplateApi.java
@@ -7,6 +7,7 @@
 package org.eclipse.xpanse.api.controllers;
 
 
+import static org.eclipse.xpanse.api.config.ServiceTemplateEntityConverter.convertToServiceTemplateDetailVo;
 import static org.eclipse.xpanse.modules.security.common.RoleConstants.ROLE_ADMIN;
 import static org.eclipse.xpanse.modules.security.common.RoleConstants.ROLE_CSP;
 
@@ -15,8 +16,9 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.annotation.Resource;
 import jakarta.validation.Valid;
-import java.util.Comparator;
 import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
 import org.eclipse.xpanse.api.config.ServiceTemplateEntityConverter;
 import org.eclipse.xpanse.modules.database.servicetemplate.ServiceTemplateEntity;
@@ -27,6 +29,7 @@ import org.eclipse.xpanse.modules.models.servicetemplate.ReviewRegistrationReque
 import org.eclipse.xpanse.modules.models.servicetemplate.enums.ServiceHostingType;
 import org.eclipse.xpanse.modules.models.servicetemplate.enums.ServiceRegistrationState;
 import org.eclipse.xpanse.modules.models.servicetemplate.view.ServiceTemplateDetailVo;
+import org.eclipse.xpanse.modules.security.IdentityProviderManager;
 import org.eclipse.xpanse.modules.servicetemplate.ServiceTemplateManage;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -54,12 +57,13 @@ public class CspServiceTemplateApi {
 
     @Resource
     private ServiceTemplateManage serviceTemplateManage;
+    @Resource
+    private IdentityProviderManager identityProviderManager;
 
     /**
      * List service templates with query params.
      *
      * @param categoryName             category of the service.
-     * @param cspName                  name of the cloud service provider.
      * @param serviceName              name of the service.
      * @param serviceVersion           version of the service.
      * @param serviceHostingType       type of the service hosting.
@@ -68,14 +72,12 @@ public class CspServiceTemplateApi {
      */
     @Tag(name = "Cloud Service Provider",
             description = "APIs for cloud service provider to manage service templates.")
-    @Operation(description = "List all service templates with query params.")
-    @GetMapping(value = "/service_templates/all", produces = MediaType.APPLICATION_JSON_VALUE)
+    @Operation(description = "List managed service templates with query params.")
+    @GetMapping(value = "/csp/service_templates", produces = MediaType.APPLICATION_JSON_VALUE)
     @ResponseStatus(HttpStatus.OK)
-    public List<ServiceTemplateDetailVo> listAllServiceTemplates(
+    public List<ServiceTemplateDetailVo> listManagedServiceTemplates(
             @Parameter(name = "categoryName", description = "category of the service")
             @RequestParam(name = "categoryName", required = false) Category categoryName,
-            @Parameter(name = "cspName", description = "name of the cloud service provider")
-            @RequestParam(name = "cspName", required = false) Csp cspName,
             @Parameter(name = "serviceName", description = "name of the service")
             @RequestParam(name = "serviceName", required = false) String serviceName,
             @Parameter(name = "serviceVersion", description = "version of the service")
@@ -86,17 +88,38 @@ public class CspServiceTemplateApi {
             @Parameter(name = "serviceRegistrationState", description = "state of registration")
             @RequestParam(name = "serviceRegistrationState", required = false)
             ServiceRegistrationState serviceRegistrationState) {
+        Optional<Csp> cspOptional = identityProviderManager.getCspFromMetadata();
+        Csp cspName = cspOptional.orElse(null);
         ServiceTemplateQueryModel queryRequest =
                 new ServiceTemplateQueryModel(categoryName, cspName, serviceName, serviceVersion,
                         serviceHostingType, serviceRegistrationState, false);
         List<ServiceTemplateEntity> serviceTemplateEntities =
                 serviceTemplateManage.listServiceTemplates(queryRequest);
         log.info(serviceTemplateEntities.size() + " service templates found.");
-        return serviceTemplateEntities.stream().sorted(Comparator.comparingInt(
-                        serviceTemplateDetailVo -> serviceTemplateDetailVo != null
-                                ? serviceTemplateDetailVo.getCsp().ordinal() : -1))
+        return serviceTemplateEntities.stream()
                 .map(ServiceTemplateEntityConverter::convertToServiceTemplateDetailVo)
                 .toList();
+    }
+
+
+    /**
+     * View details of service template registration.
+     *
+     * @param id id of service template.
+     * @return service template details.
+     */
+    @Tag(name = "Cloud Service Provider",
+            description = "APIs for cloud service provider to manage service templates.")
+    @Operation(description = "view service template by id.")
+    @GetMapping(value = "/csp/service_templates/{id}", produces =
+            MediaType.APPLICATION_JSON_VALUE)
+    @ResponseStatus(HttpStatus.OK)
+    public ServiceTemplateDetailVo getRegistrationDetails(
+            @Parameter(name = "id", description = "id of service template")
+            @PathVariable("id") String id) {
+        ServiceTemplateEntity templateEntity =
+                serviceTemplateManage.getServiceTemplateDetails(UUID.fromString(id), false, true);
+        return convertToServiceTemplateDetailVo(templateEntity);
     }
 
     /**
@@ -111,10 +134,11 @@ public class CspServiceTemplateApi {
     @PutMapping(value = "/service_templates/review/{id}", produces =
             MediaType.APPLICATION_JSON_VALUE)
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void reviewServiceRegistrationRequest(
+    public void reviewRegistration(
             @Parameter(name = "id", description = "id of service template")
             @PathVariable("id") String id,
             @Valid @RequestBody ReviewRegistrationRequest reviewRegistrationRequest) {
-        serviceTemplateManage.reviewServiceTemplateRegistration(id, reviewRegistrationRequest);
+        serviceTemplateManage.reviewServiceTemplateRegistration(UUID.fromString(id),
+                reviewRegistrationRequest);
     }
 }

--- a/modules/api/src/main/java/org/eclipse/xpanse/api/controllers/ServiceCatalogApi.java
+++ b/modules/api/src/main/java/org/eclipse/xpanse/api/controllers/ServiceCatalogApi.java
@@ -17,6 +17,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.annotation.Resource;
 import java.util.Comparator;
 import java.util.List;
+import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
 import org.eclipse.xpanse.api.config.ServiceTemplateEntityConverter;
 import org.eclipse.xpanse.modules.database.servicetemplate.ServiceTemplateEntity;
@@ -112,7 +113,7 @@ public class ServiceCatalogApi {
             @Parameter(name = "id", description = "The id of orderable service.")
             @PathVariable("id") String id) {
         ServiceTemplateEntity serviceTemplateEntity =
-                serviceTemplateManage.getServiceTemplateDetails(id, false);
+                serviceTemplateManage.getServiceTemplateDetails(UUID.fromString(id), false, false);
         if (ServiceRegistrationState.APPROVED
                 != serviceTemplateEntity.getServiceRegistrationState()) {
             String errMsg = String.format("Service template with id %s not approved.", id);
@@ -137,7 +138,7 @@ public class ServiceCatalogApi {
     @Operation(description = "Get the API document of the orderable service.")
     @Secured({ROLE_ADMIN, ROLE_ISV, ROLE_USER})
     public Link openApi(@PathVariable("id") String id) {
-        String apiUrl = this.serviceTemplateManage.getOpenApiUrl(id);
+        String apiUrl = this.serviceTemplateManage.getOpenApiUrl(UUID.fromString(id));
         String successMsg = String.format(
                 "Get API document of the orderable service successful with Url %s.", apiUrl);
         log.info(successMsg);

--- a/modules/api/src/main/java/org/eclipse/xpanse/api/controllers/ServiceTemplateApi.java
+++ b/modules/api/src/main/java/org/eclipse/xpanse/api/controllers/ServiceTemplateApi.java
@@ -19,6 +19,7 @@ import jakarta.validation.Valid;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
 import org.eclipse.xpanse.api.config.ServiceTemplateEntityConverter;
 import org.eclipse.xpanse.modules.database.servicetemplate.ServiceTemplateEntity;
@@ -96,7 +97,8 @@ public class ServiceTemplateApi {
     public ServiceTemplateDetailVo update(
             @Parameter(name = "id", description = "id of service template") @PathVariable("id")
             String id, @Valid @RequestBody Ocl ocl) {
-        ServiceTemplateEntity templateEntity = serviceTemplateManage.updateServiceTemplate(id, ocl);
+        ServiceTemplateEntity templateEntity =
+                serviceTemplateManage.updateServiceTemplate(UUID.fromString(id), ocl);
         String successMsg = String.format("Update service template with id %s successful.", id);
         log.info(successMsg);
         return convertToServiceTemplateDetailVo(templateEntity);
@@ -144,7 +146,7 @@ public class ServiceTemplateApi {
             @RequestParam(name = "oclLocation") String oclLocation) throws Exception {
         log.info("Update service template {} with Url {}", id, oclLocation);
         ServiceTemplateEntity templateEntity =
-                serviceTemplateManage.updateServiceTemplateByUrl(id, oclLocation);
+                serviceTemplateManage.updateServiceTemplateByUrl(UUID.fromString(id), oclLocation);
         String successMsg = String.format("Update service template with id %s by Url %s", id,
                 oclLocation);
         log.info(successMsg);
@@ -165,7 +167,7 @@ public class ServiceTemplateApi {
     public Response unregister(
             @Parameter(name = "id", description = "id of service template") @PathVariable("id")
             String id) {
-        serviceTemplateManage.unregisterServiceTemplate(id);
+        serviceTemplateManage.unregisterServiceTemplate(UUID.fromString(id));
         String successMsg =
                 String.format("Unregister service template using id %s successful.", id);
         log.info(successMsg);
@@ -216,7 +218,7 @@ public class ServiceTemplateApi {
     }
 
     /**
-     * Get service template using id.
+     * Get details of service template using id.
      *
      * @param id id of service template.
      * @return response
@@ -226,12 +228,10 @@ public class ServiceTemplateApi {
     @GetMapping(value = "/service_templates/{id}", produces = MediaType.APPLICATION_JSON_VALUE)
     @ResponseStatus(HttpStatus.OK)
     public ServiceTemplateDetailVo details(
-            @Parameter(name = "id", description = "id of service template") @PathVariable("id")
-            String id) {
+            @Parameter(name = "id", description = "id of service template")
+            @PathVariable("id") String id) {
         ServiceTemplateEntity templateEntity =
-                serviceTemplateManage.getServiceTemplateDetails(id, true);
-        String successMsg = String.format("Get detail of service template with id %s success.", id);
-        log.info(successMsg);
+                serviceTemplateManage.getServiceTemplateDetails(UUID.fromString(id), true, false);
         return convertToServiceTemplateDetailVo(templateEntity);
     }
 }

--- a/modules/security/src/main/java/org/eclipse/xpanse/modules/security/IdentityProviderManager.java
+++ b/modules/security/src/main/java/org/eclipse/xpanse/modules/security/IdentityProviderManager.java
@@ -13,6 +13,8 @@ import java.util.Optional;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
+import org.eclipse.xpanse.modules.models.common.enums.Csp;
+import org.eclipse.xpanse.modules.models.common.exceptions.UnsupportedEnumValueException;
 import org.eclipse.xpanse.modules.security.common.CurrentUserInfo;
 import org.eclipse.xpanse.modules.security.common.CurrentUserInfoHolder;
 import org.springframework.context.ApplicationContext;
@@ -49,7 +51,7 @@ public class IdentityProviderManager {
                 throw new IllegalStateException(
                         "More than one identity provider service is active.");
             }
-            activeIdentityProviderService = identityProviderServices.get(0);
+            activeIdentityProviderService = identityProviderServices.getFirst();
             log.info("Identity provider service with type:{} is active.",
                     activeIdentityProviderService.getIdentityProviderType());
         }
@@ -97,5 +99,23 @@ public class IdentityProviderManager {
         return StringUtils.isBlank(currentUserInfo.getNamespace())
                 ? Optional.ofNullable(currentUserInfo.getUserId())
                 : Optional.ofNullable(currentUserInfo.getNamespace());
+    }
+
+    /**
+     * Get csp from metadata fo current login user.
+     *
+     * @return csp of current login user.
+     */
+    public Optional<Csp> getCspFromMetadata() {
+        CurrentUserInfo currentUserInfo = getCurrentUserInfo();
+        if (Objects.nonNull(currentUserInfo) && StringUtils.isNotBlank(currentUserInfo.getCsp())) {
+            try {
+                Csp csp = Csp.getByValue(currentUserInfo.getCsp());
+                return Optional.of(csp);
+            } catch (UnsupportedEnumValueException e) {
+                log.error("Unsupported csp value:{}", currentUserInfo.getCsp());
+            }
+        }
+        return Optional.empty();
     }
 }

--- a/modules/security/src/main/java/org/eclipse/xpanse/modules/security/common/CurrentUserInfo.java
+++ b/modules/security/src/main/java/org/eclipse/xpanse/modules/security/common/CurrentUserInfo.java
@@ -26,5 +26,7 @@ public class CurrentUserInfo {
 
     private String namespace;
 
+    private String csp;
+
     private String token;
 }

--- a/modules/security/src/main/java/org/eclipse/xpanse/modules/security/zitadel/ZitadelIdentityProviderService.java
+++ b/modules/security/src/main/java/org/eclipse/xpanse/modules/security/zitadel/ZitadelIdentityProviderService.java
@@ -6,6 +6,7 @@
 
 package org.eclipse.xpanse.modules.security.zitadel;
 
+import static org.eclipse.xpanse.modules.security.zitadel.config.ZitadelOauth2Constant.CSP_KEY;
 import static org.eclipse.xpanse.modules.security.zitadel.config.ZitadelOauth2Constant.METADATA_KEY;
 import static org.eclipse.xpanse.modules.security.zitadel.config.ZitadelOauth2Constant.NAMESPACE_KEY;
 import static org.eclipse.xpanse.modules.security.zitadel.config.ZitadelOauth2Constant.REQUIRED_SCOPES;
@@ -157,6 +158,9 @@ public class ZitadelIdentityProviderService implements IdentityProviderService {
                             userMetadata.put(key, value);
                             if (StringUtils.equals(NAMESPACE_KEY, key)) {
                                 currentUserInfo.setNamespace(value);
+                            }
+                            if (StringUtils.equals(CSP_KEY, key)) {
+                                currentUserInfo.setCsp(value);
                             }
                         }
                         currentUserInfo.setMetadata(userMetadata);

--- a/modules/security/src/main/java/org/eclipse/xpanse/modules/security/zitadel/config/ZitadelOauth2Constant.java
+++ b/modules/security/src/main/java/org/eclipse/xpanse/modules/security/zitadel/config/ZitadelOauth2Constant.java
@@ -93,8 +93,13 @@ public class ZitadelOauth2Constant {
     public static final String ADDRESS_KEY = "address";
 
     /**
-     * Key in metadata for getting the specified value from the metadata of the user.
+     * Key in metadata for getting the namespace value from the metadata of the user.
      */
     public static final String NAMESPACE_KEY = "namespace";
+
+    /**
+     * Key in metadata for getting the csp value from the metadata of the user.
+     */
+    public static final String CSP_KEY = "csp";
 
 }

--- a/modules/security/src/test/java/org/eclipse/xpanse/modules/security/IdentityProviderManagerTest.java
+++ b/modules/security/src/test/java/org/eclipse/xpanse/modules/security/IdentityProviderManagerTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.when;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import org.eclipse.xpanse.modules.models.common.enums.Csp;
 import org.eclipse.xpanse.modules.security.common.CurrentUserInfo;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -25,49 +26,82 @@ class IdentityProviderManagerTest {
     @InjectMocks
     private IdentityProviderManager identityProviderManagerUnderTest;
 
+    void mockCurrentUserInfoWithCspAndNamespace(String csp, String namespace) {
+        when(mockActiveIdentityProviderService.getCurrentUserInfo()).thenReturn(
+                getCurrentUserInfo(csp, namespace));
+    }
+
+    CurrentUserInfo getCurrentUserInfo(String csp, String namespace) {
+        final CurrentUserInfo currentUserInfo = new CurrentUserInfo();
+        currentUserInfo.setUserId("userId");
+        currentUserInfo.setUserName("userName");
+        currentUserInfo.setRoles(List.of("admin", "csp", "isv"));
+        currentUserInfo.setMetadata(Map.of("namespace", namespace, "csp", csp));
+        currentUserInfo.setNamespace(namespace);
+        currentUserInfo.setCsp(csp);
+        return currentUserInfo;
+    }
+
+
     @Test
     void testGetCurrentUserInfo() {
         // Setup
-        final CurrentUserInfo expectedResult = new CurrentUserInfo();
-        expectedResult.setUserId("userId");
-        expectedResult.setUserName("userName");
-        expectedResult.setRoles(List.of("value"));
-        expectedResult.setMetadata(Map.ofEntries(Map.entry("value", "value")));
-        expectedResult.setNamespace("namespace");
-
+        final CurrentUserInfo expectedResult = getCurrentUserInfo("huawei", "ISV-A");
         // Configure IdentityProviderService.getCurrentUserInfo(...).
-        final CurrentUserInfo currentUserInfo = new CurrentUserInfo();
-        currentUserInfo.setUserId("userId");
-        currentUserInfo.setUserName("userName");
-        currentUserInfo.setRoles(List.of("value"));
-        currentUserInfo.setMetadata(Map.ofEntries(Map.entry("value", "value")));
-        currentUserInfo.setNamespace("namespace");
-        when(mockActiveIdentityProviderService.getCurrentUserInfo()).thenReturn(currentUserInfo);
-
+        mockCurrentUserInfoWithCspAndNamespace("huawei", "ISV-A");
         // Run the test
         final CurrentUserInfo result = identityProviderManagerUnderTest.getCurrentUserInfo();
-
         // Verify the results
         assertThat(result).isEqualTo(expectedResult);
+
+        // Run the test
+        final Optional<String> idResult = identityProviderManagerUnderTest.getCurrentLoginUserId();
+        // Verify the results
+        assertThat(idResult).isEqualTo(Optional.of("userId"));
     }
 
     @Test
-    void testGetCurrentLoginUserId() {
+    void testGetUserNamespace() {
         // Setup
+        final String expectedResult = "ISV-A";
         // Configure IdentityProviderService.getCurrentUserInfo(...).
-        final CurrentUserInfo currentUserInfo = new CurrentUserInfo();
-        currentUserInfo.setUserId("userId");
-        currentUserInfo.setUserName("userName");
-        currentUserInfo.setRoles(List.of("value"));
-        currentUserInfo.setMetadata(Map.ofEntries(Map.entry("value", "value")));
-        currentUserInfo.setNamespace("namespace");
-        when(mockActiveIdentityProviderService.getCurrentUserInfo()).thenReturn(currentUserInfo);
+        mockCurrentUserInfoWithCspAndNamespace("huawei", "ISV-A");
+        // Run the test
+        final Optional<String> result = identityProviderManagerUnderTest.getUserNamespace();
+        // Verify the results
+        assertThat(result).isEqualTo(Optional.of(expectedResult));
+
+        // Setup
+        final String expectedResult2 = "userId";
+        // Configure IdentityProviderService.getCurrentUserInfo(...).
+        mockCurrentUserInfoWithCspAndNamespace("huawei", "");
+        // Run the test
+        final Optional<String> result2 = identityProviderManagerUnderTest.getUserNamespace();
+        // Verify the results
+        assertThat(result2).isEqualTo(Optional.of(expectedResult2));
+    }
+
+    @Test
+    void testGetCspFromMetadata() {
+        // Setup
+        final Optional<Csp> expectedResult = Optional.of(Csp.HUAWEI);
+        // Configure IdentityProviderService.getCurrentUserInfo(...).
+        mockCurrentUserInfoWithCspAndNamespace("huawei", "ISV-A");
+        // Run the test
+        final Optional<Csp> result = identityProviderManagerUnderTest.getCspFromMetadata();
+        // Verify the results
+        assertThat(result).isEqualTo((expectedResult));
+
+
+        // Setup
+        final Optional<Csp> expectedResult2 = Optional.empty();
+        // Configure IdentityProviderService.getCurrentUserInfo(...).
+        mockCurrentUserInfoWithCspAndNamespace("errorValue", "ISV-A");
 
         // Run the test
-        final Optional<String> result = identityProviderManagerUnderTest.getCurrentLoginUserId();
-
+        final Optional<Csp> result2 = identityProviderManagerUnderTest.getCspFromMetadata();
         // Verify the results
-        assertThat(result).isEqualTo(Optional.of("userId"));
+        assertThat(result2).isEqualTo(expectedResult2);
     }
 
     @Test

--- a/modules/security/src/test/java/org/eclipse/xpanse/modules/security/common/CurrentUserInfoHolderTest.java
+++ b/modules/security/src/test/java/org/eclipse/xpanse/modules/security/common/CurrentUserInfoHolderTest.java
@@ -1,0 +1,69 @@
+package org.eclipse.xpanse.modules.security.common;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class CurrentUserInfoHolderTest {
+
+    @Test
+    @Order(1)
+    void testSetCurrentUserInfo() {
+        // Setup
+        final CurrentUserInfo currentUserInfo = new CurrentUserInfo();
+        currentUserInfo.setUserId("userId");
+        currentUserInfo.setUserName("userName");
+        currentUserInfo.setRoles(List.of("value"));
+        currentUserInfo.setMetadata(Map.ofEntries(Map.entry("csp", "huawei")));
+        currentUserInfo.setToken("token");
+
+        // Run the test
+        CurrentUserInfoHolder.setCurrentUserInfo(currentUserInfo);
+
+        // Verify the results
+    }
+
+    @Test
+    @Order(2)
+    void testGetCurrentUserInfo() {
+        // Setup
+        final CurrentUserInfo expectedResult = new CurrentUserInfo();
+        expectedResult.setUserId("userId");
+        expectedResult.setUserName("userName");
+        expectedResult.setRoles(List.of("value"));
+        expectedResult.setMetadata(Map.ofEntries(Map.entry("csp", "huawei")));
+        expectedResult.setToken("token");
+
+        // Run the test
+        final CurrentUserInfo result = CurrentUserInfoHolder.getCurrentUserInfo();
+
+        // Verify the results
+        assertThat(result).isEqualTo(expectedResult);
+    }
+
+    @Test
+    @Order(3)
+    void testGetToken() {
+        assertThat(CurrentUserInfoHolder.getToken()).isEqualTo("token");
+    }
+
+    @Test
+    @Order(4)
+    void testClear() {
+        // Setup
+        // Run the test
+        CurrentUserInfoHolder.clear();
+        // Verify the results
+        assertThat(CurrentUserInfoHolder.getCurrentUserInfo()).isNull();
+        assertThat(CurrentUserInfoHolder.getToken()).isNull();
+    }
+
+
+}

--- a/modules/security/src/test/java/org/eclipse/xpanse/modules/security/common/CurrentUserInfoTest.java
+++ b/modules/security/src/test/java/org/eclipse/xpanse/modules/security/common/CurrentUserInfoTest.java
@@ -1,12 +1,24 @@
 package org.eclipse.xpanse.modules.security.common;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.List;
 import java.util.Map;
-import org.junit.jupiter.api.Assertions;
+import org.eclipse.xpanse.modules.models.common.enums.Csp;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.BeanUtils;
 
+@ExtendWith(MockitoExtension.class)
 class CurrentUserInfoTest {
+
+    @Mock
+    private List<String> mockRoles;
+    @Mock
+    private Map<String, String> mockMetadata;
 
     private CurrentUserInfo test;
 
@@ -15,96 +27,51 @@ class CurrentUserInfoTest {
         test = new CurrentUserInfo();
         test.setUserId("userId");
         test.setUserName("userName");
-        test.setRoles(List.of("admin"));
-        test.setMetadata(Map.of("namespace", "test"));
-        test.setNamespace("test");
+        test.setRoles(mockRoles);
+        test.setMetadata(mockMetadata);
+        test.setNamespace("namespace");
+        test.setCsp(Csp.HUAWEI.toValue());
         test.setToken("token");
     }
 
     @Test
     void testGetters() {
-        Assertions.assertEquals("userId", test.getUserId());
-        Assertions.assertEquals("userName", test.getUserName());
-        Assertions.assertEquals("admin", test.getRoles().get(0));
-        Assertions.assertTrue(test.getMetadata().containsKey("namespace"));
-        Assertions.assertEquals("test", test.getMetadata().get("namespace"));
-        Assertions.assertEquals("test", test.getNamespace());
+        assertThat(test.getUserId()).isEqualTo("userId");
+        assertThat(test.getUserName()).isEqualTo("userName");
+        assertThat(test.getRoles()).isEqualTo(mockRoles);
+        assertThat(test.getMetadata()).isEqualTo(mockMetadata);
+        assertThat(test.getNamespace()).isEqualTo("namespace");
+        assertThat(test.getCsp()).isEqualTo(Csp.HUAWEI.toValue());
+        assertThat(test.getToken()).isEqualTo("token");
     }
-
 
     @Test
-    void testEqualsAndHashCode() {
-
-        Assertions.assertEquals(test, test);
-        Assertions.assertNotEquals(test.hashCode(), 0);
-
-        Object object = new Object();
-        Assertions.assertNotEquals(test, object);
-        Assertions.assertNotEquals(test.hashCode(), object.hashCode());
-
+    void testEquals() {
         CurrentUserInfo test1 = new CurrentUserInfo();
-        Assertions.assertNotEquals(test, test1);
-        Assertions.assertNotEquals(test.hashCode(), test1.hashCode());
-
+        assertThat(test).isNotEqualTo(test1);
         CurrentUserInfo test2 = new CurrentUserInfo();
-        CurrentUserInfo test3 = new CurrentUserInfo();
-        test2.setUserId("userId2");
-        test3.setUserId("userId3");
-        Assertions.assertNotEquals(test, test1);
-        Assertions.assertNotEquals(test, test2);
-        Assertions.assertNotEquals(test, test3);
-        Assertions.assertNotEquals(test1, test2);
-        Assertions.assertNotEquals(test2, test3);
-        Assertions.assertNotEquals(test.hashCode(), test1.hashCode());
-        Assertions.assertNotEquals(test2.hashCode(), test3.hashCode());
-
-        test2.setUserName("userName2");
-        test3.setUserName("userName3");
-        Assertions.assertNotEquals(test, test1);
-        Assertions.assertNotEquals(test, test2);
-        Assertions.assertNotEquals(test, test3);
-        Assertions.assertNotEquals(test1, test2);
-        Assertions.assertNotEquals(test2, test3);
-        Assertions.assertNotEquals(test.hashCode(), test1.hashCode());
-        Assertions.assertNotEquals(test2.hashCode(), test3.hashCode());
-
-        test2.setRoles(List.of("user"));
-        test3.setRoles(List.of("csp"));
-        Assertions.assertNotEquals(test, test1);
-        Assertions.assertNotEquals(test, test2);
-        Assertions.assertNotEquals(test, test3);
-        Assertions.assertNotEquals(test1, test2);
-        Assertions.assertNotEquals(test2, test3);
-        Assertions.assertNotEquals(test.hashCode(), test1.hashCode());
-        Assertions.assertNotEquals(test2.hashCode(), test3.hashCode());
-
-        test2.setMetadata(Map.of("namespace", "test"));
-        test3.setMetadata(Map.of("namespace", "test1"));
-        Assertions.assertNotEquals(test, test1);
-        Assertions.assertNotEquals(test, test2);
-        Assertions.assertNotEquals(test, test3);
-        Assertions.assertNotEquals(test1, test2);
-        Assertions.assertNotEquals(test2, test3);
-        Assertions.assertNotEquals(test.hashCode(), test1.hashCode());
-        Assertions.assertNotEquals(test2.hashCode(), test3.hashCode());
-
-        test2.setNamespace("test");
-        test3.setNamespace("test1");
-        Assertions.assertNotEquals(test, test1);
-        Assertions.assertNotEquals(test, test2);
-        Assertions.assertNotEquals(test, test3);
-        Assertions.assertNotEquals(test1, test2);
-        Assertions.assertNotEquals(test2, test3);
-        Assertions.assertNotEquals(test.hashCode(), test1.hashCode());
-        Assertions.assertNotEquals(test2.hashCode(), test3.hashCode());
+        BeanUtils.copyProperties(test, test2);
+        assertThat(test).isEqualTo(test2);
     }
 
+    @Test
+    void testCanEqual() {
+        assertThat(test.canEqual("other")).isFalse();
+    }
+
+    @Test
+    void testHashCode() {
+        CurrentUserInfo test1 = new CurrentUserInfo();
+        assertThat(test.hashCode()).isNotEqualTo(test1.hashCode());
+        CurrentUserInfo test2 = new CurrentUserInfo();
+        BeanUtils.copyProperties(test, test2);
+        assertThat(test.hashCode()).isEqualTo(test2.hashCode());
+    }
 
     @Test
     void testToString() {
-        String exceptedString = "CurrentUserInfo(userId=userId, userName=userName, roles=[admin],"
-                + " metadata={namespace=test}, namespace=test, token=token)";
-        Assertions.assertEquals(test.toString(), exceptedString);
-        Assertions.assertNotEquals(test.toString(), null);
+        String result = "CurrentUserInfo(userId=userId, userName=userName, roles=mockRoles, "
+                + "metadata=mockMetadata, namespace=namespace, csp=huawei, token=token)";
+        assertThat(test.toString()).isEqualTo(result);
     }
 }

--- a/runtime/src/test/resources/jwt_admin_csp.json
+++ b/runtime/src/test/resources/jwt_admin_csp.json
@@ -3,10 +3,18 @@
   "email": "test@xpanse.de",
   "aud": "https://localhost:7082",
   "scope": "openid user isv admin csp",
-  "roles": ["user", "isv", "admin", "csp"],
+  "roles": [
+    "user",
+    "isv",
+    "admin",
+    "csp"
+  ],
   "urn:zitadel:iam:org:project:roles": {
     "admin": "admin",
     "csp": "csp"
+  },
+  "urn:zitadel:iam:user:metadata": {
+    "csp": "aHVhd2Vp"
   },
   "sub": "1234566"
 }

--- a/runtime/src/test/resources/jwt_all_roles.json
+++ b/runtime/src/test/resources/jwt_all_roles.json
@@ -10,5 +10,8 @@
     "admin": "admin",
     "csp": "csp"
   },
+  "urn:zitadel:iam:user:metadata": {
+    "csp": "aHVhd2Vp"
+  },
   "sub": "1234566"
 }


### PR DESCRIPTION
fixes https://github.com/eclipse-xpanse/xpanse/issues/1405
related to https://github.com/eclipse-xpanse/xpanse-iam/pull/19
Isv user registered service template with with csp `flexibleEngine`:
![image](https://github.com/eclipse-xpanse/xpanse/assets/121531362/17a855b9-855f-42d1-b574-a76a8c825012)
Csp user with the value `huawei` of the key `csp` in metadata list service templates only return service templates with csp `huawei`:
![image](https://github.com/eclipse-xpanse/xpanse/assets/121531362/0ef44e2e-98ba-4de9-9828-c3cf603a36b0)
Csp user with the value `huawei` of the key `csp` in metadata get details of service templates with csp `flexibleEngine`:
![image](https://github.com/eclipse-xpanse/xpanse/assets/121531362/c5448071-66cd-4e85-9cd0-a49b102d5098)
Csp user with the value `huawei` of the key `csp` in metadata review service template with csp `flexibleEngine`:
![image](https://github.com/eclipse-xpanse/xpanse/assets/121531362/0b32934c-d207-4953-939d-96a01f0063c2)

