### PR TITLE
extend OCL with AZ information

### DIFF
--- a/modules/deployment/src/main/java/org/eclipse/xpanse/modules/deployment/AvailabilityZonesRequestValidator.java
+++ b/modules/deployment/src/main/java/org/eclipse/xpanse/modules/deployment/AvailabilityZonesRequestValidator.java
@@ -1,0 +1,73 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * SPDX-FileCopyrightText: Huawei Inc.
+ *
+ */
+
+package org.eclipse.xpanse.modules.deployment;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.eclipse.xpanse.modules.models.service.deploy.exceptions.VariableInvalidException;
+import org.eclipse.xpanse.modules.models.servicetemplate.AvailabilityZoneConfig;
+import org.springframework.util.CollectionUtils;
+
+/**
+ * Check whether the input map of available zones meet the deployment requirements.
+ */
+@Slf4j
+public class AvailabilityZonesRequestValidator {
+
+    /**
+     * Check whether the input map of available zones meet the deployment requirements.
+     *
+     * @param inputMap    The map of input available zones.
+     * @param zoneConfigs The list of availability zone configs.
+     */
+    public static void validateAvailabilityZones(Map<String, String> inputMap,
+                                                 List<AvailabilityZoneConfig> zoneConfigs) {
+        if (CollectionUtils.isEmpty(zoneConfigs)) {
+            return;
+        }
+        Set<String> requiredZoneVarNameSet =
+                zoneConfigs.stream().filter(AvailabilityZoneConfig::getMandatory)
+                        .map(AvailabilityZoneConfig::getVarName).collect(Collectors.toSet());
+        if (CollectionUtils.isEmpty(requiredZoneVarNameSet)) {
+            return;
+        }
+        if (CollectionUtils.isEmpty(inputMap)) {
+            String missingZonesMsg =
+                    String.format("The required availability zones variables %s are missing.",
+                            StringUtils.join(requiredZoneVarNameSet, ", "));
+            throw new VariableInvalidException(List.of(missingZonesMsg));
+        }
+        Set<String> missingZoneVarNames = requiredZoneVarNameSet.stream()
+                .filter(requiredZoneVarName -> !inputMap.containsKey(requiredZoneVarName))
+                .collect(Collectors.toSet());
+        if (!missingZoneVarNames.isEmpty()) {
+            String missingZonesMsg =
+                    String.format("The required availability zones variable names %s are missing.",
+                            StringUtils.join(missingZoneVarNames, ", "));
+            throw new VariableInvalidException(List.of(missingZonesMsg));
+        }
+        Map<String, String> requiredZoneVarValues = new HashMap<>();
+        for (String zoneVarName : inputMap.keySet()) {
+            if (requiredZoneVarNameSet.contains(zoneVarName)) {
+                if (requiredZoneVarValues.containsValue(inputMap.get(zoneVarName))) {
+                    String duplicatedValuesMessage = String.format("The values of required "
+                                    + "availability zones variables %s are duplicated.",
+                            inputMap.get(zoneVarName));
+                    throw new VariableInvalidException(List.of(duplicatedValuesMessage));
+                } else {
+                    requiredZoneVarValues.put(zoneVarName, inputMap.get(zoneVarName));
+                }
+            }
+        }
+
+    }
+}

--- a/modules/deployment/src/main/java/org/eclipse/xpanse/modules/deployment/DeployService.java
+++ b/modules/deployment/src/main/java/org/eclipse/xpanse/modules/deployment/DeployService.java
@@ -105,6 +105,10 @@ public class DeployService {
         sensitiveDataHandler.encodeDeployVariable(existingServiceTemplate,
                 deployRequest.getServiceRequestProperties());
 
+        AvailabilityZonesRequestValidator.validateAvailabilityZones(
+                deployRequest.getAvailabilityZones(),
+                existingServiceTemplate.getOcl().getDeployment().getServiceAvailability());
+
         if (StringUtils.isEmpty(deployRequest.getCustomerServiceName())) {
             deployRequest.setCustomerServiceName(generateCustomerServiceName(deployRequest));
         }

--- a/modules/deployment/src/main/java/org/eclipse/xpanse/modules/deployment/deployers/opentofu/tofumaker/TofuMakerDeployment.java
+++ b/modules/deployment/src/main/java/org/eclipse/xpanse/modules/deployment/deployers/opentofu/tofumaker/TofuMakerDeployment.java
@@ -8,7 +8,7 @@ package org.eclipse.xpanse.modules.deployment.deployers.opentofu.tofumaker;
 import java.util.Objects;
 import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
-import org.eclipse.xpanse.modules.models.servicetemplate.Ocl;
+import org.eclipse.xpanse.modules.models.servicetemplate.Deployment;
 import org.eclipse.xpanse.modules.models.servicetemplate.enums.DeployerKind;
 import org.eclipse.xpanse.modules.orchestrator.deployment.DeployResult;
 import org.eclipse.xpanse.modules.orchestrator.deployment.DeployTask;
@@ -82,13 +82,13 @@ public class TofuMakerDeployment implements Deployer {
      * Validates the OpenTofu script.
      */
     @Override
-    public DeploymentScriptValidationResult validate(Ocl ocl) {
+    public DeploymentScriptValidationResult validate(Deployment deployment) {
         DeploymentScriptValidationResult result = null;
-        if (Objects.nonNull(ocl.getDeployment().getDeployer())) {
-            result = tofuMakerScriptValidator.validateOpenTofuScripts(ocl);
+        if (Objects.nonNull(deployment.getDeployer())) {
+            result = tofuMakerScriptValidator.validateOpenTofuScripts(deployment);
         }
-        if (Objects.nonNull(ocl.getDeployment().getScriptsRepo())) {
-            result = tofuMakerScriptValidator.validateOpenTofuScriptsFromGitRepo(ocl);
+        if (Objects.nonNull(deployment.getScriptsRepo())) {
+            result = tofuMakerScriptValidator.validateOpenTofuScriptsFromGitRepo(deployment);
         }
         return result;
     }

--- a/modules/deployment/src/main/java/org/eclipse/xpanse/modules/deployment/deployers/opentofu/tofumaker/TofuMakerDeploymentPlanManage.java
+++ b/modules/deployment/src/main/java/org/eclipse/xpanse/modules/deployment/deployers/opentofu/tofumaker/TofuMakerDeploymentPlanManage.java
@@ -67,7 +67,6 @@ public class TofuMakerDeploymentPlanManage {
         request.setGitRepoDetails(
                 tofuMakerHelper.convertOpenTofuScriptGitRepoDetailsFromDeployFromGitRepo(
                         task.getOcl().getDeployment().getScriptsRepo()));
-        request.getVariables().put("region", task.getDeployRequest().getRegion().getName());
         return request;
     }
 }

--- a/modules/deployment/src/main/java/org/eclipse/xpanse/modules/deployment/deployers/opentofu/tofumaker/TofuMakerHelper.java
+++ b/modules/deployment/src/main/java/org/eclipse/xpanse/modules/deployment/deployers/opentofu/tofumaker/TofuMakerHelper.java
@@ -77,9 +77,7 @@ public class TofuMakerHelper {
         inputVariables.putAll(this.deployEnvironments.getVariablesFromDeployTask(
                 deployTask, isDeployRequest));
         inputVariables.putAll(this.deployEnvironments.getFlavorVariables(deployTask));
-        // we additionally pass the region as var since the provider information is
-        // also taken from GIT repo.
-        inputVariables.put("region", deployTask.getDeployRequest().getRegion().getName());
+        inputVariables.putAll(this.deployEnvironments.getAvailabilityZoneVariables(deployTask));
         return inputVariables;
     }
 

--- a/modules/deployment/src/main/java/org/eclipse/xpanse/modules/deployment/deployers/opentofu/tofumaker/TofuMakerScriptValidator.java
+++ b/modules/deployment/src/main/java/org/eclipse/xpanse/modules/deployment/deployers/opentofu/tofumaker/TofuMakerScriptValidator.java
@@ -18,7 +18,7 @@ import org.eclipse.xpanse.modules.deployment.deployers.opentofu.tofumaker.genera
 import org.eclipse.xpanse.modules.deployment.deployers.opentofu.tofumaker.generated.model.OpenTofuDeployFromGitRepoRequest;
 import org.eclipse.xpanse.modules.deployment.deployers.opentofu.tofumaker.generated.model.OpenTofuDeployWithScriptsRequest;
 import org.eclipse.xpanse.modules.deployment.deployers.opentofu.tofumaker.generated.model.OpenTofuValidationResult;
-import org.eclipse.xpanse.modules.models.servicetemplate.Ocl;
+import org.eclipse.xpanse.modules.models.servicetemplate.Deployment;
 import org.eclipse.xpanse.modules.orchestrator.deployment.DeploymentScriptValidationResult;
 import org.slf4j.MDC;
 import org.springframework.context.annotation.Profile;
@@ -52,11 +52,12 @@ public class TofuMakerScriptValidator {
     /**
      * Validate scripts provided in the OCL.
      */
-    public DeploymentScriptValidationResult validateOpenTofuScripts(Ocl ocl) {
+    public DeploymentScriptValidationResult validateOpenTofuScripts(Deployment deployment) {
         DeploymentScriptValidationResult deployValidationResult = null;
         try {
             OpenTofuValidationResult validate =
-                    openTofuFromScriptsApi.validateWithScripts(getValidateScriptsInOclRequest(ocl),
+                    openTofuFromScriptsApi.validateWithScripts(
+                            getValidateScriptsInOclRequest(deployment),
                             Objects.nonNull(MDC.get("TASK_ID"))
                                     ? UUID.fromString(MDC.get("TASK_ID")) : null);
             try {
@@ -76,12 +77,13 @@ public class TofuMakerScriptValidator {
     /**
      * Validate scripts in the GIT repo.
      */
-    public DeploymentScriptValidationResult validateOpenTofuScriptsFromGitRepo(Ocl ocl) {
+    public DeploymentScriptValidationResult validateOpenTofuScriptsFromGitRepo(
+            Deployment deployment) {
         DeploymentScriptValidationResult deployValidationResult = null;
         try {
             OpenTofuValidationResult validate =
                     openTofuFromGitRepoApi.validateScriptsFromGitRepo(
-                            getValidateScriptsInGitRepoRequest(ocl),
+                            getValidateScriptsInGitRepoRequest(deployment),
                             Objects.nonNull(MDC.get("TASK_ID"))
                                     ? UUID.fromString(MDC.get("TASK_ID")) : null);
             try {
@@ -98,26 +100,27 @@ public class TofuMakerScriptValidator {
         return deployValidationResult;
     }
 
-    private OpenTofuDeployWithScriptsRequest getValidateScriptsInOclRequest(Ocl ocl) {
+    private OpenTofuDeployWithScriptsRequest getValidateScriptsInOclRequest(Deployment deployment) {
         OpenTofuDeployWithScriptsRequest request =
                 new OpenTofuDeployWithScriptsRequest();
         request.setIsPlanOnly(false);
-        request.setScripts(getFilesByOcl(ocl));
+        request.setScripts(getFilesByOcl(deployment));
         return request;
     }
 
-    private OpenTofuDeployFromGitRepoRequest getValidateScriptsInGitRepoRequest(Ocl ocl) {
+    private OpenTofuDeployFromGitRepoRequest getValidateScriptsInGitRepoRequest(
+            Deployment deployment) {
         OpenTofuDeployFromGitRepoRequest request =
                 new OpenTofuDeployFromGitRepoRequest();
         request.setIsPlanOnly(false);
         request.setGitRepoDetails(
                 tofuMakerHelper.convertOpenTofuScriptGitRepoDetailsFromDeployFromGitRepo(
-                        ocl.getDeployment().getScriptsRepo()));
+                        deployment.getScriptsRepo()));
         return request;
     }
 
-    private List<String> getFilesByOcl(Ocl ocl) {
-        String deployer = ocl.getDeployment().getDeployer();
+    private List<String> getFilesByOcl(Deployment deployment) {
+        String deployer = deployment.getDeployer();
         return Collections.singletonList(deployer);
     }
 }

--- a/modules/deployment/src/main/java/org/eclipse/xpanse/modules/deployment/deployers/terraform/terraformboot/TerraformBootDeployment.java
+++ b/modules/deployment/src/main/java/org/eclipse/xpanse/modules/deployment/deployers/terraform/terraformboot/TerraformBootDeployment.java
@@ -8,7 +8,7 @@ package org.eclipse.xpanse.modules.deployment.deployers.terraform.terraformboot;
 import java.util.Objects;
 import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
-import org.eclipse.xpanse.modules.models.servicetemplate.Ocl;
+import org.eclipse.xpanse.modules.models.servicetemplate.Deployment;
 import org.eclipse.xpanse.modules.models.servicetemplate.enums.DeployerKind;
 import org.eclipse.xpanse.modules.orchestrator.deployment.DeployResult;
 import org.eclipse.xpanse.modules.orchestrator.deployment.DeployTask;
@@ -82,13 +82,13 @@ public class TerraformBootDeployment implements Deployer {
      * Validates the Terraform script.
      */
     @Override
-    public DeploymentScriptValidationResult validate(Ocl ocl) {
+    public DeploymentScriptValidationResult validate(Deployment deployment) {
         DeploymentScriptValidationResult result = null;
-        if (Objects.nonNull(ocl.getDeployment().getDeployer())) {
-            result = terraformBootScriptValidator.validateTerraformScripts(ocl);
+        if (Objects.nonNull(deployment.getDeployer())) {
+            result = terraformBootScriptValidator.validateTerraformScripts(deployment);
         }
-        if (Objects.nonNull(ocl.getDeployment().getScriptsRepo())) {
-            result = terraformBootScriptValidator.validateTerraformScriptsFromGitRepo(ocl);
+        if (Objects.nonNull(deployment.getScriptsRepo())) {
+            result = terraformBootScriptValidator.validateTerraformScriptsFromGitRepo(deployment);
         }
         return result;
     }

--- a/modules/deployment/src/main/java/org/eclipse/xpanse/modules/deployment/deployers/terraform/terraformboot/TerraformBootDeploymentPlanManage.java
+++ b/modules/deployment/src/main/java/org/eclipse/xpanse/modules/deployment/deployers/terraform/terraformboot/TerraformBootDeploymentPlanManage.java
@@ -67,7 +67,6 @@ public class TerraformBootDeploymentPlanManage {
         request.setGitRepoDetails(
                 terraformBootHelper.convertTerraformScriptGitRepoDetailsFromDeployFromGitRepo(
                         task.getOcl().getDeployment().getScriptsRepo()));
-        request.getVariables().put("region", task.getDeployRequest().getRegion().getName());
         return request;
     }
 }

--- a/modules/deployment/src/main/java/org/eclipse/xpanse/modules/deployment/deployers/terraform/terraformboot/TerraformBootHelper.java
+++ b/modules/deployment/src/main/java/org/eclipse/xpanse/modules/deployment/deployers/terraform/terraformboot/TerraformBootHelper.java
@@ -78,9 +78,7 @@ public class TerraformBootHelper {
         inputVariables.putAll(this.deployEnvironments.getVariablesFromDeployTask(
                 deployTask, isDeployRequest));
         inputVariables.putAll(this.deployEnvironments.getFlavorVariables(deployTask));
-        // we additionally pass the region as var since the provider information is
-        // also taken from GIT repo.
-        inputVariables.put("region", deployTask.getDeployRequest().getRegion().getName());
+        inputVariables.putAll(this.deployEnvironments.getAvailabilityZoneVariables(deployTask));
         return inputVariables;
     }
 

--- a/modules/deployment/src/main/java/org/eclipse/xpanse/modules/deployment/deployers/terraform/terraformboot/TerraformBootScriptValidator.java
+++ b/modules/deployment/src/main/java/org/eclipse/xpanse/modules/deployment/deployers/terraform/terraformboot/TerraformBootScriptValidator.java
@@ -18,7 +18,7 @@ import org.eclipse.xpanse.modules.deployment.deployers.terraform.terraformboot.g
 import org.eclipse.xpanse.modules.deployment.deployers.terraform.terraformboot.generated.model.TerraformDeployFromGitRepoRequest;
 import org.eclipse.xpanse.modules.deployment.deployers.terraform.terraformboot.generated.model.TerraformDeployWithScriptsRequest;
 import org.eclipse.xpanse.modules.deployment.deployers.terraform.terraformboot.generated.model.TerraformValidationResult;
-import org.eclipse.xpanse.modules.models.servicetemplate.Ocl;
+import org.eclipse.xpanse.modules.models.servicetemplate.Deployment;
 import org.eclipse.xpanse.modules.orchestrator.deployment.DeploymentScriptValidationResult;
 import org.slf4j.MDC;
 import org.springframework.context.annotation.Profile;
@@ -52,11 +52,12 @@ public class TerraformBootScriptValidator {
     /**
      * Validate scripts provided in the OCL.
      */
-    public DeploymentScriptValidationResult validateTerraformScripts(Ocl ocl) {
+    public DeploymentScriptValidationResult validateTerraformScripts(Deployment deployment) {
         DeploymentScriptValidationResult deploymentScriptValidationResult = null;
         try {
             TerraformValidationResult validate =
-                    terraformFromScriptsApi.validateWithScripts(getValidateScriptsInOclRequest(ocl),
+                    terraformFromScriptsApi.validateWithScripts(
+                            getValidateScriptsInOclRequest(deployment),
                             Objects.nonNull(MDC.get("TASK_ID"))
                                     ? UUID.fromString(MDC.get("TASK_ID")) : null);
             try {
@@ -76,12 +77,13 @@ public class TerraformBootScriptValidator {
     /**
      * Validate scripts in the GIT repo.
      */
-    public DeploymentScriptValidationResult validateTerraformScriptsFromGitRepo(Ocl ocl) {
+    public DeploymentScriptValidationResult validateTerraformScriptsFromGitRepo(
+            Deployment deployment) {
         DeploymentScriptValidationResult deploymentScriptValidationResult = null;
         try {
             TerraformValidationResult validate =
                     terraformFromGitRepoApi.validateScriptsFromGitRepo(
-                            getValidateScriptsInGitRepoRequest(ocl),
+                            getValidateScriptsInGitRepoRequest(deployment),
                             Objects.nonNull(MDC.get("TASK_ID"))
                                     ? UUID.fromString(MDC.get("TASK_ID")) : null);
             try {
@@ -98,26 +100,28 @@ public class TerraformBootScriptValidator {
         return deploymentScriptValidationResult;
     }
 
-    private TerraformDeployWithScriptsRequest getValidateScriptsInOclRequest(Ocl ocl) {
+    private TerraformDeployWithScriptsRequest getValidateScriptsInOclRequest(
+            Deployment deployment) {
         TerraformDeployWithScriptsRequest request =
                 new TerraformDeployWithScriptsRequest();
         request.setIsPlanOnly(false);
-        request.setScripts(getFilesByOcl(ocl));
+        request.setScripts(getFilesByOcl(deployment));
         return request;
     }
 
-    private TerraformDeployFromGitRepoRequest getValidateScriptsInGitRepoRequest(Ocl ocl) {
+    private TerraformDeployFromGitRepoRequest getValidateScriptsInGitRepoRequest(
+            Deployment deployment) {
         TerraformDeployFromGitRepoRequest request =
                 new TerraformDeployFromGitRepoRequest();
         request.setIsPlanOnly(false);
         request.setGitRepoDetails(
                 terraformBootHelper.convertTerraformScriptGitRepoDetailsFromDeployFromGitRepo(
-                        ocl.getDeployment().getScriptsRepo()));
+                        deployment.getScriptsRepo()));
         return request;
     }
 
-    private List<String> getFilesByOcl(Ocl ocl) {
-        String deployer = ocl.getDeployment().getDeployer();
+    private List<String> getFilesByOcl(Deployment deployment) {
+        String deployer = deployment.getDeployer();
         return Collections.singletonList(deployer);
     }
 }

--- a/modules/deployment/src/main/java/org/eclipse/xpanse/modules/deployment/deployers/terraform/terraformlocal/TerraformLocalDeployment.java
+++ b/modules/deployment/src/main/java/org/eclipse/xpanse/modules/deployment/deployers/terraform/terraformlocal/TerraformLocalDeployment.java
@@ -32,7 +32,7 @@ import org.eclipse.xpanse.modules.deployment.deployers.terraform.utils.TfResourc
 import org.eclipse.xpanse.modules.deployment.utils.DeployEnvironments;
 import org.eclipse.xpanse.modules.deployment.utils.ScriptsGitRepoManage;
 import org.eclipse.xpanse.modules.models.service.deploy.exceptions.ServiceNotDeployedException;
-import org.eclipse.xpanse.modules.models.servicetemplate.Ocl;
+import org.eclipse.xpanse.modules.models.servicetemplate.Deployment;
 import org.eclipse.xpanse.modules.models.servicetemplate.enums.DeployerKind;
 import org.eclipse.xpanse.modules.orchestrator.deployment.DeployResult;
 import org.eclipse.xpanse.modules.orchestrator.deployment.DeployTask;
@@ -204,6 +204,8 @@ public class TerraformLocalDeployment implements Deployer {
                 this.deployEnvironments.getVariablesFromDeployTask(task, isDeployTask);
         // load flavor variables also as input variables for terraform executor.
         inputVariables.putAll(this.deployEnvironments.getFlavorVariables(task));
+        // load availability zone variables also as input variables for OpenTofu executor.
+        inputVariables.putAll(this.deployEnvironments.getAvailabilityZoneVariables(task));
         // load credential variables also as env variables for terraform executor.
         envVariables.putAll(this.deployEnvironments.getCredentialVariablesByHostingType(
                 task.getDeployRequest().getServiceHostingType(),
@@ -211,19 +213,19 @@ public class TerraformLocalDeployment implements Deployer {
                 task.getDeployRequest().getUserId()));
         envVariables.putAll(this.deployEnvironments.getPluginMandatoryVariables(
                 task.getDeployRequest().getCsp()));
-        return getExecutor(envVariables, inputVariables, workspace, task.getOcl());
+        return getExecutor(envVariables, inputVariables, workspace, task.getOcl().getDeployment());
     }
 
     private TerraformLocalExecutor getExecutor(Map<String, String> envVariables,
                                                Map<String, Object> inputVariables, String workspace,
-                                               Ocl ocl) {
+                                               Deployment deployment) {
         if (terraformLocalConfig.isDebugEnabled()) {
             log.info("Debug enabled for Terraform CLI with level {}",
                     terraformLocalConfig.getDebugLogLevel());
             envVariables.put(TF_DEBUG_FLAG, terraformLocalConfig.getDebugLogLevel());
         }
         return new TerraformLocalExecutor(envVariables, inputVariables, workspace,
-                getSubDirectory(ocl));
+                getSubDirectory(deployment));
     }
 
     private void prepareDeployWorkspaceWithScripts(DeployTask deployTask, String workspace) {
@@ -333,25 +335,26 @@ public class TerraformLocalDeployment implements Deployer {
     /**
      * Validates the Terraform script.
      */
-    public DeploymentScriptValidationResult validate(Ocl ocl) {
+    @Override
+    public DeploymentScriptValidationResult validate(Deployment deployment) {
         String workspace = getWorkspacePath(UUID.randomUUID());
         // Create the workspace.
         buildWorkspace(workspace);
-        if (Objects.nonNull(ocl.getDeployment().getDeployer())) {
-            createScriptFile(workspace, ocl.getDeployment().getDeployer());
+        if (Objects.nonNull(deployment.getDeployer())) {
+            createScriptFile(workspace, deployment.getDeployer());
         } else {
-            scriptsGitRepoManage.checkoutScripts(workspace, ocl.getDeployment().getScriptsRepo());
+            scriptsGitRepoManage.checkoutScripts(workspace, deployment.getScriptsRepo());
         }
         TerraformLocalExecutor executor =
-                getExecutor(new HashMap<>(), new HashMap<>(), workspace, ocl);
+                getExecutor(new HashMap<>(), new HashMap<>(), workspace, deployment);
         return executor.tfValidate();
     }
 
-    private @Nullable String getSubDirectory(Ocl ocl) {
-        if (Objects.nonNull(ocl.getDeployment().getDeployer())) {
+    private @Nullable String getSubDirectory(Deployment deployment) {
+        if (Objects.nonNull(deployment.getDeployer())) {
             return null;
-        } else if (Objects.nonNull(ocl.getDeployment().getScriptsRepo())) {
-            return ocl.getDeployment().getScriptsRepo().getScriptsPath();
+        } else if (Objects.nonNull(deployment.getScriptsRepo())) {
+            return deployment.getScriptsRepo().getScriptsPath();
         }
         return null;
     }

--- a/modules/deployment/src/test/java/org/eclipse/xpanse/modules/deployment/AvailabilityZonesRequestValidatorTest.java
+++ b/modules/deployment/src/test/java/org/eclipse/xpanse/modules/deployment/AvailabilityZonesRequestValidatorTest.java
@@ -1,0 +1,78 @@
+package org.eclipse.xpanse.modules.deployment;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.eclipse.xpanse.modules.models.service.deploy.exceptions.VariableInvalidException;
+import org.eclipse.xpanse.modules.models.servicetemplate.AvailabilityZoneConfig;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class AvailabilityZonesRequestValidatorTest {
+
+    @Test
+    void testValidateAvailabilityZonesWithEmptyZoneConfig() {
+        // Setup
+        final Map<String, String> inputMap = new HashMap<>();
+        final List<AvailabilityZoneConfig> zoneConfigs = new ArrayList<>();
+        Assertions.assertDoesNotThrow(() -> {
+            AvailabilityZonesRequestValidator.validateAvailabilityZones(inputMap, zoneConfigs);
+        });
+    }
+
+    @Test
+    void testValidateAvailabilityZonesWithEmptyRequiredZoneConfig() {
+        // Setup
+        final AvailabilityZoneConfig availabilityZoneConfig = new AvailabilityZoneConfig();
+        availabilityZoneConfig.setDisplayName("displayName");
+        availabilityZoneConfig.setVarName("varName");
+        availabilityZoneConfig.setMandatory(false);
+        availabilityZoneConfig.setDescription("description");
+        final List<AvailabilityZoneConfig> zoneConfigs = List.of(availabilityZoneConfig);
+        final Map<String, String> inputMap = Map.ofEntries(Map.entry("value", "value"));
+        // Run the test
+        Assertions.assertDoesNotThrow(() -> {
+            AvailabilityZonesRequestValidator.validateAvailabilityZones(inputMap, zoneConfigs);
+        });
+    }
+
+    @Test
+    void testValidateAvailabilityZonesWithoutRequiredZoneValues() {
+        // Setup
+        final AvailabilityZoneConfig availabilityZoneConfig = new AvailabilityZoneConfig();
+        availabilityZoneConfig.setDisplayName("displayName");
+        availabilityZoneConfig.setVarName("varName");
+        availabilityZoneConfig.setMandatory(true);
+        availabilityZoneConfig.setDescription("description");
+        final List<AvailabilityZoneConfig> zoneConfigs = List.of(availabilityZoneConfig);
+        final Map<String, String> inputMap = Map.ofEntries(Map.entry("value", "value"));
+        // Run the test
+        Assertions.assertThrows(VariableInvalidException.class, () -> {
+            AvailabilityZonesRequestValidator.validateAvailabilityZones(inputMap, zoneConfigs);
+        });
+    }
+
+    @Test
+    void testValidateAvailabilityZonesWithDuplicatedValues() {
+        // Setup
+        final AvailabilityZoneConfig availabilityZoneConfig = new AvailabilityZoneConfig();
+        availabilityZoneConfig.setDisplayName("displayName");
+        availabilityZoneConfig.setVarName("varName");
+        availabilityZoneConfig.setMandatory(true);
+        availabilityZoneConfig.setDescription("description");
+        final AvailabilityZoneConfig availabilityZoneConfig1 = new AvailabilityZoneConfig();
+        availabilityZoneConfig1.setDisplayName("displayName1");
+        availabilityZoneConfig1.setVarName("varName1");
+        availabilityZoneConfig1.setMandatory(true);
+        availabilityZoneConfig1.setDescription("description1");
+        final List<AvailabilityZoneConfig> zoneConfigs = List.of(availabilityZoneConfig,
+                availabilityZoneConfig1);
+        final Map<String, String> inputMap = Map.ofEntries(
+                Map.entry("varName", "value"), Map.entry("varName1", "value"));
+        // Run the test
+        Assertions.assertThrows(VariableInvalidException.class, () -> {
+            AvailabilityZonesRequestValidator.validateAvailabilityZones(inputMap, zoneConfigs);
+        });
+    }
+}

--- a/modules/deployment/src/test/java/org/eclipse/xpanse/modules/deployment/deployers/opentofu/tofumaker/TofuMakerDeploymentTest.java
+++ b/modules/deployment/src/test/java/org/eclipse/xpanse/modules/deployment/deployers/opentofu/tofumaker/TofuMakerDeploymentTest.java
@@ -217,7 +217,8 @@ class TofuMakerDeploymentTest {
         when(tofuMakerScriptValidator.validateOpenTofuScripts(any())).thenReturn(expectedResult);
 
         // Run the test
-        final DeploymentScriptValidationResult result = openTofuMakerDeployment.validate(ocl);
+        final DeploymentScriptValidationResult result =
+                openTofuMakerDeployment.validate(ocl.getDeployment());
 
         // Verify the results
         assertThat(result).isEqualTo(expectedResult);
@@ -237,7 +238,8 @@ class TofuMakerDeploymentTest {
         when(tofuMakerScriptValidator.validateOpenTofuScripts(any())).thenReturn(expectedResult);
 
         // Run the test
-        final DeploymentScriptValidationResult result = openTofuMakerDeployment.validate(ocl);
+        final DeploymentScriptValidationResult result =
+                openTofuMakerDeployment.validate(ocl.getDeployment());
 
         // Verify the results
         assertThat(result).isEqualTo(expectedResult);
@@ -250,7 +252,7 @@ class TofuMakerDeploymentTest {
                 new OpenTofuMakerRequestFailedException("IO error"));
 
         Assertions.assertThrows(OpenTofuMakerRequestFailedException.class,
-                () -> this.openTofuMakerDeployment.validate(ocl));
+                () -> this.openTofuMakerDeployment.validate(ocl.getDeployment()));
     }
 
 }

--- a/modules/deployment/src/test/java/org/eclipse/xpanse/modules/deployment/deployers/terraform/terraformboot/TerraformBootDeploymentTest.java
+++ b/modules/deployment/src/test/java/org/eclipse/xpanse/modules/deployment/deployers/terraform/terraformboot/TerraformBootDeploymentTest.java
@@ -220,7 +220,8 @@ class TerraformBootDeploymentTest {
                 expectedResult);
 
         // Run the test
-        final DeploymentScriptValidationResult result = terraformBootDeployment.validate(ocl);
+        final DeploymentScriptValidationResult result =
+                terraformBootDeployment.validate(ocl.getDeployment());
 
         // Verify the results
         assertThat(result).isEqualTo(expectedResult);
@@ -241,7 +242,8 @@ class TerraformBootDeploymentTest {
                 expectedResult);
 
         // Run the test
-        final DeploymentScriptValidationResult result = terraformBootDeployment.validate(ocl);
+        final DeploymentScriptValidationResult result =
+                terraformBootDeployment.validate(ocl.getDeployment());
 
         // Verify the results
         assertThat(result).isEqualTo(expectedResult);
@@ -254,7 +256,7 @@ class TerraformBootDeploymentTest {
                 new TerraformBootRequestFailedException("IO error"));
 
         Assertions.assertThrows(TerraformBootRequestFailedException.class,
-                () -> this.terraformBootDeployment.validate(ocl));
+                () -> this.terraformBootDeployment.validate(ocl.getDeployment()));
     }
 
 }

--- a/modules/deployment/src/test/java/org/eclipse/xpanse/modules/deployment/deployers/terraform/terraformlocal/TerraformLocalDeploymentTest.java
+++ b/modules/deployment/src/test/java/org/eclipse/xpanse/modules/deployment/deployers/terraform/terraformlocal/TerraformLocalDeploymentTest.java
@@ -247,7 +247,8 @@ class TerraformLocalDeploymentTest {
         expectedResult.setDiagnostics(new ArrayList<>());
 
         // Run the test
-        final DeploymentScriptValidationResult result = terraformLocalDeployment.validate(ocl);
+        final DeploymentScriptValidationResult result =
+                terraformLocalDeployment.validate(ocl.getDeployment());
 
         // Verify the results
         assertThat(result).isEqualTo(expectedResult);
@@ -265,7 +266,8 @@ class TerraformLocalDeploymentTest {
         expectedResult.setDiagnostics(List.of(diagnostics));
 
         // Run the test
-        final DeploymentScriptValidationResult result = terraformLocalDeployment.validate(ocl);
+        final DeploymentScriptValidationResult result =
+                terraformLocalDeployment.validate(ocl.getDeployment());
 
         // Verify the results
         assertThat(result).isEqualTo(expectedResult);
@@ -274,9 +276,8 @@ class TerraformLocalDeploymentTest {
     @Test
     void testValidate_ThrowsTerraformExecutorException() {
         ocl.getDeployment().setDeployer(errorDeployer);
-
         Assertions.assertThrows(TerraformExecutorException.class,
-                () -> this.terraformLocalDeployment.validate(ocl));
+                () -> this.terraformLocalDeployment.validate(ocl.getDeployment()));
     }
 
 }

--- a/modules/models/src/main/java/org/eclipse/xpanse/modules/models/service/deploy/DeployRequest.java
+++ b/modules/models/src/main/java/org/eclipse/xpanse/modules/models/service/deploy/DeployRequest.java
@@ -6,6 +6,7 @@
 package org.eclipse.xpanse.modules.models.service.deploy;
 
 import io.swagger.v3.oas.annotations.Hidden;
+import java.io.Serial;
 import java.util.UUID;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -20,6 +21,8 @@ import lombok.ToString;
 @Data
 public class DeployRequest extends DeployRequestBase {
 
+    @Serial
+    private static final long serialVersionUID = -8027459207480627100L;
     /**
      * The id of the service to deploy.
      */

--- a/modules/models/src/main/java/org/eclipse/xpanse/modules/models/service/deploy/DeployRequestBase.java
+++ b/modules/models/src/main/java/org/eclipse/xpanse/modules/models/service/deploy/DeployRequestBase.java
@@ -92,4 +92,7 @@ public class DeployRequestBase implements Serializable {
      */
     @Schema(description = "The properties for the requested service")
     private Map<String, Object> serviceRequestProperties;
+
+    @Schema(description = "The availability zones to deploy the service instance.")
+    private Map<String, String> availabilityZones;
 }

--- a/modules/models/src/main/java/org/eclipse/xpanse/modules/models/servicetemplate/AvailabilityZoneConfig.java
+++ b/modules/models/src/main/java/org/eclipse/xpanse/modules/models/servicetemplate/AvailabilityZoneConfig.java
@@ -1,0 +1,44 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * SPDX-FileCopyrightText: Huawei Inc.
+ */
+
+package org.eclipse.xpanse.modules.models.servicetemplate;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import java.io.Serial;
+import java.io.Serializable;
+import lombok.Data;
+
+/**
+ * Defines the availability zone model of the managed service.
+ */
+@Data
+public class AvailabilityZoneConfig implements Serializable {
+
+    @Serial
+    private static final long serialVersionUID = -4194637466122775932L;
+
+    @NotNull
+    @NotBlank
+    @NotEmpty
+    @Schema(description = "The display name of availability zone.")
+    private String displayName;
+
+    @NotNull
+    @NotBlank
+    @NotEmpty
+    @Schema(description = "The variable name of availability zone.")
+    private String varName;
+
+    @NotNull
+    @Schema(description = "Indicates if the variable is mandatory.")
+    private Boolean mandatory;
+
+    @Schema(description = "The description of availability zone.")
+    private String description;
+
+}

--- a/modules/models/src/main/java/org/eclipse/xpanse/modules/models/servicetemplate/Deployment.java
+++ b/modules/models/src/main/java/org/eclipse/xpanse/modules/models/servicetemplate/Deployment.java
@@ -38,6 +38,9 @@ public class Deployment implements Serializable {
     @Schema(description = "The credential type to do the deployment")
     private CredentialType credentialType = CredentialType.VARIABLES;
 
+    @Schema(description = "The list of availability zones of the service.")
+    private List<AvailabilityZoneConfig> serviceAvailability;
+
     @Schema(description = "The real deployer, something like terraform scripts. "
             + "Either deployer or deployFromGitRepo must be provided.")
     private String deployer;

--- a/modules/models/src/main/java/org/eclipse/xpanse/modules/models/workflow/migrate/MigrateRequest.java
+++ b/modules/models/src/main/java/org/eclipse/xpanse/modules/models/workflow/migrate/MigrateRequest.java
@@ -7,6 +7,7 @@ package org.eclipse.xpanse.modules.models.workflow.migrate;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
+import java.io.Serial;
 import java.util.UUID;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -20,6 +21,10 @@ import org.eclipse.xpanse.modules.models.service.deploy.DeployRequestBase;
 @ToString(callSuper = true)
 @Data
 public class MigrateRequest extends DeployRequestBase {
+
+    @Serial
+    private static final long serialVersionUID = 204243455244611956L;
+
     /**
      * The id of the service to migrate.
      */

--- a/modules/models/src/test/java/org/eclipse/xpanse/modules/models/service/deploy/DeployRequestTest.java
+++ b/modules/models/src/test/java/org/eclipse/xpanse/modules/models/service/deploy/DeployRequestTest.java
@@ -6,37 +6,41 @@
 
 package org.eclipse.xpanse.modules.models.service.deploy;
 
+import static org.assertj.core.api.Assertions.as;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import java.util.Collections;
 import java.util.Map;
 import java.util.UUID;
 import org.eclipse.xpanse.modules.models.common.enums.Category;
 import org.eclipse.xpanse.modules.models.common.enums.Csp;
-import org.eclipse.xpanse.modules.models.servicetemplate.Ocl;
 import org.eclipse.xpanse.modules.models.servicetemplate.Region;
 import org.eclipse.xpanse.modules.models.servicetemplate.enums.ServiceHostingType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.BeanUtils;
 
 /**
  * Test of CreateRequest.
  */
 class DeployRequestTest {
 
-    private static final UUID id = UUID.fromString("ed6248d4-2bcd-4e94-84b0-29e014c05137");
-    private static final String userId = "userId";
-    private static final Category category = Category.COMPUTE;
-    private static final String serviceName = "service";
-    private static final String customerServiceName = "customerService";
-    private static final String version = "1.0";
-    private static final String regionName = "us-east-1";
-    private static final String areaName = "Asia China";
-    private static final Csp csp = Csp.AWS;
-    private static final String flavor = "flavor";
-    private static final Map<String, Object> properties = Collections.singletonMap("key", "value");
-    private static DeployRequest request;
+    private final UUID id = UUID.fromString("ed6248d4-2bcd-4e94-84b0-29e014c05137");
+    private final String userId = "userId" ;
+    private final Category category = Category.COMPUTE;
+    private final String serviceName = "service" ;
+    private final String customerServiceName = "customerService" ;
+    private final String version = "1.0" ;
+    private final String regionName = "us-east-1" ;
+    private final String areaName = "Asia China" ;
+    private final Region region = new Region();
+    private final Csp csp = Csp.AWS;
+    private final String flavor = "flavor" ;
+    private final ServiceHostingType serviceHostingType = ServiceHostingType.SELF;
+    private final Map<String, Object> properties = Collections.singletonMap("key", "value");
+    private final Map<String, String> availabilityZones = Collections.singletonMap("key", "value");
+    private DeployRequest request;
 
     @BeforeEach
     void setUp() {
@@ -47,138 +51,56 @@ class DeployRequestTest {
         request.setServiceName(serviceName);
         request.setCustomerServiceName(customerServiceName);
         request.setVersion(version);
-        Region region = new Region();
         region.setName(regionName);
         region.setArea(areaName);
         request.setRegion(region);
         request.setCsp(csp);
         request.setFlavor(flavor);
         request.setServiceRequestProperties(properties);
+        request.setServiceHostingType(serviceHostingType);
+        request.setAvailabilityZones(availabilityZones);
     }
 
     @Test
-    void testGetterAndSetter() {
+    void testGetters() {
         assertEquals(id, request.getId());
         assertEquals(userId, request.getUserId());
         assertEquals(category, request.getCategory());
         assertEquals(serviceName, request.getServiceName());
         assertEquals(customerServiceName, request.getCustomerServiceName());
         assertEquals(version, request.getVersion());
-        Region region = new Region();
-        region.setName(regionName);
-        region.setArea(areaName);
         assertEquals(region, request.getRegion());
+        assertEquals(areaName, request.getRegion().getArea());
+        assertEquals(regionName, request.getRegion().getName());
         assertEquals(csp, request.getCsp());
         assertEquals(flavor, request.getFlavor());
         assertEquals(properties, request.getServiceRequestProperties());
+        assertEquals(availabilityZones, request.getAvailabilityZones());
+        assertEquals(serviceHostingType, request.getServiceHostingType());
     }
 
     @Test
     void testEqualsAndHashCode() {
-        assertEquals(request, request);
-        assertEquals(request.hashCode(), request.hashCode());
-
         Object obj = new Object();
-        assertNotEquals(request, obj);
-        assertNotEquals(request, null);
-        assertNotEquals(request.hashCode(), obj.hashCode());
+        assertThat(request).isNotEqualTo(obj);
+        assertThat(request.hashCode()).isNotEqualTo(obj.hashCode());
+        DeployRequest test1 = new DeployRequest();
+        assertThat(request).isNotEqualTo(test1);
+        assertThat(request.hashCode()).isNotEqualTo(test1.hashCode());
+        DeployRequest test2 = new DeployRequest();
+        BeanUtils.copyProperties(request, test2);
+        assertThat(request).isEqualTo(test2);
+        assertThat(request.hashCode()).isEqualTo(test2.hashCode());
+    }
 
-        DeployRequest request1 = new DeployRequest();
-        DeployRequest request2 = new DeployRequest();
-        assertNotEquals(request, request1);
-        assertNotEquals(request, request2);
-        assertEquals(request1, request2);
-        assertNotEquals(request.hashCode(), request1.hashCode());
-        assertNotEquals(request.hashCode(), request2.hashCode());
-        assertEquals(request1.hashCode(), request2.hashCode());
-
-        request1.setId(id);
-        assertNotEquals(request, request1);
-        assertNotEquals(request1, request2);
-        assertNotEquals(request.hashCode(), request1.hashCode());
-        assertNotEquals(request1.hashCode(), request2.hashCode());
-
-        request1.setUserId(userId);
-        assertNotEquals(request, request1);
-        assertNotEquals(request1, request2);
-        assertNotEquals(request.hashCode(), request1.hashCode());
-        assertNotEquals(request1.hashCode(), request2.hashCode());
-
-        request1.setCategory(category);
-        assertNotEquals(request, request1);
-        assertNotEquals(request1, request2);
-        assertNotEquals(request.hashCode(), request1.hashCode());
-        assertNotEquals(request1.hashCode(), request2.hashCode());
-
-        request1.setServiceName(serviceName);
-        assertNotEquals(request, request1);
-        assertNotEquals(request1, request2);
-        assertNotEquals(request.hashCode(), request1.hashCode());
-        assertNotEquals(request1.hashCode(), request2.hashCode());
-
-        request1.setCustomerServiceName(customerServiceName);
-        assertNotEquals(request, request1);
-        assertNotEquals(request1, request2);
-        assertNotEquals(request.hashCode(), request1.hashCode());
-        assertNotEquals(request1.hashCode(), request2.hashCode());
-
-        request1.setVersion(version);
-        assertNotEquals(request, request1);
-        assertNotEquals(request1, request2);
-        assertNotEquals(request.hashCode(), request1.hashCode());
-        assertNotEquals(request1.hashCode(), request2.hashCode());
-
-        Region region = new Region();
-        region.setName(regionName);
-        region.setArea(areaName);
-        request1.setRegion(region);
-        assertNotEquals(request, request1);
-        assertNotEquals(request1, request2);
-        assertNotEquals(request.hashCode(), request1.hashCode());
-        assertNotEquals(request1.hashCode(), request2.hashCode());
-
-        request1.setCsp(csp);
-        assertNotEquals(request, request1);
-        assertNotEquals(request1, request2);
-        assertNotEquals(request.hashCode(), request1.hashCode());
-        assertNotEquals(request1.hashCode(), request2.hashCode());
-
-        request1.setFlavor(flavor);
-        assertNotEquals(request, request1);
-        assertNotEquals(request1, request2);
-        assertNotEquals(request.hashCode(), request1.hashCode());
-        assertNotEquals(request1.hashCode(), request2.hashCode());
-
-        assertNotEquals(request, request1);
-        assertNotEquals(request1, request2);
-        assertNotEquals(request.hashCode(), request1.hashCode());
-        assertNotEquals(request1.hashCode(), request2.hashCode());
-
-        request1.setServiceRequestProperties(properties);
-        assertEquals(request, request1);
-        assertNotEquals(request1, request2);
-        assertEquals(request.hashCode(), request1.hashCode());
-        assertNotEquals(request1.hashCode(), request2.hashCode());
+    @Test
+    void testCanEqual() {
+        assertThat(request.canEqual("other")).isFalse();
+        assertThat(request.canEqual(new DeployRequest())).isTrue();
     }
 
     @Test
     void testToString() {
-        DeployRequest request = new DeployRequest();
-        request.setId(id);
-        request.setUserId(userId);
-        request.setCategory(category);
-        request.setServiceName(serviceName);
-        request.setCustomerServiceName(customerServiceName);
-        request.setVersion(version);
-        Region region = new Region();
-        region.setName(regionName);
-        region.setArea(areaName);
-        request.setRegion(region);
-        request.setCsp(csp);
-        request.setFlavor(flavor);
-        request.setServiceHostingType(ServiceHostingType.SERVICE_VENDOR);
-        request.setServiceRequestProperties(properties);
-
         String expectedToString = "DeployRequest(super=DeployRequestBase(" +
                 "userId=" + userId +
                 ", category=" + category +
@@ -188,8 +110,9 @@ class DeployRequestTest {
                 ", region=" + region +
                 ", csp=" + csp +
                 ", flavor=" + flavor +
-                ", serviceHostingType=" + ServiceHostingType.SERVICE_VENDOR +
+                ", serviceHostingType=" + serviceHostingType +
                 ", serviceRequestProperties=" + properties +
+                ", availabilityZones=" + availabilityZones +
                 "), id=" + id + ")";
         assertEquals(expectedToString, request.toString());
     }

--- a/modules/models/src/test/java/org/eclipse/xpanse/modules/models/servicetemplate/AvailabilityZoneConfigTest.java
+++ b/modules/models/src/test/java/org/eclipse/xpanse/modules/models/servicetemplate/AvailabilityZoneConfigTest.java
@@ -1,0 +1,63 @@
+package org.eclipse.xpanse.modules.models.servicetemplate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class AvailabilityZoneConfigTest {
+    private final String displayName = "displayName";
+    private final String varName = "varName";
+    private final String description = "description";
+    private final Boolean mandatory = true;
+    private AvailabilityZoneConfig test;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        test = new AvailabilityZoneConfig();
+        test.setDisplayName(displayName);
+        test.setVarName(varName);
+        test.setDescription(description);
+        test.setMandatory(mandatory);
+    }
+
+    @Test
+    void testGetters() {
+        assertThat(test.getDisplayName()).isEqualTo(displayName);
+        assertThat(test.getVarName()).isEqualTo(varName);
+        assertThat(test.getDescription()).isEqualTo(description);
+        assertThat(test.getMandatory()).isEqualTo(mandatory);
+    }
+
+    @Test
+    void testEqualsAndHashCode() {
+        Object obj = new Object();
+        assertThat(test).isNotEqualTo(obj);
+        assertThat(test.hashCode()).isNotEqualTo(obj.hashCode());
+        AvailabilityZoneConfig test1 = new AvailabilityZoneConfig();
+        assertThat(test).isNotEqualTo(test1);
+        assertThat(test.hashCode()).isNotEqualTo(test1.hashCode());
+        AvailabilityZoneConfig test2 = new AvailabilityZoneConfig();
+        test2.setDisplayName(displayName);
+        test2.setVarName(varName);
+        test2.setDescription(description);
+        test2.setMandatory(mandatory);
+        assertThat(test).isEqualTo(test2);
+        assertThat(test.hashCode()).isEqualTo(test2.hashCode());
+    }
+
+    @Test
+    void testCanEqual() {
+        assertThat(test.canEqual("other")).isFalse();
+        assertThat(test.canEqual(new AvailabilityZoneConfig())).isTrue();
+    }
+
+    @Test
+    void testToString() throws Exception {
+        String result = "AvailabilityZoneConfig(displayName=" + displayName
+                + ", varName=" + varName + ", mandatory=" + mandatory
+                + ", description=" + description
+                + ")";
+        assertThat(test.toString()).isEqualTo(result);
+    }
+}

--- a/modules/models/src/test/java/org/eclipse/xpanse/modules/models/servicetemplate/DeploymentTest.java
+++ b/modules/models/src/test/java/org/eclipse/xpanse/modules/models/servicetemplate/DeploymentTest.java
@@ -5,25 +5,28 @@
 
 package org.eclipse.xpanse.modules.models.servicetemplate;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import java.util.List;
 import org.eclipse.xpanse.modules.models.credential.enums.CredentialType;
 import org.eclipse.xpanse.modules.models.servicetemplate.enums.DeployerKind;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.BeanUtils;
 
 /**
  * Test of Deployment.
  */
 class DeploymentTest {
 
-    private static final DeployerKind kind = DeployerKind.TERRAFORM;
-    private static final String deployer = "deployer";
-    private static List<DeployVariable> variables;
-    private static Deployment deployment;
+    private final DeployerKind kind = DeployerKind.TERRAFORM;
+    private final String deployer = "deployer";
+    private ScriptsRepo scriptsRepo;
+    private List<DeployVariable> variables;
+    private List<AvailabilityZoneConfig> availabilityZones;
     private final CredentialType credentialType = CredentialType.API_KEY;
+    private Deployment test;
 
     @BeforeEach
     void setUp() {
@@ -31,63 +34,57 @@ class DeploymentTest {
         deployVariable.setName("HW_AK");
         variables = List.of(deployVariable);
 
-        deployment = new Deployment();
-        deployment.setKind(kind);
-        deployment.setDeployer(deployer);
-        deployment.setVariables(variables);
-        deployment.setCredentialType(credentialType);
+        AvailabilityZoneConfig availabilityZoneConfig = new AvailabilityZoneConfig();
+        availabilityZoneConfig.setDisplayName("displayName");
+        availabilityZoneConfig.setVarName("varName");
+        availabilityZoneConfig.setMandatory(true);
+        availabilityZoneConfig.setDescription("description");
+        availabilityZones = List.of(availabilityZoneConfig);
+
+        scriptsRepo = new ScriptsRepo();
+        scriptsRepo.setRepoUrl("repoUrl");
+        scriptsRepo.setBranch("branch");
+        scriptsRepo.setScriptsPath("scriptsPath");
+
+        test = new Deployment();
+        test.setKind(kind);
+        test.setDeployer(deployer);
+        test.setVariables(variables);
+        test.setCredentialType(credentialType);
+        test.setServiceAvailability(availabilityZones);
+        test.setScriptsRepo(scriptsRepo);
     }
 
     @Test
     void testGetterAndSetter() {
-        assertEquals(kind, deployment.getKind());
-        assertEquals(deployer, deployment.getDeployer());
-        assertEquals(variables, deployment.getVariables());
-        assertEquals(credentialType, deployment.getCredentialType());
+        assertEquals(kind, test.getKind());
+        assertEquals(deployer, test.getDeployer());
+        assertEquals(variables, test.getVariables());
+        assertEquals(credentialType, test.getCredentialType());
+        assertEquals(availabilityZones, test.getServiceAvailability());
+        assertEquals(scriptsRepo, test.getScriptsRepo());
     }
 
     @Test
     void testEqualsAndHashCode() {
-        assertEquals(deployment.hashCode(), deployment.hashCode());
-
         Object obj = new Object();
-        assertNotEquals(deployment, obj);
-        assertNotEquals(deployment, null);
-        assertNotEquals(deployment.hashCode(), obj.hashCode());
-
-        Deployment deployment1 = new Deployment();
-        Deployment deployment2 = new Deployment();
-        assertNotEquals(deployment, deployment1);
-        assertNotEquals(deployment, deployment2);
-        assertEquals(deployment1, deployment2);
-        assertNotEquals(deployment.hashCode(), deployment1.hashCode());
-        assertNotEquals(deployment.hashCode(), deployment2.hashCode());
-        assertEquals(deployment1.hashCode(), deployment2.hashCode());
-
-        deployment1.setKind(kind);
-        assertNotEquals(deployment, deployment1);
-        assertNotEquals(deployment1, deployment2);
-        assertNotEquals(deployment.hashCode(), deployment1.hashCode());
-        assertNotEquals(deployment1.hashCode(), deployment2.hashCode());
-
-        deployment1.setVariables(variables);
-        assertNotEquals(deployment, deployment1);
-        assertNotEquals(deployment1, deployment2);
-        assertNotEquals(deployment.hashCode(), deployment1.hashCode());
-        assertNotEquals(deployment1.hashCode(), deployment2.hashCode());
-
-        deployment1.setDeployer(deployer);
-        assertNotEquals(deployment, deployment1);
-        assertNotEquals(deployment1, deployment2);
-        assertNotEquals(deployment.hashCode(), deployment1.hashCode());
-        assertNotEquals(deployment1.hashCode(), deployment2.hashCode());
-
-        deployment1.setCredentialType(credentialType);
-        assertEquals(deployment, deployment1);
-        assertNotEquals(deployment1, deployment2);
-        assertEquals(deployment.hashCode(), deployment1.hashCode());
-        assertNotEquals(deployment1.hashCode(), deployment2.hashCode());
+        assertThat(test).isNotEqualTo(obj);
+        assertThat(test.hashCode()).isNotEqualTo(obj.hashCode());
+        Deployment test1 = new Deployment();
+        assertThat(test).isNotEqualTo(test1);
+        assertThat(test.hashCode()).isNotEqualTo(test1.hashCode());
+        Deployment test2 = new Deployment();
+        BeanUtils.copyProperties(test, test2);
+        assertThat(test).isEqualTo(test2);
+        assertThat(test.hashCode()).isEqualTo(test2.hashCode());
     }
+
+    @Test
+    void testCanEqual() {
+        assertThat(test.canEqual("other")).isFalse();
+        assertThat(test.canEqual(new Deployment())).isTrue();
+    }
+
 
     @Test
     void testToString() {
@@ -95,10 +92,11 @@ class DeploymentTest {
                 "kind=" + kind +
                 ", variables=" + variables +
                 ", credentialType=" + credentialType +
+                ", serviceAvailability=" + availabilityZones +
                 ", deployer=" + deployer +
-                ", scriptsRepo=null" +
+                ", scriptsRepo=" + scriptsRepo +
                 ")";
-        assertEquals(expectedString, deployment.toString());
+        assertEquals(expectedString, test.toString());
     }
 
 }

--- a/modules/models/src/test/java/org/eclipse/xpanse/modules/models/servicetemplate/ScriptsRepoTest.java
+++ b/modules/models/src/test/java/org/eclipse/xpanse/modules/models/servicetemplate/ScriptsRepoTest.java
@@ -1,0 +1,59 @@
+package org.eclipse.xpanse.modules.models.servicetemplate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class ScriptsRepoTest {
+
+    final String repoUrl = "repoUrl";
+    final String branch = "branch";
+    final String scriptsPath = "scriptsPath";
+    private ScriptsRepo test;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        test = new ScriptsRepo();
+        test.setRepoUrl(repoUrl);
+        test.setBranch(branch);
+        test.setScriptsPath(scriptsPath);
+    }
+
+    @Test
+    void testGetters() {
+        assertThat(test.getRepoUrl()).isEqualTo(repoUrl);
+        assertThat(test.getBranch()).isEqualTo(branch);
+        assertThat(test.getScriptsPath()).isEqualTo(scriptsPath);
+    }
+
+    @Test
+    void testEqualsAndHashCode() {
+        Object obj = new Object();
+        assertThat(test).isNotEqualTo(obj);
+        assertThat(test.hashCode()).isNotEqualTo(obj.hashCode());
+        ScriptsRepo test1 = new ScriptsRepo();
+        assertThat(test).isNotEqualTo(test1);
+        assertThat(test.hashCode()).isNotEqualTo(test1.hashCode());
+        ScriptsRepo test2 = new ScriptsRepo();
+        test2.setRepoUrl(repoUrl);
+        test2.setBranch(branch);
+        test2.setScriptsPath(scriptsPath);
+        assertThat(test).isEqualTo(test2);
+        assertThat(test.hashCode()).isEqualTo(test2.hashCode());
+    }
+
+    @Test
+    void testCanEqual() {
+        assertThat(test.canEqual("other")).isFalse();
+        assertThat(test.canEqual(new ScriptsRepo())).isTrue();
+    }
+
+    @Test
+    void testToString() throws Exception {
+        String result = "ScriptsRepo(repoUrl=" + repoUrl
+                + ", branch=" + branch
+                + ", scriptsPath=" + scriptsPath + ")";
+        assertThat(test.toString()).isEqualTo(result);
+    }
+}

--- a/modules/models/src/test/java/org/eclipse/xpanse/modules/models/servicetemplate/ServiceProviderContactDetailsTest.java
+++ b/modules/models/src/test/java/org/eclipse/xpanse/modules/models/servicetemplate/ServiceProviderContactDetailsTest.java
@@ -1,0 +1,66 @@
+package org.eclipse.xpanse.modules.models.servicetemplate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class ServiceProviderContactDetailsTest {
+
+    private final List<String> email = List.of("test@email");
+    private final List<String> phone = List.of("110000000");
+    private final List<String> chat = List.of("chat");
+    private final List<String> website = List.of("website");
+
+    private ServiceProviderContactDetails test;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        test = new ServiceProviderContactDetails();
+        test.setEmail(email);
+        test.setPhone(phone);
+        test.setChat(chat);
+        test.setWebsite(website);
+    }
+
+    @Test
+    void testGetters() {
+        assertThat(test.getEmail()).isEqualTo(email);
+        assertThat(test.getPhone()).isEqualTo(phone);
+        assertThat(test.getChat()).isEqualTo(chat);
+        assertThat(test.getWebsite()).isEqualTo(website);
+    }
+
+    @Test
+    void testEqualsAndHashCode() {
+        Object obj = new Object();
+        assertThat(test).isNotEqualTo(obj);
+        assertThat(test.hashCode()).isNotEqualTo(obj.hashCode());
+        ServiceProviderContactDetails test1 = new ServiceProviderContactDetails();
+        assertThat(test).isNotEqualTo(test1);
+        assertThat(test.hashCode()).isNotEqualTo(test1.hashCode());
+        ServiceProviderContactDetails test2 = new ServiceProviderContactDetails();
+        test2.setEmail(email);
+        test2.setPhone(phone);
+        test2.setChat(chat);
+        test2.setWebsite(website);
+        assertThat(test).isEqualTo(test2);
+        assertThat(test.hashCode()).isEqualTo(test2.hashCode());
+    }
+
+    @Test
+    void testCanEqual() {
+        assertThat(test.canEqual("other")).isFalse();
+        assertThat(test.canEqual(new ServiceProviderContactDetails())).isTrue();
+    }
+
+    @Test
+    void testToString() throws Exception {
+        String result = "ServiceProviderContactDetails(email=" + email
+                + ", phone=" + phone + ", chat=" + chat
+                + ", website=" + website + ")";
+        assertThat(test.toString()).isEqualTo(result);
+    }
+
+}

--- a/modules/models/src/test/java/org/eclipse/xpanse/modules/models/workflow/migrate/MigrateRequestTest.java
+++ b/modules/models/src/test/java/org/eclipse/xpanse/modules/models/workflow/migrate/MigrateRequestTest.java
@@ -1,48 +1,111 @@
 package org.eclipse.xpanse.modules.models.workflow.migrate;
 
+import static org.assertj.core.api.Assertions.as;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.util.Collections;
+import java.util.Map;
 import java.util.UUID;
+import org.eclipse.xpanse.modules.models.common.enums.Category;
+import org.eclipse.xpanse.modules.models.common.enums.Csp;
+import org.eclipse.xpanse.modules.models.servicetemplate.Region;
+import org.eclipse.xpanse.modules.models.servicetemplate.enums.ServiceHostingType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.BeanUtils;
 
 class MigrateRequestTest {
 
-    private MigrateRequest migrateRequestUnderTest;
+    private final UUID id = UUID.fromString("ed6248d4-2bcd-4e94-84b0-29e014c05137");
+    private final String userId = "userId" ;
+    private final Category category = Category.COMPUTE;
+    private final String serviceName = "service" ;
+    private final String customerServiceName = "customerService" ;
+    private final String version = "1.0" ;
+    private final String regionName = "us-east-1" ;
+    private final String areaName = "Asia China" ;
+    private final Region region = new Region();
+    private final Csp csp = Csp.AWS;
+    private final String flavor = "flavor" ;
+    private final ServiceHostingType serviceHostingType = ServiceHostingType.SELF;
+    private final Map<String, Object> properties = Collections.singletonMap("key", "value");
+    private final Map<String, String> availabilityZones = Collections.singletonMap("key", "value");
+    private MigrateRequest request;
 
     @BeforeEach
     void setUp() {
-        migrateRequestUnderTest = new MigrateRequest();
+        request = new MigrateRequest();
+        request.setId(id);
+        request.setUserId(userId);
+        request.setCategory(category);
+        request.setServiceName(serviceName);
+        request.setCustomerServiceName(customerServiceName);
+        request.setVersion(version);
+        region.setArea(areaName);
+        region.setName(regionName);
+        request.setRegion(region);
+        request.setCsp(csp);
+        request.setFlavor(flavor);
+        request.setServiceRequestProperties(properties);
+        request.setServiceHostingType(serviceHostingType);
+        request.setAvailabilityZones(availabilityZones);
     }
 
     @Test
-    void testIdGetterAndSetter() {
-        final UUID id = UUID.fromString("c490ed22-e795-4ef1-a92e-349b14982892");
-        migrateRequestUnderTest.setId(id);
-        assertThat(migrateRequestUnderTest.getId()).isEqualTo(id);
+    void testGetterAndSetter() {
+        assertEquals(id, request.getId());
+        assertEquals(userId, request.getUserId());
+        assertEquals(category, request.getCategory());
+        assertEquals(serviceName, request.getServiceName());
+        assertEquals(customerServiceName, request.getCustomerServiceName());
+        assertEquals(version, request.getVersion());
+        assertEquals(region, request.getRegion());
+        assertEquals(areaName, request.getRegion().getArea());
+        assertEquals(regionName, request.getRegion().getName());
+        assertEquals(csp, request.getCsp());
+        assertEquals(flavor, request.getFlavor());
+        assertEquals(properties, request.getServiceRequestProperties());
+        assertEquals(availabilityZones, request.getAvailabilityZones());
+        assertEquals(serviceHostingType, request.getServiceHostingType());
     }
 
     @Test
-    void testEquals() {
-        assertThat(migrateRequestUnderTest.equals("o")).isFalse();
+    void testEqualsAndHashCode() {
+        Object obj = new Object();
+        assertThat(request).isNotEqualTo(obj);
+        assertThat(request.hashCode()).isNotEqualTo(obj.hashCode());
+        MigrateRequest test1 = new MigrateRequest();
+        assertThat(request).isNotEqualTo(test1);
+        assertThat(request.hashCode()).isNotEqualTo(test1.hashCode());
+        MigrateRequest test2 = new MigrateRequest();
+        BeanUtils.copyProperties(request, test2);
+        assertThat(request).isEqualTo(test2);
+        assertThat(request.hashCode()).isEqualTo(test2.hashCode());
     }
 
     @Test
     void testCanEqual() {
-        assertThat(migrateRequestUnderTest.canEqual("other")).isFalse();
+        assertThat(request.canEqual("other")).isFalse();
+        assertThat(request.canEqual(new MigrateRequest())).isTrue();
     }
 
-    @Test
-    void testHashCode() {
-        MigrateRequest test = new MigrateRequest();
-        assertThat(migrateRequestUnderTest.hashCode()).isEqualTo(test.hashCode());
-    }
 
     @Test
     void testToString() {
-        String result = "MigrateRequest(super=DeployRequestBase(userId=null, category=null, "
-                + "serviceName=null, customerServiceName=null, version=null, region=null, csp=null,"
-                + " flavor=null, serviceHostingType=null, serviceRequestProperties=null), id=null)";
-        assertThat(migrateRequestUnderTest.toString()).isEqualTo(result);
+        String expectedToString = "MigrateRequest(super=DeployRequestBase(" +
+                "userId=" + userId +
+                ", category=" + category +
+                ", serviceName=" + serviceName +
+                ", customerServiceName=" + customerServiceName +
+                ", version=" + version +
+                ", region=" + region +
+                ", csp=" + csp +
+                ", flavor=" + flavor +
+                ", serviceHostingType=" + serviceHostingType +
+                ", serviceRequestProperties=" + properties +
+                ", availabilityZones=" + availabilityZones +
+                "), id=" + id + ")" ;
+        assertEquals(expectedToString, request.toString());
     }
 }

--- a/modules/orchestrator/src/main/java/org/eclipse/xpanse/modules/orchestrator/deployment/Deployer.java
+++ b/modules/orchestrator/src/main/java/org/eclipse/xpanse/modules/orchestrator/deployment/Deployer.java
@@ -7,7 +7,7 @@
 package org.eclipse.xpanse.modules.orchestrator.deployment;
 
 import java.util.UUID;
-import org.eclipse.xpanse.modules.models.servicetemplate.Ocl;
+import org.eclipse.xpanse.modules.models.servicetemplate.Deployment;
 import org.eclipse.xpanse.modules.models.servicetemplate.enums.DeployerKind;
 
 /**
@@ -29,7 +29,7 @@ public interface Deployer {
 
     DeployerKind getDeployerKind();
 
-    DeploymentScriptValidationResult validate(Ocl ocl);
+    DeploymentScriptValidationResult validate(Deployment deployment);
 
     /**
      * Method to get the changes the infrastructure changes the service deployment would do for a

--- a/modules/servicetemplate/src/main/java/org/eclipse/xpanse/modules/servicetemplate/utils/AvailabilityZoneSchemaValidator.java
+++ b/modules/servicetemplate/src/main/java/org/eclipse/xpanse/modules/servicetemplate/utils/AvailabilityZoneSchemaValidator.java
@@ -1,0 +1,49 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * SPDX-FileCopyrightText: Huawei Inc.
+ *
+ */
+
+package org.eclipse.xpanse.modules.servicetemplate.utils;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import lombok.extern.slf4j.Slf4j;
+import org.eclipse.xpanse.modules.models.servicetemplate.AvailabilityZoneConfig;
+import org.eclipse.xpanse.modules.models.servicetemplate.exceptions.InvalidValueSchemaException;
+
+/**
+ * Validate the availability of deployment variables.
+ */
+@Slf4j
+public class AvailabilityZoneSchemaValidator {
+
+    /**
+     * Define a method to verify automatic filling of deployment variables.
+     *
+     * @param availabilityZones The availability zone config list.
+     */
+    public static void validateServiceAvailability(List<AvailabilityZoneConfig> availabilityZones) {
+
+        if (Objects.isNull(availabilityZones)) {
+            return;
+        }
+        if (availabilityZones.isEmpty()) {
+            String errorMessage = "The availability zone configuration list could not be empty.";
+            throw new InvalidValueSchemaException(List.of(errorMessage));
+        }
+        Set<String> availabilityVarName = new HashSet<>();
+        for (AvailabilityZoneConfig availabilityZone : availabilityZones) {
+            if (availabilityVarName.contains(availabilityZone.getVarName())) {
+                String errorMessage = String.format(
+                        "The availability zone configuration list with duplicated variable name %s",
+                        availabilityZone.getVarName());
+                throw new InvalidValueSchemaException(List.of(errorMessage));
+            } else {
+                availabilityVarName.add(availabilityZone.getVarName());
+            }
+        }
+    }
+}

--- a/modules/servicetemplate/src/test/java/org/eclipse/xpanse/modules/servicetemplate/utils/AvailabilityZoneSchemaValidatorTest.java
+++ b/modules/servicetemplate/src/test/java/org/eclipse/xpanse/modules/servicetemplate/utils/AvailabilityZoneSchemaValidatorTest.java
@@ -1,0 +1,41 @@
+package org.eclipse.xpanse.modules.servicetemplate.utils;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.eclipse.xpanse.modules.models.servicetemplate.AvailabilityZoneConfig;
+import org.eclipse.xpanse.modules.models.servicetemplate.exceptions.InvalidValueSchemaException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class AvailabilityZoneSchemaValidatorTest {
+    @Test
+    void testValidateServiceAvailability() {
+        // Setup
+        final List<AvailabilityZoneConfig> availabilityZones = new ArrayList<>();
+        // Run the test
+        Assertions.assertThrows(InvalidValueSchemaException.class, () ->
+                AvailabilityZoneSchemaValidator.validateServiceAvailability(availabilityZones));
+
+        final AvailabilityZoneConfig availabilityZoneConfig = new AvailabilityZoneConfig();
+        availabilityZoneConfig.setDisplayName("displayName");
+        availabilityZoneConfig.setVarName("varName");
+        availabilityZoneConfig.setMandatory(false);
+        availabilityZoneConfig.setDescription("description");
+        availabilityZones.add(availabilityZoneConfig);
+
+        // Run the test
+        Assertions.assertDoesNotThrow(() ->
+                AvailabilityZoneSchemaValidator.validateServiceAvailability(availabilityZones));
+
+        final AvailabilityZoneConfig availabilityZoneConfig1 = new AvailabilityZoneConfig();
+        availabilityZoneConfig1.setDisplayName("displayName1");
+        availabilityZoneConfig1.setVarName("varName");
+        availabilityZoneConfig1.setMandatory(false);
+        availabilityZoneConfig1.setDescription("description1");
+
+        availabilityZones.add(availabilityZoneConfig1);
+        // Run the test
+        Assertions.assertThrows(InvalidValueSchemaException.class, () ->
+                AvailabilityZoneSchemaValidator.validateServiceAvailability(availabilityZones));
+    }
+}

--- a/modules/servicetemplate/src/test/java/org/eclipse/xpanse/modules/servicetemplate/utils/DeployVariableAutoFillValidatorTest.java
+++ b/modules/servicetemplate/src/test/java/org/eclipse/xpanse/modules/servicetemplate/utils/DeployVariableAutoFillValidatorTest.java
@@ -1,0 +1,54 @@
+package org.eclipse.xpanse.modules.servicetemplate.utils;
+
+import java.util.List;
+import org.eclipse.xpanse.modules.models.service.deploy.enums.DeployResourceKind;
+import org.eclipse.xpanse.modules.models.servicetemplate.AutoFill;
+import org.eclipse.xpanse.modules.models.servicetemplate.DeployVariable;
+import org.eclipse.xpanse.modules.models.servicetemplate.enums.DeployVariableDataType;
+import org.eclipse.xpanse.modules.models.servicetemplate.enums.DeployVariableKind;
+import org.eclipse.xpanse.modules.models.servicetemplate.exceptions.InvalidValueSchemaException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class DeployVariableAutoFillValidatorTest {
+
+
+    @Test
+    void testValidateDeployVariableAutoFill() {
+        // Setup
+        final DeployVariable deployVariable = new DeployVariable();
+        deployVariable.setName("name");
+        deployVariable.setKind(DeployVariableKind.FIX_ENV);
+        deployVariable.setDataType(DeployVariableDataType.STRING);
+        deployVariable.setExample("example");
+        deployVariable.setMandatory(true);
+        final AutoFill autoFill = new AutoFill();
+        autoFill.setDeployResourceKind(DeployResourceKind.VPC);
+        deployVariable.setAutoFill(autoFill);
+        final List<DeployVariable> deployVariables = List.of(deployVariable);
+
+        // Run the test
+        Assertions.assertDoesNotThrow(() ->
+                DeployVariableAutoFillValidator.validateDeployVariableAutoFill(deployVariables));
+    }
+
+    @Test
+    void testValidateDeployVariableAutoFillThrowsException() {
+        // Setup
+        final DeployVariable deployVariable = new DeployVariable();
+        deployVariable.setName("name");
+        deployVariable.setKind(DeployVariableKind.FIX_ENV);
+        deployVariable.setDataType(DeployVariableDataType.STRING);
+        deployVariable.setExample("example");
+        deployVariable.setMandatory(true);
+        final AutoFill autoFill = new AutoFill();
+        autoFill.setDeployResourceKind(DeployResourceKind.SUBNET);
+        deployVariable.setAutoFill(autoFill);
+        final List<DeployVariable> deployVariables = List.of(deployVariable);
+
+        // Run the test
+        Assertions.assertThrows(InvalidValueSchemaException.class, () ->
+                DeployVariableAutoFillValidator.validateDeployVariableAutoFill(
+                        deployVariables));
+    }
+}

--- a/runtime/src/test/resources/ocl_opentofu_test.yml
+++ b/runtime/src/test/resources/ocl_opentofu_test.yml
@@ -47,6 +47,11 @@ serviceProviderContactDetails:
 deployment:
   # kind, Supported values are terraform, opentofu.
   kind: terraform
+  serviceAvailability:
+    - displayName: Availability Zone
+      varName: availability_zone
+      mandatory: false
+      description: The availability zone to deploy the service instance. If the value is empty, the service instance will be deployed in a random availability zone.
   # Context for deployment: the context including some kind of parameters for the deployment, such as fix_env, fix_variable, env, variable, env_env, env_variable.
   # - fix_env: Values for variable of this type are defined by the managed service provider in the OCL template. Runtime will inject it to deployer as environment variables. This variable is not visible to the end user.
   # - fix_variable: Values for variable of this type are defined by the managed service provider in the OCL template. Runtime will inject it to deployer as usual variables. This variable is not visible to the end user.
@@ -87,10 +92,19 @@ deployment:
       mandatory: false
       value: "secgroup-default"
   deployer: |
+    variable "region" {
+      type        = string
+      description = "The region to deploy the service instance."
+    }
+    
     variable "flavor_id" {
       type        = string
-      default     = "s6.large.2"
       description = "The flavor id of the service instance."
+    }
+    
+    variable "availability_zone" {
+      type        = string
+      description = "The availability zone of the service instance."
     }
 
     variable "admin_passwd" {
@@ -115,12 +129,6 @@ deployment:
       type        = string
       default     = "secgroup-default"
       description = "The security group name of the service instance."
-    }
-    
-    variable "region" {
-      type        = string
-      default     = "cn-southwest-2"
-      description = "The region to deploy the service instance."
     }
     
     terraform {
@@ -152,6 +160,14 @@ deployment:
 
     output "flavor_id" {
       value = var.flavor_id
+    }
+    
+    output "region" {
+      value = var.region
+    }
+    
+    output "availability_zone" {
+      value = var.availability_zone == "" ? "" : var.availability_zone
     }
 
     output "vpc_name" {

--- a/runtime/src/test/resources/ocl_terraform_test.yml
+++ b/runtime/src/test/resources/ocl_terraform_test.yml
@@ -47,6 +47,11 @@ serviceProviderContactDetails:
 deployment:
   # kind, Supported values are terraform, opentofu.
   kind: terraform
+  serviceAvailability:
+    - displayName: Availability Zone
+      varName: availability_zone
+      mandatory: true
+      description: The availability zone to deploy the service instance. If the value is empty, the service instance will be deployed in a random availability zone.
   # Context for deployment: the context including some kind of parameters for the deployment, such as fix_env, fix_variable, env, variable, env_env, env_variable.
   # - fix_env: Values for variable of this type are defined by the managed service provider in the OCL template. Runtime will inject it to deployer as environment variables. This variable is not visible to the end user.
   # - fix_variable: Values for variable of this type are defined by the managed service provider in the OCL template. Runtime will inject it to deployer as usual variables. This variable is not visible to the end user.
@@ -87,10 +92,19 @@ deployment:
       mandatory: false
       value: "secgroup-default"
   deployer: |
+    variable "region" {
+      type        = string
+      description = "The region to deploy the service instance."
+    }
+    
     variable "flavor_id" {
       type        = string
-      default     = "s6.large.2"
       description = "The flavor id of the service instance."
+    }
+    
+    variable "availability_zone" {
+      type        = string
+      description = "The availability zone of the service instance."
     }
 
     variable "admin_passwd" {
@@ -115,12 +129,6 @@ deployment:
       type        = string
       default     = "secgroup-default"
       description = "The security group name of the service instance."
-    }
-    
-    variable "region" {
-      type        = string
-      default     = "cn-southwest-2"
-      description = "The region to deploy the service instance."
     }
     
     terraform {
@@ -152,6 +160,14 @@ deployment:
 
     output "flavor_id" {
       value = var.flavor_id
+    }
+    
+    output "region" {
+      value = var.region
+    }
+    
+    output "availability_zone" {
+      value = var.availability_zone == "" ? "" : var.availability_zone
     }
 
     output "vpc_name" {

--- a/runtime/src/test/resources/ocl_terraform_update.yml
+++ b/runtime/src/test/resources/ocl_terraform_update.yml
@@ -47,6 +47,11 @@ serviceProviderContactDetails:
 deployment:
   # kind, Supported values are terraform, opentofu.
   kind: terraform
+  serviceAvailability:
+    - displayName: Availability Zone
+      varName: availability_zone
+      mandatory: false
+      description: The availability zone to deploy the service instance. If the value is empty, the service instance will be deployed in a random availability zone.
   # Context for deployment: the context including some kind of parameters for the deployment, such as fix_env, fix_variable, env, variable, env_env, env_variable.
   # - fix_env: Values for variable of this type are defined by the managed service provider in the OCL template. Runtime will inject it to deployer as environment variables. This variable is not visible to the end user.
   # - fix_variable: Values for variable of this type are defined by the managed service provider in the OCL template. Runtime will inject it to deployer as usual variables. This variable is not visible to the end user.
@@ -87,10 +92,19 @@ deployment:
       mandatory: false
       value: "secgroup-default"
   deployer: |
+    variable "region" {
+      type        = string
+      description = "The region to deploy the service instance."
+    }
+    
     variable "flavor_id" {
       type        = string
-      default     = "s6.large.2"
       description = "The flavor id of the service instance."
+    }
+    
+    variable "availability_zone" {
+      type        = string
+      description = "The availability zone of the service instance."
     }
 
     variable "admin_passwd" {
@@ -115,12 +129,6 @@ deployment:
       type        = string
       default     = "secgroup-default"
       description = "The security group name of the service instance."
-    }
-    
-    variable "region" {
-      type        = string
-      default     = "cn-southwest-2"
-      description = "The region to deploy the service instance."
     }
     
     terraform {
@@ -152,6 +160,14 @@ deployment:
 
     output "flavor_id" {
       value = var.flavor_id
+    }
+    
+    output "region" {
+      value = var.region
+    }
+    
+    output "availability_zone" {
+      value = var.availability_zone == "" ? "" : var.availability_zone
     }
 
     output "vpc_name" {

--- a/samples/develop/flexibleEngine-compute-terraform-dev.yml
+++ b/samples/develop/flexibleEngine-compute-terraform-dev.yml
@@ -1,25 +1,25 @@
 # The version of the Xpanse description language
 version: 1.0
 # The category of the service.
-category: middleware
+category: compute
 # The Service provided by the ISV, the name will be shown on the console as a service.
-name: Kafka-cluster
+name: terraform-ecs
 # The version of the service, the end-user can select the version they want to deploy.
 serviceVersion: v1.0.0
 # For the users may have more than one service, the @namespace can be used to separate the clusters.
-description: This is an enhanced Kafka cluster services by ISV-A.
+description: This is an ehanced compute services by ISV-A.
 namespace: ISV-A
 # Icon for the service.
 icon: |
   data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAGQAAACRAQMAAAAPc4+9AAAAAXNSR0IB2cksfwAAAAlwSFlzAAALEwAACxMBAJqcGAAAAAZQTFRF+/v7Hh8gVD0A0wAAAcVJREFUeJzNlc1twzAMhSX44KNH0CgaTd6gK3kUd4McDVTwq/hjiUyaIkV7qNA2/QCFIh+ppxB+svLNEqqBGTC0ANugBOwmCGDCFOAwIWGDOoqoODtN2BdL6wxD9NMTO9tXPa1PqL5M30W5p8lm5vNcF0t7ahSrVguqNqmMokRW4YQucVjBCBWH1Z2g3WDlW2skoYU+2x8JOtGedBF3k2iXMO0j16iUiI6gxzPdQhnU/s2G9pCO57QY2r6hvjPbKJHq7DRTRXT60avtuTRdbrFJI3mSZhNOqYjVbd99YyK1QKWzEqSWrE0k07U60uPaelflMzaaeu1KBuurHSsn572I1KWy2joX5ZBfWbS/VEt50H5P6aL4JxTuyJ/+QCNPX4PWF3Q8Xe1eF9FsLdD2VaOnaP2hWvs+zI58/7i3vH3nRFtDZpyTUNaZkON5XnBNsp8lrmDMrpvBr+b6pUl+4XbkQdndqnzYGzfuJm1JmIWimIbe6dndd/bk7gVce/cJdo3uIeLJl7+I2xTnPek67mjtDeppE7b03Ov+kSfDe3JweW53njxeGfXkaz28VeYd86+af/H8a7hgJKaebILaFzakLfxyfQLTxVB6K1K9KQAAAABJRU5ErkJggg==
 # Reserved for CSP, aws,azure,ali,huawei and ...
 cloudServiceProvider:
-  name: huawei
+  name: flexibleengine
   regions:
-    - name: cn-southwest-2
-      area: Asia China
-    - name: cn-north-4
-      area: Asia China
+    - name: eu-west-0
+      area: Western Europe
+    - name: eu-west-1
+      area: Western Europe
 billing:
   # The business model(`flat`, `exponential`, ...)
   model: flat
@@ -30,37 +30,39 @@ billing:
 serviceHostingType: self
 # The flavor of the service, the @category/@name/@version/@flavor can locate the specific service to be deployed.
 flavors:
-  - name: 1-zookeeper-with-3-worker-nodes-normal
+  - name: flavor-error-test
+    # The fixed price during the period (the price applied one shot whatever is the service use)
+    fixedPrice: 10
+    # Properties for the service, which can be used by the deployment.
+    properties:
+      flavor_id: s6.small.1
+  - name: 2vCPUs-4GB-normal
+    # The fixed price during the period (the price applied one shot whatever is the service use)
+    fixedPrice: 20
+    # Properties for the service, which can be used by the deployment.
+    properties:
+      flavor_id: s6.large.2
+  - name: 2vCPUs-8GB-normal
+    # The fixed price during the period (the price applied one shot whatever is the service use)
+    fixedPrice: 30
+    # Properties for the service, which can be used by the deployment.
+    properties:
+      flavor_id: s6.large.4
+  - name: 4vCPUs-8GB-normal
     # The fixed price during the period (the price applied one shot whatever is the service use)
     fixedPrice: 40
     # Properties for the service, which can be used by the deployment.
     properties:
-      worker_nodes_count: 3
-      flavor_id: s6.large.4
-  - name: 1-zookeeper-with-3-worker-nodes-performance
+      flavor_id: s6.xlarge.2
+  - name: 4vCPUs-16GB-normal
     # The fixed price during the period (the price applied one shot whatever is the service use)
-    fixedPrice: 60
+    fixedPrice: 50
     # Properties for the service, which can be used by the deployment.
     properties:
-      worker_nodes_count: 3
-      flavor_id: s6.xlarge.4
-  - name: 1-zookeeper-with-5-worker-nodes-normal
-    # The fixed price during the period (the price applied one shot whatever is the service use)
-    fixedPrice: 60
-    # Properties for the service, which can be used by the deployment.
-    properties:
-      worker_nodes_count: 5
-      flavor_id: s6.large.4
-  - name: 1-zookeeper-with-5-worker-nodes-performance
-    # The fixed price during the period (the price applied one shot whatever is the service use)
-    fixedPrice: 80
-    # Properties for the service, which can be used by the deployment.
-    properties:
-      worker_nodes_count: 5
       flavor_id: s6.xlarge.4
 # The contact details of the service.
 serviceProviderContactDetails:
-  email: ["test@test.com"]
+  email: [ "test@test.com" ]
 deployment:
   # kind, Supported values are terraform, opentofu.
   kind: terraform
@@ -79,7 +81,7 @@ deployment:
   # The parameters will be used to generate the API of the managed service.
   variables:
     - name: admin_passwd
-      description: The admin password of all nodes in the Kafka cluster instance. If the value is empty, will create a random password.
+      description: The admin password of the compute instance. If the value is empty, will create a random password.
       kind: variable
       dataType: string
       mandatory: false
@@ -87,131 +89,143 @@ deployment:
         minLength: 8
         maxLength: 16
         pattern: ^(?=.*?[A-Z])(?=.*?[a-z])(?=.*?[0-9])(?=.*?[#?!@$%^&*-]).{8,16}$
+    - name: image_name
+      description: The image name of the compute instance. If the value is empty, will use the default value to create compute instance.
+      kind: variable
+      dataType: string
+      example: "OBS Ubuntu 22.04"
+      mandatory: false
+      value: "OBS Ubuntu 22.04"
     - name: vpc_name
-      description: The vpc name of all nodes in the Kafka cluster instance. If the value is empty, will use the default value to find or create VPC.
+      description: The vpc name of the compute instance. If the value is empty, will use the default value to find or create VPC.
       kind: variable
       dataType: string
-      example: "kafka-vpc-default"
+      example: "ecs-vpc-default"
       mandatory: false
-      value: "kafka-vpc-default"
+      value: "ecs-vpc-default"
     - name: subnet_name
-      description: The sub network name of all nodes in the Kafka cluster instance. If the value is empty, will use the default value to find or create subnet.
+      description: The sub network name of the compute instance. If the value is empty, will use the default value to find or create subnet.
       kind: variable
       dataType: string
-      example: "kafka-subnet-default"
+      example: "ecs-subnet-default"
       mandatory: false
-      value: "kafka-subnet-default"
+      value: "ecs-subnet-default"
     - name: secgroup_name
-      description: The security group name of all nodes in the Kafka cluster instance. If the value is empty, will use the default value to find or create security group.
+      description: The security group name of the compute instance. If the value is empty, will use the default value to find or create security group.
       kind: variable
       dataType: string
-      example: "kafka-secgroup-default"
+      example: "ecs-secgroup-default"
       mandatory: false
-      value: "kafka-secgroup-default"
+      value: "ecs-secgroup-default"
   deployer: |
     variable "region" {
       type        = string
-      description = "The region to deploy the Kafka cluster instance."
+      description = "The region to deploy the compute instance."
     }
     
     variable "availability_zone" {
       type        = string
-      description = "The availability zone to deploy the Kafka cluster instance."
+      description = "The availability zone to deploy the compute instance."
     }
     
     variable "flavor_id" {
       type        = string
       default     = "s6.large.2"
-      description = "The flavor_id of all nodes in the Kafka cluster instance."
+      description = "The flavor_id of the compute instance."
     }
-
-    variable "worker_nodes_count" {
+    
+    variable "image_name" {
       type        = string
-      default     = 3
-      description = "The worker nodes count in the Kafka cluster instance."
+      default     = "OBS Ubuntu 22.04"
+      description = "The image name of the compute instance."
     }
-
+    
     variable "admin_passwd" {
       type        = string
       default     = ""
-      description = "The root password of all nodes in the Kafka cluster instance."
+      description = "The root password of the compute instance."
     }
 
     variable "vpc_name" {
       type        = string
-      default     = "kafka-vpc-default"
-      description = "The vpc name of all nodes in the Kafka cluster instance."
+      default     = "ecs-vpc-default"
+      description = "The vpc name of the compute instance."
     }
-
+    
     variable "subnet_name" {
       type        = string
-      default     = "kafka-subnet-default"
-      description = "The subnet name of all nodes in the Kafka cluster instance."
+      default     = "ecs-subnet-default"
+      description = "The subnet name of the compute instance."
     }
 
     variable "secgroup_name" {
       type        = string
-      default     = "kafka-secgroup-default"
-      description = "The security group name of all nodes in the Kafka cluster instance."
+      default     = "ecs-secgroup-default"
+      description = "The security group name of the compute instance."
     }
     
     terraform {
       required_providers {
-        huaweicloud = {
-          source  = "huaweicloud/huaweicloud"
-          version = "~> 1.61.0"
+        flexibleengine = {
+          source  = "FlexibleEngineCloud/flexibleengine"
+          version = "~> 1.45.0"
         }
       }
     }
     
-    provider "huaweicloud" {
+    provider "flexibleengine" {
       region = var.region
     }
-    
-    data "huaweicloud_availability_zones" "osc-az" {}
 
-    data "huaweicloud_vpcs" "existing" {
-      name = var.vpc_name
+    data "flexibleengine_availability_zones" "osc-az" {}
+
+    data "flexibleengine_vpc_v1" "existing" {
+      name  = var.vpc_name
+      count = length(data.flexibleengine_vpc_v1.existing)
     }
 
-    data "huaweicloud_vpc_subnets" "existing" {
-      name = var.subnet_name
+    data "flexibleengine_vpc_subnet_v1" "existing" {
+      name    = var.subnet_name
+      count = length(data.flexibleengine_vpc_subnet_v1.existing)
     }
 
-    data "huaweicloud_networking_secgroups" "existing" {
-      name = var.secgroup_name
+    data "flexibleengine_networking_secgroup_v2" "existing" {
+      name  = var.secgroup_name
+      count = length(data.flexibleengine_networking_secgroup_v2.existing)
     }
 
     locals {
-      availability_zone = var.availability_zone == "" ? data.huaweicloud_availability_zones.osc-az.names[0] : var.availability_zone
+      availability_zone = var.availability_zone == "" ? data.flexibleengine_availability_zones.osc-az.names[0] : var.availability_zone
       admin_passwd      = var.admin_passwd == "" ? random_password.password.result : var.admin_passwd
-      vpc_id            = length(data.huaweicloud_vpcs.existing.vpcs) > 0 ? data.huaweicloud_vpcs.existing.vpcs[0].id : huaweicloud_vpc.new[0].id
-      subnet_id         = length(data.huaweicloud_vpc_subnets.existing.subnets)> 0 ? data.huaweicloud_vpc_subnets.existing.subnets[0].id : huaweicloud_vpc_subnet.new[0].id
-      secgroup_id       = length(data.huaweicloud_networking_secgroups.existing.security_groups) > 0 ? data.huaweicloud_networking_secgroups.existing.security_groups[0].id : huaweicloud_networking_secgroup.new[0].id
+      vpc_id            = length(data.flexibleengine_vpc_v1.existing) > 0 ? data.flexibleengine_vpc_v1.existing[0].id : flexibleengine_vpc_v1.new[0].id
+      subnet_id         = length(data.flexibleengine_vpc_subnet_v1.existing) > 0 ? data.flexibleengine_vpc_subnet_v1.existing[0].id : flexibleengine_vpc_subnet_v1.new[0].id
+      secgroup_id       = length(data.flexibleengine_networking_secgroup_v2.existing) > 0 ? data.flexibleengine_networking_secgroup_v2.existing[0].id : flexibleengine_networking_secgroup_v2.new[0].id
+      secgroup_name     = length(data.flexibleengine_networking_secgroup_v2.existing) > 0 ? data.flexibleengine_networking_secgroup_v2.existing[0].name : flexibleengine_networking_secgroup_v2.new[0].name
     }
 
-    resource "huaweicloud_vpc" "new" {
-      count = length(data.huaweicloud_vpcs.existing.vpcs) == 0 ? 1 : 0
-      name  = var.vpc_name
+    resource "flexibleengine_vpc_v1" "new" {
+      count = length(data.flexibleengine_vpc_v1.existing) == 0 ? 1 : 0
+      name  = "${var.vpc_name}-${random_id.new.hex}"
       cidr  = "192.168.0.0/16"
     }
 
-    resource "huaweicloud_vpc_subnet" "new" {
-      count      = length(data.huaweicloud_vpcs.existing.vpcs) == 0 ? 1 : 0
+    resource "flexibleengine_vpc_subnet_v1" "new" {
+      count      = length(data.flexibleengine_vpc_subnet_v1.existing) == 0 ? 1 : 0
       vpc_id     = local.vpc_id
-      name       = var.subnet_name
+      name       = "${var.subnet_name}-${random_id.new.hex}"
       cidr       = "192.168.10.0/24"
       gateway_ip = "192.168.10.1"
+      dns_list   = ["100.125.0.41","100.125.12.161"]
     }
 
-    resource "huaweicloud_networking_secgroup" "new" {
-      count       = length(data.huaweicloud_networking_secgroups.existing.security_groups) == 0 ? 1 : 0
-      name        = var.secgroup_name
-      description = "Kafka cluster security group"
+    resource "flexibleengine_networking_secgroup_v2" "new" {
+      count       = length(data.flexibleengine_networking_secgroup_v2.existing) == 0 ? 1 : 0
+      name        = "${var.secgroup_name}-${random_id.new.hex}"
+      description = "Compute security group"
     }
 
-    resource "huaweicloud_networking_secgroup_rule" "secgroup_rule_0" {
-      count             = length(data.huaweicloud_networking_secgroups.existing.security_groups) == 0 ? 1 : 0
+    resource "flexibleengine_networking_secgroup_rule_v2" "secgroup_rule_0" {
+      count             = length(data.flexibleengine_networking_secgroup_v2.existing) == 0 ? 1 : 0
       direction         = "ingress"
       ethertype         = "IPv4"
       protocol          = "tcp"
@@ -221,24 +235,24 @@ deployment:
       security_group_id = local.secgroup_id
     }
 
-    resource "huaweicloud_networking_secgroup_rule" "secgroup_rule_1" {
-      count             = length(data.huaweicloud_networking_secgroups.existing.security_groups) == 0 ? 1 : 0
+    resource "flexibleengine_networking_secgroup_rule_v2" "secgroup_rule_1" {
+      count             = length(data.flexibleengine_networking_secgroup_v2.existing) == 0 ? 1 : 0
       direction         = "ingress"
       ethertype         = "IPv4"
       protocol          = "tcp"
-      port_range_min    = 2181
-      port_range_max    = 2181
+      port_range_min    = 8080
+      port_range_max    = 8088
       remote_ip_prefix  = "121.37.117.211/32"
       security_group_id = local.secgroup_id
     }
 
-    resource "huaweicloud_networking_secgroup_rule" "secgroup_rule_2" {
-      count             = length(data.huaweicloud_networking_secgroups.existing.security_groups) == 0 ? 1 : 0
+    resource "flexibleengine_networking_secgroup_rule_v2" "secgroup_rule_2" {
+      count             = length(data.flexibleengine_networking_secgroup_v2.existing) == 0 ? 1 : 0
       direction         = "ingress"
       ethertype         = "IPv4"
       protocol          = "tcp"
-      port_range_min    = 9092
-      port_range_max    = 9093
+      port_range_min    = 9090
+      port_range_max    = 9099
       remote_ip_prefix  = "121.37.117.211/32"
       security_group_id = local.secgroup_id
     }
@@ -257,61 +271,68 @@ deployment:
       override_special = "#%@"
     }
 
-    resource "huaweicloud_kps_keypair" "keypair" {
-      name     = "keypair-kafka-${random_id.new.hex}"
-      key_file = "keypair-kafka-${random_id.new.hex}.pem"
+    resource "flexibleengine_compute_keypair_v2" "keypair" {
+      name = "keypair-ecs-${random_id.new.hex}"
     }
 
-    data "huaweicloud_images_image" "image" {
-      name        = "Kafka-v3.3.2_Ubuntu-20.04"
+    data "flexibleengine_images_image" "image" {
+      name_regex        = "^${var.image_name}"
       most_recent = true
     }
 
-    resource "huaweicloud_compute_instance" "zookeeper" {
+    resource "flexibleengine_compute_instance_v2" "ecs-tf" {
       availability_zone  = local.availability_zone
-      name               = "kafka-zookeeper-${random_id.new.hex}"
+      name               = "ecs-terraform-${random_id.new.hex}"
       flavor_id          = var.flavor_id
-      security_group_ids = [ local.secgroup_id ]
-      image_id           = data.huaweicloud_images_image.image.id
-      key_pair           = huaweicloud_kps_keypair.keypair.name
+      security_groups    = [ local.secgroup_name ]
+      image_id           = data.flexibleengine_images_image.image.id
+      key_pair           = flexibleengine_compute_keypair_v2.keypair.name
+      admin_pass         = local.admin_passwd
       network {
         uuid = local.subnet_id
       }
-      user_data = <<EOF
-        #!bin/bash
-        echo root:${local.admin_passwd} | sudo chpasswd
-        sudo systemctl start docker
-        sudo systemctl enable docker
-        sudo docker run -d --name zookeeper-server --privileged=true -p 2181:2181 -e ALLOW_ANONYMOUS_LOGIN=yes bitnami/zookeeper:3.8.1
-      EOF
     }
-
-    resource "huaweicloud_compute_instance" "kafka-broker" {
-      count              = var.worker_nodes_count
-      availability_zone  = local.availability_zone
-      name               = "kafka-broker-${random_id.new.hex}-${count.index}"
-      flavor_id          = var.flavor_id
-      security_group_ids = [ local.secgroup_id ]
-      image_id           = data.huaweicloud_images_image.image.id
-      key_pair           = huaweicloud_kps_keypair.keypair.name
-      network {
-        uuid = local.subnet_id
+    
+    resource "flexibleengine_blockstorage_volume_v2" "volume" {
+      name              = "volume-tf-${random_id.new.hex}"
+      description       = "my volume"
+      volume_type       = "SSD"
+      size              = 40
+      availability_zone = local.availability_zone
+      tags = {
+        foo = "bar"
+        key = "value"
       }
-      user_data = <<EOF
-        #!bin/bash
-        echo root:${local.admin_passwd} | sudo chpasswd
-        sudo systemctl start docker
-        sudo systemctl enable docker
-        private_ip=$(ifconfig | grep -A1 "eth0" | grep 'inet' | awk -F ' ' ' {print $2}'|awk ' {print $1}')
-        sudo docker run -d --name kafka-server --restart always -p 9092:9092 -p 9093:9093  -e KAFKA_BROKER_ID=${count.index}  -e KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://$private_ip:9092 -e KAFKA_LISTENERS=PLAINTEXT://0.0.0.0:9092 -e ALLOW_PLAINTEXT_LISTENER=yes -e KAFKA_CFG_ZOOKEEPER_CONNECT=${huaweicloud_compute_instance.zookeeper.access_ip_v4}:2181 bitnami/kafka:3.3.2
-      EOF
-      depends_on = [
-        huaweicloud_compute_instance.zookeeper
-      ]
+    }
+    
+    resource "flexibleengine_compute_volume_attach_v2" "attached" {
+      instance_id = flexibleengine_compute_instance_v2.ecs-tf.id
+      volume_id   = flexibleengine_blockstorage_volume_v2.volume.id
+    }
+    
+    resource "flexibleengine_vpc_eip" "eip-tf" {
+       publicip {
+         type = "5_bgp"
+      }
+      bandwidth {
+        name        = "eip-tf-${random_id.new.hex}"
+        size        = 5
+        share_type  = "PER"
+        charge_mode = "traffic"
+      }
+    }
+    
+    resource "flexibleengine_compute_floatingip_associate_v2" "associated" {
+      floating_ip = flexibleengine_vpc_eip.eip-tf.publicip.0.ip_address
+      instance_id = flexibleengine_compute_instance_v2.ecs-tf.id
     }
 
-    output "zookeeper_server" {
-      value = "${huaweicloud_compute_instance.zookeeper.access_ip_v4}:2181"
+    output "ecs-host" {
+      value = flexibleengine_compute_instance_v2.ecs-tf.access_ip_v4
+    }
+    
+    output "ecs-public-ip" {
+      value = flexibleengine_vpc_eip.eip-tf.address
     }
 
     output "admin_passwd" {

--- a/samples/develop/flexibleengine-compute-terraform-dev.json
+++ b/samples/develop/flexibleengine-compute-terraform-dev.json
@@ -1,0 +1,11 @@
+{
+  "serviceName": "terraform-ecs",
+  "version": "v1.0.0",
+  "csp": "flexibleengine",
+  "category": "compute",
+  "flavor": "2vCPUs-4GB-normal",
+  "region": "eu-west-0",
+  "customerServiceName": "default-terraform-ecs",
+  "serviceHostingType": "self",
+  "serviceRequestProperties": {}
+}

--- a/samples/develop/huawei-compute-opentofu-dev-autofill.yml
+++ b/samples/develop/huawei-compute-opentofu-dev-autofill.yml
@@ -66,6 +66,11 @@ serviceProviderContactDetails:
 deployment:
   # kind, Supported values are terraform, opentofu.
   kind: opentofu
+  serviceAvailability:
+    - displayName: Availability Zone
+      varName: availability_zone
+      mandatory: false
+      description: The availability zone to deploy the service instance. If the value is empty, the service instance will be deployed in a random availability zone.
   # Context for deployment: the context including some kind of parameters for the deployment, such as fix_env, fix_variable, env, variable, env_env, env_variable.
   # - fix_env: Values for variable of this type are defined by the managed service provider in the OCL template. Runtime will inject it to deployer as environment variables. This variable is not visible to the end user.
   # - fix_variable: Values for variable of this type are defined by the managed service provider in the OCL template. Runtime will inject it to deployer as usual variables. This variable is not visible to the end user.
@@ -122,6 +127,16 @@ deployment:
         deployResourceKind: security_group
         isAllowCreate: false
   deployer: |
+    variable "region" {
+      type        = string
+      description = "The region to deploy the compute instance."
+    }
+    
+    variable "availability_zone" {
+      type        = string
+      description = "The availability zone to deploy the compute instance."
+    }
+    
     variable "flavor_id" {
       type        = string
       default     = "s6.large.2"
@@ -158,12 +173,6 @@ deployment:
       description = "The security group name of the compute instance."
     }
     
-    variable "region" {
-      type        = string
-      default     = "cn-southwest-2"
-      description = "The region to deploy the compute instance."
-    }
-    
     terraform {
       required_providers {
         huaweicloud = {
@@ -176,6 +185,8 @@ deployment:
     provider "huaweicloud" {
       region = var.region
     }
+
+    data "huaweicloud_availability_zones" "osc-az" {}
 
     data "huaweicloud_vpcs" "existing" {
       name = var.vpc_name
@@ -190,10 +201,11 @@ deployment:
     }
 
     locals {
-      admin_passwd = var.admin_passwd == "" ? random_password.password.result : var.admin_passwd
-      vpc_id       = length(data.huaweicloud_vpcs.existing.vpcs) > 0 ? data.huaweicloud_vpcs.existing.vpcs[0].id : huaweicloud_vpc.new[0].id
-      subnet_id    = length(data.huaweicloud_vpc_subnets.existing.subnets)> 0 ? data.huaweicloud_vpc_subnets.existing.subnets[0].id : huaweicloud_vpc_subnet.new[0].id
-      secgroup_id  = length(data.huaweicloud_networking_secgroups.existing.security_groups) > 0 ? data.huaweicloud_networking_secgroups.existing.security_groups[0].id : huaweicloud_networking_secgroup.new[0].id
+      availability_zone = var.availability_zone == "" ? data.huaweicloud_availability_zones.osc-az.names[0] : var.availability_zone
+      admin_passwd      = var.admin_passwd == "" ? random_password.password.result : var.admin_passwd
+      vpc_id            = length(data.huaweicloud_vpcs.existing.vpcs) > 0 ? data.huaweicloud_vpcs.existing.vpcs[0].id : huaweicloud_vpc.new[0].id
+      subnet_id         = length(data.huaweicloud_vpc_subnets.existing.subnets)> 0 ? data.huaweicloud_vpc_subnets.existing.subnets[0].id : huaweicloud_vpc_subnet.new[0].id
+      secgroup_id       = length(data.huaweicloud_networking_secgroups.existing.security_groups) > 0 ? data.huaweicloud_networking_secgroups.existing.security_groups[0].id : huaweicloud_networking_secgroup.new[0].id
     }
 
     resource "huaweicloud_vpc" "new" {
@@ -249,8 +261,6 @@ deployment:
       security_group_id = local.secgroup_id
     }
 
-    data "huaweicloud_availability_zones" "osc-az" {}
-
     resource "random_id" "new" {
       byte_length = 4
     }
@@ -267,7 +277,7 @@ deployment:
 
     resource "huaweicloud_kps_keypair" "keypair" {
       name     = "keypair-ecs-${random_id.new.hex}"
-      key_file = "keypair-kafka-${random_id.new.hex}.pem"
+      key_file = "keypair-ecs-${random_id.new.hex}.pem"
     }
 
     data "huaweicloud_images_image" "image" {
@@ -275,25 +285,25 @@ deployment:
       most_recent = true
     }
 
-    resource "huaweicloud_compute_instance" "ecs-opentofu" {
-      availability_zone  = data.huaweicloud_availability_zones.osc-az.names[0]
-      name               = "ecs-opentofu-${random_id.new.hex}"
+    resource "huaweicloud_compute_instance" "ecs-tofu" {
+      availability_zone  = local.availability_zone
+      name               = "ecs-tofu-${random_id.new.hex}"
       flavor_id          = var.flavor_id
       security_group_ids = [ local.secgroup_id ]
       image_id           = data.huaweicloud_images_image.image.id
       key_pair           = huaweicloud_kps_keypair.keypair.name
-      admin_pass       = local.admin_passwd
+      admin_pass         = local.admin_passwd
       network {
         uuid = local.subnet_id
       }
     }
     
     resource "huaweicloud_evs_volume" "volume" {
-      name              = "volume-${random_id.new.hex}"
+      name              = "volume-tofu-${random_id.new.hex}"
       description       = "my volume"
       volume_type       = "SSD"
       size              = 40
-      availability_zone = data.huaweicloud_availability_zones.osc-az.names[0]
+      availability_zone = local.availability_zone
       tags = {
         foo = "bar"
         key = "value"
@@ -301,16 +311,16 @@ deployment:
     }
     
     resource "huaweicloud_compute_volume_attach" "attached" {
-      instance_id = huaweicloud_compute_instance.ecs-opentofu.id
+      instance_id = huaweicloud_compute_instance.ecs-tofu.id
       volume_id   = huaweicloud_evs_volume.volume.id
     }
     
-    resource "huaweicloud_vpc_eip" "myeip" {
+    resource "huaweicloud_vpc_eip" "eip-tofu" {
        publicip {
          type = "5_sbgp"
       }
       bandwidth {
-        name        = "mybandwidth"
+        name        = "eip-tofu-${random_id.new.hex}"
         size        = 5
         share_type  = "PER"
         charge_mode = "traffic"
@@ -318,16 +328,16 @@ deployment:
     }
     
     resource "huaweicloud_compute_eip_associate" "associated" {
-      public_ip   = huaweicloud_vpc_eip.myeip.address
-      instance_id = huaweicloud_compute_instance.ecs-opentofu.id
+      public_ip   = huaweicloud_vpc_eip.eip-tofu.address
+      instance_id = huaweicloud_compute_instance.ecs-tofu.id
     }
 
     output "ecs-host" {
-      value = huaweicloud_compute_instance.ecs-opentofu.access_ip_v4
+      value = huaweicloud_compute_instance.ecs-tofu.access_ip_v4
     }
     
     output "ecs-public-ip" {
-      value = huaweicloud_vpc_eip.myeip.address
+      value = huaweicloud_vpc_eip.eip-tofu.address
     }
 
     output "admin_passwd" {

--- a/samples/develop/huawei-compute-opentofu-dev-git-repo.yml
+++ b/samples/develop/huawei-compute-opentofu-dev-git-repo.yml
@@ -66,6 +66,11 @@ serviceProviderContactDetails:
 deployment:
   # kind, Supported values are terraform, opentofu.
   kind: opentofu
+  serviceAvailability:
+    - displayName: Availability Zone
+      varName: availability_zone
+      mandatory: false
+      description: The availability zone to deploy the service instance. If the value is empty, the service instance will be deployed in a random availability zone.
   # Context for deployment: the context including some kind of parameters for the deployment, such as fix_env, fix_variable, env, variable, env_env, env_variable.
   # - fix_env: Values for variable of this type are defined by the managed service provider in the OCL template. Runtime will inject it to deployer as environment variables. This variable is not visible to the end user.
   # - fix_variable: Values for variable of this type are defined by the managed service provider in the OCL template. Runtime will inject it to deployer as usual variables. This variable is not visible to the end user.

--- a/samples/develop/huawei-compute-opentofu-dev.yml
+++ b/samples/develop/huawei-compute-opentofu-dev.yml
@@ -66,6 +66,11 @@ serviceProviderContactDetails:
 deployment:
   # kind, Supported values are terraform, opentofu.
   kind: opentofu
+  serviceAvailability:
+    - displayName: Availability Zone
+      varName: availability_zone
+      mandatory: false
+      description: The availability zone to deploy the service instance. If the value is empty, the service instance will be deployed in a random availability zone.
   # Context for deployment: the context including some kind of parameters for the deployment, such as fix_env, fix_variable, env, variable, env_env, env_variable.
   # - fix_env: Values for variable of this type are defined by the managed service provider in the OCL template. Runtime will inject it to deployer as environment variables. This variable is not visible to the end user.
   # - fix_variable: Values for variable of this type are defined by the managed service provider in the OCL template. Runtime will inject it to deployer as usual variables. This variable is not visible to the end user.
@@ -113,10 +118,20 @@ deployment:
       mandatory: false
       value: "ecs-secgroup-default"
   deployer: |
+    variable "region" {
+      type        = string
+      description = "The region to deploy the compute instance."
+    }
+    
+    variable "availability_zone" {
+      type        = string
+      description = "The availability zone to deploy the compute instance."
+    }
+    
     variable "flavor_id" {
       type        = string
       default     = "s6.large.2"
-      description = "The flavor id of the compute instance."
+      description = "The flavor_id of the compute instance."
     }
     
     variable "image_name" {
@@ -148,12 +163,6 @@ deployment:
       default     = "ecs-secgroup-default"
       description = "The security group name of the compute instance."
     }
-     
-    variable "region" {
-      type        = string
-      default     = "cn-southwest-2"
-      description = "The region to deploy the compute instance."
-    }
     
     terraform {
       required_providers {
@@ -168,6 +177,8 @@ deployment:
       region = var.region
     }
 
+    data "huaweicloud_availability_zones" "osc-az" {}
+
     data "huaweicloud_vpcs" "existing" {
       name = var.vpc_name
     }
@@ -181,10 +192,11 @@ deployment:
     }
 
     locals {
-      admin_passwd = var.admin_passwd == "" ? random_password.password.result : var.admin_passwd
-      vpc_id       = length(data.huaweicloud_vpcs.existing.vpcs) > 0 ? data.huaweicloud_vpcs.existing.vpcs[0].id : huaweicloud_vpc.new[0].id
-      subnet_id    = length(data.huaweicloud_vpc_subnets.existing.subnets)> 0 ? data.huaweicloud_vpc_subnets.existing.subnets[0].id : huaweicloud_vpc_subnet.new[0].id
-      secgroup_id  = length(data.huaweicloud_networking_secgroups.existing.security_groups) > 0 ? data.huaweicloud_networking_secgroups.existing.security_groups[0].id : huaweicloud_networking_secgroup.new[0].id
+      availability_zone = var.availability_zone == "" ? data.huaweicloud_availability_zones.osc-az.names[0] : var.availability_zone
+      admin_passwd      = var.admin_passwd == "" ? random_password.password.result : var.admin_passwd
+      vpc_id            = length(data.huaweicloud_vpcs.existing.vpcs) > 0 ? data.huaweicloud_vpcs.existing.vpcs[0].id : huaweicloud_vpc.new[0].id
+      subnet_id         = length(data.huaweicloud_vpc_subnets.existing.subnets)> 0 ? data.huaweicloud_vpc_subnets.existing.subnets[0].id : huaweicloud_vpc_subnet.new[0].id
+      secgroup_id       = length(data.huaweicloud_networking_secgroups.existing.security_groups) > 0 ? data.huaweicloud_networking_secgroups.existing.security_groups[0].id : huaweicloud_networking_secgroup.new[0].id
     }
 
     resource "huaweicloud_vpc" "new" {
@@ -240,8 +252,6 @@ deployment:
       security_group_id = local.secgroup_id
     }
 
-    data "huaweicloud_availability_zones" "osc-az" {}
-
     resource "random_id" "new" {
       byte_length = 4
     }
@@ -258,7 +268,7 @@ deployment:
 
     resource "huaweicloud_kps_keypair" "keypair" {
       name     = "keypair-ecs-${random_id.new.hex}"
-      key_file = "keypair-kafka-${random_id.new.hex}.pem"
+      key_file = "keypair-ecs-${random_id.new.hex}.pem"
     }
 
     data "huaweicloud_images_image" "image" {
@@ -266,25 +276,25 @@ deployment:
       most_recent = true
     }
 
-    resource "huaweicloud_compute_instance" "ecs-opentofu" {
-      availability_zone  = data.huaweicloud_availability_zones.osc-az.names[0]
-      name               = "ecs-opentofu-${random_id.new.hex}"
+    resource "huaweicloud_compute_instance" "ecs-tofu" {
+      availability_zone  = local.availability_zone
+      name               = "ecs-tofu-${random_id.new.hex}"
       flavor_id          = var.flavor_id
       security_group_ids = [ local.secgroup_id ]
       image_id           = data.huaweicloud_images_image.image.id
       key_pair           = huaweicloud_kps_keypair.keypair.name
-      admin_pass       = local.admin_passwd
+      admin_pass         = local.admin_passwd
       network {
         uuid = local.subnet_id
       }
     }
     
     resource "huaweicloud_evs_volume" "volume" {
-      name              = "volume-${random_id.new.hex}"
+      name              = "volume-tofu-${random_id.new.hex}"
       description       = "my volume"
       volume_type       = "SSD"
       size              = 40
-      availability_zone = data.huaweicloud_availability_zones.osc-az.names[0]
+      availability_zone = local.availability_zone
       tags = {
         foo = "bar"
         key = "value"
@@ -292,16 +302,16 @@ deployment:
     }
     
     resource "huaweicloud_compute_volume_attach" "attached" {
-      instance_id = huaweicloud_compute_instance.ecs-opentofu.id
+      instance_id = huaweicloud_compute_instance.ecs-tofu.id
       volume_id   = huaweicloud_evs_volume.volume.id
     }
     
-    resource "huaweicloud_vpc_eip" "myeip" {
+    resource "huaweicloud_vpc_eip" "eip-tofu" {
        publicip {
          type = "5_sbgp"
       }
       bandwidth {
-        name        = "mybandwidth"
+        name        = "eip-tofu-${random_id.new.hex}"
         size        = 5
         share_type  = "PER"
         charge_mode = "traffic"
@@ -309,16 +319,16 @@ deployment:
     }
     
     resource "huaweicloud_compute_eip_associate" "associated" {
-      public_ip   = huaweicloud_vpc_eip.myeip.address
-      instance_id = huaweicloud_compute_instance.ecs-opentofu.id
+      public_ip   = huaweicloud_vpc_eip.eip-tofu.address
+      instance_id = huaweicloud_compute_instance.ecs-tofu.id
     }
 
     output "ecs-host" {
-      value = huaweicloud_compute_instance.ecs-opentofu.access_ip_v4
+      value = huaweicloud_compute_instance.ecs-tofu.access_ip_v4
     }
     
     output "ecs-public-ip" {
-      value = huaweicloud_vpc_eip.myeip.address
+      value = huaweicloud_vpc_eip.eip-tofu.address
     }
 
     output "admin_passwd" {

--- a/samples/develop/huawei-compute-terraform-dev-autofill.yml
+++ b/samples/develop/huawei-compute-terraform-dev-autofill.yml
@@ -66,6 +66,11 @@ serviceProviderContactDetails:
 deployment:
   # kind, Supported values are terraform, opentofu.
   kind: terraform
+  serviceAvailability:
+    - displayName: Availability Zone
+      varName: availability_zone
+      mandatory: false
+      description: The availability zone to deploy the service instance. If the value is empty, the service instance will be deployed in a random availability zone.
   # Context for deployment: the context including some kind of parameters for the deployment, such as fix_env, fix_variable, env, variable, env_env, env_variable.
   # - fix_env: Values for variable of this type are defined by the managed service provider in the OCL template. Runtime will inject it to deployer as environment variables. This variable is not visible to the end user.
   # - fix_variable: Values for variable of this type are defined by the managed service provider in the OCL template. Runtime will inject it to deployer as usual variables. This variable is not visible to the end user.
@@ -122,6 +127,16 @@ deployment:
         deployResourceKind: security_group
         isAllowCreate: false
   deployer: |
+    variable "region" {
+      type        = string
+      description = "The region to deploy the compute instance."
+    }
+    
+    variable "availability_zone" {
+      type        = string
+      description = "The availability zone to deploy the compute instance."
+    }
+    
     variable "flavor_id" {
       type        = string
       default     = "s6.large.2"
@@ -158,12 +173,6 @@ deployment:
       description = "The security group name of the compute instance."
     }
     
-    variable "region" {
-      type        = string
-      default     = "cn-southwest-2"
-      description = "The region to deploy the compute instance."
-    }
-    
     terraform {
       required_providers {
         huaweicloud = {
@@ -176,6 +185,8 @@ deployment:
     provider "huaweicloud" {
       region = var.region
     }
+
+    data "huaweicloud_availability_zones" "osc-az" {}
 
     data "huaweicloud_vpcs" "existing" {
       name = var.vpc_name
@@ -190,10 +201,11 @@ deployment:
     }
 
     locals {
-      admin_passwd = var.admin_passwd == "" ? random_password.password.result : var.admin_passwd
-      vpc_id       = length(data.huaweicloud_vpcs.existing.vpcs) > 0 ? data.huaweicloud_vpcs.existing.vpcs[0].id : huaweicloud_vpc.new[0].id
-      subnet_id    = length(data.huaweicloud_vpc_subnets.existing.subnets)> 0 ? data.huaweicloud_vpc_subnets.existing.subnets[0].id : huaweicloud_vpc_subnet.new[0].id
-      secgroup_id  = length(data.huaweicloud_networking_secgroups.existing.security_groups) > 0 ? data.huaweicloud_networking_secgroups.existing.security_groups[0].id : huaweicloud_networking_secgroup.new[0].id
+      availability_zone = var.availability_zone == "" ? data.huaweicloud_availability_zones.osc-az.names[0] : var.availability_zone
+      admin_passwd      = var.admin_passwd == "" ? random_password.password.result : var.admin_passwd
+      vpc_id            = length(data.huaweicloud_vpcs.existing.vpcs) > 0 ? data.huaweicloud_vpcs.existing.vpcs[0].id : huaweicloud_vpc.new[0].id
+      subnet_id         = length(data.huaweicloud_vpc_subnets.existing.subnets)> 0 ? data.huaweicloud_vpc_subnets.existing.subnets[0].id : huaweicloud_vpc_subnet.new[0].id
+      secgroup_id       = length(data.huaweicloud_networking_secgroups.existing.security_groups) > 0 ? data.huaweicloud_networking_secgroups.existing.security_groups[0].id : huaweicloud_networking_secgroup.new[0].id
     }
 
     resource "huaweicloud_vpc" "new" {
@@ -249,8 +261,6 @@ deployment:
       security_group_id = local.secgroup_id
     }
 
-    data "huaweicloud_availability_zones" "osc-az" {}
-
     resource "random_id" "new" {
       byte_length = 4
     }
@@ -267,7 +277,7 @@ deployment:
 
     resource "huaweicloud_kps_keypair" "keypair" {
       name     = "keypair-ecs-${random_id.new.hex}"
-      key_file = "keypair-kafka-${random_id.new.hex}.pem"
+      key_file = "keypair-ecs-${random_id.new.hex}.pem"
     }
 
     data "huaweicloud_images_image" "image" {
@@ -275,25 +285,25 @@ deployment:
       most_recent = true
     }
 
-    resource "huaweicloud_compute_instance" "ecs-terraform" {
-      availability_zone  = data.huaweicloud_availability_zones.osc-az.names[0]
-      name               = "ecs-terraform-${random_id.new.hex}"
+    resource "huaweicloud_compute_instance" "ecs-tf" {
+      availability_zone  = local.availability_zone
+      name               = "ecs-tf-${random_id.new.hex}"
       flavor_id          = var.flavor_id
       security_group_ids = [ local.secgroup_id ]
       image_id           = data.huaweicloud_images_image.image.id
       key_pair           = huaweicloud_kps_keypair.keypair.name
-      admin_pass       = local.admin_passwd
+      admin_pass         = local.admin_passwd
       network {
         uuid = local.subnet_id
       }
     }
     
     resource "huaweicloud_evs_volume" "volume" {
-      name              = "volume-${random_id.new.hex}"
+      name              = "volume-tf-${random_id.new.hex}"
       description       = "my volume"
       volume_type       = "SSD"
       size              = 40
-      availability_zone = data.huaweicloud_availability_zones.osc-az.names[0]
+      availability_zone = local.availability_zone
       tags = {
         foo = "bar"
         key = "value"
@@ -301,16 +311,16 @@ deployment:
     }
     
     resource "huaweicloud_compute_volume_attach" "attached" {
-      instance_id = huaweicloud_compute_instance.ecs-terraform.id
+      instance_id = huaweicloud_compute_instance.ecs-tf.id
       volume_id   = huaweicloud_evs_volume.volume.id
     }
     
-    resource "huaweicloud_vpc_eip" "myeip" {
+    resource "huaweicloud_vpc_eip" "eip-tf" {
        publicip {
          type = "5_sbgp"
       }
       bandwidth {
-        name        = "mybandwidth"
+        name        = "eip-tf-${random_id.new.hex}"
         size        = 5
         share_type  = "PER"
         charge_mode = "traffic"
@@ -318,16 +328,16 @@ deployment:
     }
     
     resource "huaweicloud_compute_eip_associate" "associated" {
-      public_ip   = huaweicloud_vpc_eip.myeip.address
-      instance_id = huaweicloud_compute_instance.ecs-terraform.id
+      public_ip   = huaweicloud_vpc_eip.eip-tf.address
+      instance_id = huaweicloud_compute_instance.ecs-tf.id
     }
 
     output "ecs-host" {
-      value = huaweicloud_compute_instance.ecs-terraform.access_ip_v4
+      value = huaweicloud_compute_instance.ecs-tf.access_ip_v4
     }
     
     output "ecs-public-ip" {
-      value = huaweicloud_vpc_eip.myeip.address
+      value = huaweicloud_vpc_eip.eip-tf.address
     }
 
     output "admin_passwd" {

--- a/samples/develop/huawei-compute-terraform-dev-git-repo.yml
+++ b/samples/develop/huawei-compute-terraform-dev-git-repo.yml
@@ -66,6 +66,11 @@ serviceProviderContactDetails:
 deployment:
   # kind, Supported values are terraform, opentofu.
   kind: terraform
+  serviceAvailability:
+    - displayName: Availability Zone
+      varName: availability_zone
+      mandatory: false
+      description: The availability zone to deploy the service instance. If the value is empty, the service instance will be deployed in a random availability zone.
   # Context for deployment: the context including some kind of parameters for the deployment, such as fix_env, fix_variable, env, variable, env_env, env_variable.
   # - fix_env: Values for variable of this type are defined by the managed service provider in the OCL template. Runtime will inject it to deployer as environment variables. This variable is not visible to the end user.
   # - fix_variable: Values for variable of this type are defined by the managed service provider in the OCL template. Runtime will inject it to deployer as usual variables. This variable is not visible to the end user.

--- a/samples/develop/openstack-compute-terraform-dev.yml
+++ b/samples/develop/openstack-compute-terraform-dev.yml
@@ -3,7 +3,7 @@ version: 1.0
 # The category of the service.
 category: compute
 # The Service provided by the ISV, the name will be shown on the console as a service.
-name: terraform-ecs
+name: openstack-ecs
 # The version of the service, the end-user can select the version they want to deploy.
 serviceVersion: v1.0.0
 # For the users may have more than one service, the @namespace can be used to separate the clusters.
@@ -14,12 +14,12 @@ icon: |
   data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAGQAAACRAQMAAAAPc4+9AAAAAXNSR0IB2cksfwAAAAlwSFlzAAALEwAACxMBAJqcGAAAAAZQTFRF+/v7Hh8gVD0A0wAAAcVJREFUeJzNlc1twzAMhSX44KNH0CgaTd6gK3kUd4McDVTwq/hjiUyaIkV7qNA2/QCFIh+ppxB+svLNEqqBGTC0ANugBOwmCGDCFOAwIWGDOoqoODtN2BdL6wxD9NMTO9tXPa1PqL5M30W5p8lm5vNcF0t7ahSrVguqNqmMokRW4YQucVjBCBWH1Z2g3WDlW2skoYU+2x8JOtGedBF3k2iXMO0j16iUiI6gxzPdQhnU/s2G9pCO57QY2r6hvjPbKJHq7DRTRXT60avtuTRdbrFJI3mSZhNOqYjVbd99YyK1QKWzEqSWrE0k07U60uPaelflMzaaeu1KBuurHSsn572I1KWy2joX5ZBfWbS/VEt50H5P6aL4JxTuyJ/+QCNPX4PWF3Q8Xe1eF9FsLdD2VaOnaP2hWvs+zI58/7i3vH3nRFtDZpyTUNaZkON5XnBNsp8lrmDMrpvBr+b6pUl+4XbkQdndqnzYGzfuJm1JmIWimIbe6dndd/bk7gVce/cJdo3uIeLJl7+I2xTnPek67mjtDeppE7b03Ov+kSfDe3JweW53njxeGfXkaz28VeYd86+af/H8a7hgJKaebILaFzakLfxyfQLTxVB6K1K9KQAAAABJRU5ErkJggg==
 # Reserved for CSP, aws,azure,ali,huawei and ...
 cloudServiceProvider:
-  name: huawei
+  name: openstack
   regions:
-    - name: cn-southwest-2
-      area: Asia China
-    - name: cn-north-4
-      area: Asia China
+    - name: RegionOne
+      area: Western Europe
+    - name: RegionTwo
+      area: Western Europe
 billing:
   # The business model(`flat`, `exponential`, ...)
   model: flat
@@ -35,34 +35,23 @@ flavors:
     fixedPrice: 10
     # Properties for the service, which can be used by the deployment.
     properties:
-      flavor_id: s7.small.1
-  - name: 2vCPUs-4GB-normal
+      flavor_id: cirros128
+  - name: 1vCPUs-1GB-normal
     # The fixed price during the period (the price applied one shot whatever is the service use)
     fixedPrice: 20
     # Properties for the service, which can be used by the deployment.
     properties:
-      flavor_id: s6.large.2
-  - name: 2vCPUs-8GB-normal
+      flavor_id: cirros256
+  - name: 1vCPUs-2GB-normal
     # The fixed price during the period (the price applied one shot whatever is the service use)
     fixedPrice: 30
     # Properties for the service, which can be used by the deployment.
     properties:
-      flavor_id: s6.large.4
-  - name: 4vCPUs-8GB-normal
-    # The fixed price during the period (the price applied one shot whatever is the service use)
-    fixedPrice: 40
-    # Properties for the service, which can be used by the deployment.
-    properties:
-      flavor_id: s6.xlarge.2
-  - name: 4vCPUs-16GB-normal
-    # The fixed price during the period (the price applied one shot whatever is the service use)
-    fixedPrice: 50
-    # Properties for the service, which can be used by the deployment.
-    properties:
-      flavor_id: s6.xlarge.4
+      flavor_id: cirros512
+
 # The contact details of the service.
 serviceProviderContactDetails:
-  email: [ "test@test.com" ]
+  email: ["test@test.com"]
 deployment:
   # kind, Supported values are terraform, opentofu.
   kind: terraform
@@ -80,6 +69,17 @@ deployment:
   # - env_variable: Value to this variable is read by runtime (it can read from other sources, e.g., OS env variables) and injected as a regular variable to the deployer. End user cannot see or change this variable.
   # The parameters will be used to generate the API of the managed service.
   variables:
+    - name: OS_AUTH_URL
+      description: Openstack cloud instance to be used.
+      kind: fix_env
+      dataType: string
+      mandatory: true
+      valueSchema:
+        minLength: 1
+        maxLength: 256
+      sensitiveScope: none
+      # this is an example test instance of openstack
+      value: "http://119.8.215.244/identity/v3"
     - name: admin_passwd
       description: The admin password of the compute instance. If the value is empty, will create a random password.
       kind: variable
@@ -93,9 +93,9 @@ deployment:
       description: The image name of the compute instance. If the value is empty, will use the default value to create compute instance.
       kind: variable
       dataType: string
-      example: "Ubuntu 22.04 server 64bit"
+      example: "cirros-0.5.2-x86_64-disk"
       mandatory: false
-      value: "Ubuntu 22.04 server 64bit"
+      value: "cirros-0.5.2-x86_64-disk"
     - name: vpc_name
       description: The vpc name of the compute instance. If the value is empty, will use the default value to find or create VPC.
       kind: variable
@@ -130,13 +130,13 @@ deployment:
     
     variable "flavor_id" {
       type        = string
-      default     = "s6.large.2"
+      default     = "cirros256"
       description = "The flavor_id of the compute instance."
     }
     
     variable "image_name" {
       type        = string
-      default     = "Ubuntu 22.04 server 64bit"
+      default     = "cirros-0.5.2-x86_64-disk"
       description = "The image name of the compute instance."
     }
     
@@ -166,61 +166,64 @@ deployment:
     
     terraform {
       required_providers {
-        huaweicloud = {
-          source  = "huaweicloud/huaweicloud"
-          version = "~> 1.61.0"
+        openstack = {
+          source  = "terraform-provider-openstack/openstack"
+          version = "~> 1.53.0"
         }
       }
     }
     
-    provider "huaweicloud" {
+    provider "openstack" {
       region = var.region
     }
+    
+    data "openstack_compute_availability_zones_v2" "osc-az" {}
 
-    data "huaweicloud_availability_zones" "osc-az" {}
-
-    data "huaweicloud_vpcs" "existing" {
-      name = var.vpc_name
+    data "openstack_networking_network_v2" "existing" {
+      name  = var.vpc_name
+      count = length(data.openstack_networking_network_v2.existing)
     }
 
-    data "huaweicloud_vpc_subnets" "existing" {
-      name = var.subnet_name
+    data "openstack_networking_subnet_v2" "existing" {
+      name  = var.subnet_name
+      count = length(data.openstack_networking_subnet_v2.existing)
     }
 
-    data "huaweicloud_networking_secgroups" "existing" {
-      name = var.secgroup_name
+    data "openstack_networking_secgroup_v2" "existing" {
+      name  = var.secgroup_name
+      count = length(data.openstack_networking_secgroup_v2.existing)
     }
 
     locals {
-      availability_zone = var.availability_zone == "" ? data.huaweicloud_availability_zones.osc-az.names[0] : var.availability_zone
+      availability_zone = var.availability_zone == "" ? data.openstack_compute_availability_zones_v2.osc-az.names[0] : var.availability_zone
       admin_passwd      = var.admin_passwd == "" ? random_password.password.result : var.admin_passwd
-      vpc_id            = length(data.huaweicloud_vpcs.existing.vpcs) > 0 ? data.huaweicloud_vpcs.existing.vpcs[0].id : huaweicloud_vpc.new[0].id
-      subnet_id         = length(data.huaweicloud_vpc_subnets.existing.subnets)> 0 ? data.huaweicloud_vpc_subnets.existing.subnets[0].id : huaweicloud_vpc_subnet.new[0].id
-      secgroup_id       = length(data.huaweicloud_networking_secgroups.existing.security_groups) > 0 ? data.huaweicloud_networking_secgroups.existing.security_groups[0].id : huaweicloud_networking_secgroup.new[0].id
+      vpc_id            = length(data.openstack_networking_network_v2.existing) > 0 ? data.openstack_networking_network_v2.existing[0].id : openstack_networking_network_v2.new[0].id
+      subnet_id         = length(data.openstack_networking_subnet_v2.existing) > 0 ? data.openstack_networking_subnet_v2.existing[0].id : openstack_networking_subnet_v2.new[0].id
+      secgroup_id       = length(data.openstack_networking_secgroup_v2.existing) > 0 ? data.openstack_networking_secgroup_v2.existing[0].id : openstack_networking_secgroup_v2.new[0].id
+      secgroup_name     = length(data.openstack_networking_secgroup_v2.existing) > 0 ? data.openstack_networking_secgroup_v2.existing[0].name : openstack_networking_secgroup_v2.new[0].name
     }
 
-    resource "huaweicloud_vpc" "new" {
-      count = length(data.huaweicloud_vpcs.existing.vpcs) == 0 ? 1 : 0
-      name  = var.vpc_name
-      cidr  = "192.168.0.0/16"
+    resource "openstack_networking_network_v2" "new" {
+      count = length(data.openstack_networking_network_v2.existing) == 0 ? 1 : 0
+      name  = "${var.vpc_name}-${random_id.new.hex}"
     }
 
-    resource "huaweicloud_vpc_subnet" "new" {
-      count      = length(data.huaweicloud_vpcs.existing.vpcs) == 0 ? 1 : 0
-      vpc_id     = local.vpc_id
-      name       = var.subnet_name
+    resource "openstack_networking_subnet_v2" "new" {
+      count      = length(data.openstack_networking_subnet_v2.existing) == 0 ? 1 : 0
+      network_id     = local.vpc_id
+      name       = "${var.subnet_name}-${random_id.new.hex}"
       cidr       = "192.168.10.0/24"
       gateway_ip = "192.168.10.1"
     }
 
-    resource "huaweicloud_networking_secgroup" "new" {
-      count       = length(data.huaweicloud_networking_secgroups.existing.security_groups) == 0 ? 1 : 0
-      name        = var.secgroup_name
-      description = "Kafka cluster security group"
+    resource "openstack_networking_secgroup_v2" "new" {
+      count       = length(data.openstack_networking_secgroup_v2.existing) == 0 ? 1 : 0
+      name        = "${var.secgroup_name}-${random_id.new.hex}"
+      description = "Compute security group"
     }
 
-    resource "huaweicloud_networking_secgroup_rule" "secgroup_rule_0" {
-      count             = length(data.huaweicloud_networking_secgroups.existing.security_groups) == 0 ? 1 : 0
+    resource "openstack_networking_secgroup_rule_v2" "secgroup_rule_0" {
+      count             = length(data.openstack_networking_secgroup_v2.existing) == 0 ? 1 : 0
       direction         = "ingress"
       ethertype         = "IPv4"
       protocol          = "tcp"
@@ -230,8 +233,8 @@ deployment:
       security_group_id = local.secgroup_id
     }
 
-    resource "huaweicloud_networking_secgroup_rule" "secgroup_rule_1" {
-      count             = length(data.huaweicloud_networking_secgroups.existing.security_groups) == 0 ? 1 : 0
+    resource "openstack_networking_secgroup_rule_v2" "secgroup_rule_1" {
+      count             = length(data.openstack_networking_secgroup_v2.existing) == 0 ? 1 : 0
       direction         = "ingress"
       ethertype         = "IPv4"
       protocol          = "tcp"
@@ -241,8 +244,8 @@ deployment:
       security_group_id = local.secgroup_id
     }
 
-    resource "huaweicloud_networking_secgroup_rule" "secgroup_rule_2" {
-      count             = length(data.huaweicloud_networking_secgroups.existing.security_groups) == 0 ? 1 : 0
+    resource "openstack_networking_secgroup_rule_v2" "secgroup_rule_2" {
+      count             = length(data.openstack_networking_secgroup_v2.existing) == 0 ? 1 : 0
       direction         = "ingress"
       ethertype         = "IPv4"
       protocol          = "tcp"
@@ -266,69 +269,56 @@ deployment:
       override_special = "#%@"
     }
 
-    resource "huaweicloud_kps_keypair" "keypair" {
-      name     = "keypair-ecs-${random_id.new.hex}"
-      key_file = "keypair-ecs-${random_id.new.hex}.pem"
+    resource "openstack_compute_keypair_v2" "keypair" {
+      name = "keypair-ecs-${random_id.new.hex}"
     }
 
-    data "huaweicloud_images_image" "image" {
-      name_regex        = "^${var.image_name}"
+    data "openstack_images_image_v2" "image" {
+      name_regex  = "^${var.image_name}"
       most_recent = true
     }
 
-    resource "huaweicloud_compute_instance" "ecs-tf" {
+    resource "openstack_compute_instance_v2" "ecs-tf" {
       availability_zone  = local.availability_zone
       name               = "ecs-tf-${random_id.new.hex}"
       flavor_id          = var.flavor_id
-      security_group_ids = [ local.secgroup_id ]
-      image_id           = data.huaweicloud_images_image.image.id
-      key_pair           = huaweicloud_kps_keypair.keypair.name
+      security_groups    = [ local.secgroup_name ]
+      image_id           = data.openstack_images_image_v2.image.id
+      key_pair           = openstack_compute_keypair_v2.keypair.name
       admin_pass         = local.admin_passwd
       network {
-        uuid = local.subnet_id
+        uuid = local.vpc_id
       }
     }
     
-    resource "huaweicloud_evs_volume" "volume" {
+    resource "openstack_blockstorage_volume_v3" "volume" {
       name              = "volume-tf-${random_id.new.hex}"
       description       = "my volume"
-      volume_type       = "SSD"
       size              = 40
       availability_zone = local.availability_zone
-      tags = {
-        foo = "bar"
-        key = "value"
-      }
     }
     
-    resource "huaweicloud_compute_volume_attach" "attached" {
-      instance_id = huaweicloud_compute_instance.ecs-tf.id
-      volume_id   = huaweicloud_evs_volume.volume.id
+    resource "openstack_compute_volume_attach_v2" "attached" {
+      instance_id = openstack_compute_instance_v2.ecs-tf.id
+      volume_id   = openstack_blockstorage_volume_v3.volume.id
     }
     
-    resource "huaweicloud_vpc_eip" "eip-tf" {
-       publicip {
-         type = "5_sbgp"
-      }
-      bandwidth {
-        name        = "eip-tf-${random_id.new.hex}"
-        size        = 5
-        share_type  = "PER"
-        charge_mode = "traffic"
-      }
+    resource "openstack_networking_floatingip_v2" "myip" {
+      pool = "my_pool"
     }
-    
-    resource "huaweicloud_compute_eip_associate" "associated" {
-      public_ip   = huaweicloud_vpc_eip.eip-tf.address
-      instance_id = huaweicloud_compute_instance.ecs-tf.id
+
+    resource "openstack_compute_floatingip_associate_v2" "myip" {
+      floating_ip = openstack_networking_floatingip_v2.myip.address
+      instance_id = openstack_compute_instance_v2.ecs-tf.id
+      fixed_ip    = openstack_compute_instance_v2.ecs-tf.network.1.fixed_ip_v4
     }
 
     output "ecs-host" {
-      value = huaweicloud_compute_instance.ecs-tf.access_ip_v4
+      value = openstack_compute_instance_v2.ecs-tf.access_ip_v4
     }
     
     output "ecs-public-ip" {
-      value = huaweicloud_vpc_eip.eip-tf.address
+      value = openstack_networking_floatingip_v2.myip.address
     }
 
     output "admin_passwd" {

--- a/samples/flexibleEngine-K8S.json
+++ b/samples/flexibleEngine-K8S.json
@@ -4,7 +4,10 @@
   "csp": "flexibleEngine",
   "category": "container",
   "flavor": "1-master-with-3-worker-nodes-normal",
-  "region": "eu-west-0",
+  "region": {
+    "name": "eu-west-0",
+    "area": "Western Europe"
+  },
   "customerServiceName": "default-k8s",
   "serviceHostingType": "self",
   "serviceRequestProperties": {}

--- a/samples/flexibleEngine-K8S.yml
+++ b/samples/flexibleEngine-K8S.yml
@@ -17,9 +17,9 @@ cloudServiceProvider:
   name: flexibleEngine
   regions:
     - name: eu-west-0
-      area: Europe
+      area: Western Europe
     - name: eu-west-1
-      area: Europe
+      area: Western Europe
 billing:
   # The business model(`flat`, `exponential`, ...)
   model: flat
@@ -64,6 +64,11 @@ serviceProviderContactDetails:
 deployment:
   # kind, Supported values are terraform, opentofu.
   kind: terraform
+  serviceAvailability:
+    - displayName: Availability Zone
+      varName: availability_zone
+      mandatory: false
+      description: The availability zone to deploy the service instance. If the value is empty, the service instance will be deployed in a random availability zone.
   # Context for deployment: the context including some kind of parameters for the deployment, such as fix_env, fix_variable, env, variable, env_env, env_variable.
   # - fix_env: Values for variable of this type are defined by the managed service provider in the OCL template. Runtime will inject it to deployer as environment variables. This variable is not visible to the end user.
   # - fix_variable: Values for variable of this type are defined by the managed service provider in the OCL template. Runtime will inject it to deployer as usual variables. This variable is not visible to the end user.
@@ -104,10 +109,26 @@ deployment:
       mandatory: false
       value: "k8s-secgroup-default"
   deployer: |
+    variable "region" {
+      type        = string
+      description = "The region to deploy the K8S cluster instance."
+    }
+
+    variable "availability_zone" {
+      type        = string
+      description = "The availability zone to deploy the K8S cluster instance."
+    }
+
     variable "flavor_id" {
       type        = string
-      default     = "s6.large.4"
+      default     = "s6.large.2"
       description = "The flavor_id of all nodes in the K8S cluster instance."
+    }
+
+    variable "image_name" {
+      type        = string
+      default     = "OBS Ubuntu 22.04"
+      description = "The image name of the compute instance."
     }
 
     variable "worker_nodes_count" {
@@ -138,14 +159,8 @@ deployment:
       type        = string
       default     = "k8s-secgroup-default"
       description = "The security group name of all nodes in the K8S cluster instance."
-    } 
-    
-    variable "region" {
-      type        = string
-      default     = "eu-west-0"
-      description = "The region to deploy the K8S cluster instance."
     }
-    
+
     terraform {
       required_providers {
         flexibleengine = {
@@ -154,10 +169,12 @@ deployment:
         }
       }
     }
-    
+
     provider "flexibleengine" {
       region = var.region
     }
+
+    data "flexibleengine_availability_zones" "osc-az" {}
 
     data "flexibleengine_vpc_v1" "existing" {
       name  = var.vpc_name
@@ -175,11 +192,12 @@ deployment:
     }
 
     locals {
-      admin_passwd  = var.admin_passwd == "" ? random_password.password.result : var.admin_passwd
-      vpc_id        = length(data.flexibleengine_vpc_v1.existing) > 0 ? data.flexibleengine_vpc_v1.existing[0].id : flexibleengine_vpc_v1.new[0].id
-      subnet_id     = length(data.flexibleengine_vpc_subnet_v1.existing) > 0 ? data.flexibleengine_vpc_subnet_v1.existing[0].id : flexibleengine_vpc_subnet_v1.new[0].id
-      secgroup_id   = length(data.flexibleengine_networking_secgroup_v2.existing) > 0 ? data.flexibleengine_networking_secgroup_v2.existing[0].id : flexibleengine_networking_secgroup_v2.new[0].id
-      secgroup_name = length(data.flexibleengine_networking_secgroup_v2.existing) > 0 ? data.flexibleengine_networking_secgroup_v2.existing[0].name : flexibleengine_networking_secgroup_v2.new[0].name
+      availability_zone = var.availability_zone == "" ? data.flexibleengine_availability_zones.osc-az.names[0] : var.availability_zone
+      admin_passwd      = var.admin_passwd == "" ? random_password.password.result : var.admin_passwd
+      vpc_id            = length(data.flexibleengine_vpc_v1.existing) > 0 ? data.flexibleengine_vpc_v1.existing[0].id : flexibleengine_vpc_v1.new[0].id
+      subnet_id         = length(data.flexibleengine_vpc_subnet_v1.existing) > 0 ? data.flexibleengine_vpc_subnet_v1.existing[0].id : flexibleengine_vpc_subnet_v1.new[0].id
+      secgroup_id       = length(data.flexibleengine_networking_secgroup_v2.existing) > 0 ? data.flexibleengine_networking_secgroup_v2.existing[0].id : flexibleengine_networking_secgroup_v2.new[0].id
+      secgroup_name     = length(data.flexibleengine_networking_secgroup_v2.existing) > 0 ? data.flexibleengine_networking_secgroup_v2.existing[0].name : flexibleengine_networking_secgroup_v2.new[0].name
     }
 
     resource "flexibleengine_vpc_v1" "new" {
@@ -214,7 +232,7 @@ deployment:
       security_group_id = local.secgroup_id
     }
 
-    data "flexibleengine_availability_zones" "osc-az" {}
+
 
     resource "random_id" "new" {
       byte_length = 4
@@ -234,35 +252,35 @@ deployment:
       name = "keypair-k8s-${random_id.new.hex}"
     }
 
-    data "flexibleengine_images_image_v2" "image" {
-      name        = "K8S-v1.26.2_Centos-7.9"
+    data "flexibleengine_images_image" "image" {
+      name_regex  = "^${var.image_name}"
       most_recent = true
     }
 
     resource "flexibleengine_compute_instance_v2" "k8s-master" {
-      availability_zone  = data.flexibleengine_availability_zones.osc-az.names[0]
+      availability_zone  = local.availability_zone
       name               = "k8s-master-${random_id.new.hex}"
       flavor_id          = var.flavor_id
       security_groups    = [ local.secgroup_name ]
-      image_id           = data.flexibleengine_images_image_v2.image.id
+      image_id           = data.flexibleengine_images_image.image.id
       key_pair           = flexibleengine_compute_keypair_v2.keypair.name
       network {
         uuid = local.subnet_id
       }
       user_data = <<EOF
-        #!bin/bash
-        echo root:${local.admin_passwd} | sudo chpasswd
-        sudo sh /root/k8s-init.sh true ${local.admin_passwd} ${var.worker_nodes_count} > /root/init.log
-      EOF
+            #!bin/bash
+            echo root:${local.admin_passwd} | sudo chpasswd
+            sudo sh /root/k8s-init.sh true ${local.admin_passwd} ${var.worker_nodes_count} > /root/init.log
+          EOF
     }
 
     resource "flexibleengine_compute_instance_v2" "k8s-node" {
       count              = var.worker_nodes_count
-      availability_zone  = data.flexibleengine_availability_zones.osc-az.names[0]
+      availability_zone  = local.availability_zone
       name               = "k8s-node-${random_id.new.hex}-${count.index}"
       flavor_id          = var.flavor_id
       security_groups    = [ local.secgroup_name ]
-      image_id           = data.flexibleengine_images_image_v2.image.id
+      image_id           = data.flexibleengine_images_image.image.id
       key_pair           = flexibleengine_compute_keypair_v2.keypair.name
       network {
         uuid = local.subnet_id

--- a/samples/flexibleEngine-Kafka.json
+++ b/samples/flexibleEngine-Kafka.json
@@ -4,7 +4,10 @@
   "csp": "flexibleEngine",
   "category": "middleware",
   "flavor": "1-zookeeper-with-3-worker-nodes-normal",
-  "region": "eu-west-0",
+  "region": {
+    "name": "eu-west-0",
+    "area": "Western Europe"
+  },
   "customerServiceName": "default-kafka",
   "serviceHostingType": "self",
   "serviceRequestProperties": {}

--- a/samples/flexibleEngine-Kafka.yml
+++ b/samples/flexibleEngine-Kafka.yml
@@ -17,9 +17,9 @@ cloudServiceProvider:
   name: flexibleEngine
   regions:
     - name: eu-west-0
-      area: Europe
+      area: Western Europe
     - name: eu-west-1
-      area: Europe
+      area: Western Europe
 billing:
   # The business model(`flat`, `exponential`, ...)
   model: flat
@@ -27,8 +27,8 @@ billing:
   period: monthly
   # The billing currency (`euro`, `usd`, ...)
   currency: euro
-# The flavor of the service, the @category/@name/@version/@flavor can locate the specific service to be deployed.
 serviceHostingType: self
+# The flavor of the service, the @category/@name/@version/@flavor can locate the specific service to be deployed.
 flavors:
   - name: 1-zookeeper-with-3-worker-nodes-normal
     # The fixed price during the period (the price applied one shot whatever is the service use)
@@ -64,6 +64,11 @@ serviceProviderContactDetails:
 deployment:
   # kind, Supported values are terraform, opentofu.
   kind: terraform
+  serviceAvailability:
+    - displayName: Availability Zone
+      varName: availability_zone
+      mandatory: false
+      description: The availability zone to deploy the service instance. If the value is empty, the service instance will be deployed in a random availability zone.
   # Context for deployment: the context including some kind of parameters for the deployment, such as fix_env, fix_variable, env, variable, env_env, env_variable.
   # - fix_env: Values for variable of this type are defined by the managed service provider in the OCL template. Runtime will inject it to deployer as environment variables. This variable is not visible to the end user.
   # - fix_variable: Values for variable of this type are defined by the managed service provider in the OCL template. Runtime will inject it to deployer as usual variables. This variable is not visible to the end user.
@@ -104,10 +109,26 @@ deployment:
       mandatory: false
       value: "kafka-secgroup-default"
   deployer: |
+    variable "region" {
+      type        = string
+      description = "The region to deploy the Kafka cluster instance."
+    }
+
+    variable "availability_zone" {
+      type        = string
+      description = "The availability zone to deploy the Kafka cluster instance."
+    }
+
     variable "flavor_id" {
       type        = string
-      default     = "s6.large.4"
+      default     = "s6.large.2"
       description = "The flavor_id of all nodes in the Kafka cluster instance."
+    }
+
+    variable "image_name" {
+      type        = string
+      default     = "OBS Ubuntu 22.04"
+      description = "The image name of the compute instance."
     }
 
     variable "worker_nodes_count" {
@@ -139,13 +160,7 @@ deployment:
       default     = "kafka-secgroup-default"
       description = "The security group name of all nodes in the Kafka cluster instance."
     }
-    
-    variable "region" {
-      type        = string
-      default     = "eu-west-0"
-      description = "The region to deploy the kafka cluster."
-    }
-    
+
     terraform {
       required_providers {
         flexibleengine = {
@@ -154,10 +169,12 @@ deployment:
         }
       }
     }
-    
+
     provider "flexibleengine" {
       region = var.region
     }
+
+    data "flexibleengine_availability_zones" "osc-az" {}
 
     data "flexibleengine_vpc_v1" "existing" {
       name  = var.vpc_name
@@ -175,11 +192,12 @@ deployment:
     }
 
     locals {
-      admin_passwd  = var.admin_passwd == "" ? random_password.password.result : var.admin_passwd
-      vpc_id        = length(data.flexibleengine_vpc_v1.existing) > 0 ? data.flexibleengine_vpc_v1.existing[0].id : flexibleengine_vpc_v1.new[0].id
-      subnet_id     = length(data.flexibleengine_vpc_subnet_v1.existing) > 0 ? data.flexibleengine_vpc_subnet_v1.existing[0].id : flexibleengine_vpc_subnet_v1.new[0].id
-      secgroup_id   = length(data.flexibleengine_networking_secgroup_v2.existing) > 0 ? data.flexibleengine_networking_secgroup_v2.existing[0].id : flexibleengine_networking_secgroup_v2.new[0].id
-      secgroup_name = length(data.flexibleengine_networking_secgroup_v2.existing) > 0 ? data.flexibleengine_networking_secgroup_v2.existing[0].name : flexibleengine_networking_secgroup_v2.new[0].name
+      availability_zone = var.availability_zone == "" ? data.flexibleengine_availability_zones.osc-az.names[0] : var.availability_zone
+      admin_passwd      = var.admin_passwd == "" ? random_password.password.result : var.admin_passwd
+      vpc_id            = length(data.flexibleengine_vpc_v1.existing) > 0 ? data.flexibleengine_vpc_v1.existing[0].id : flexibleengine_vpc_v1.new[0].id
+      subnet_id         = length(data.flexibleengine_vpc_subnet_v1.existing) > 0 ? data.flexibleengine_vpc_subnet_v1.existing[0].id : flexibleengine_vpc_subnet_v1.new[0].id
+      secgroup_id       = length(data.flexibleengine_networking_secgroup_v2.existing) > 0 ? data.flexibleengine_networking_secgroup_v2.existing[0].id : flexibleengine_networking_secgroup_v2.new[0].id
+      secgroup_name     = length(data.flexibleengine_networking_secgroup_v2.existing) > 0 ? data.flexibleengine_networking_secgroup_v2.existing[0].name : flexibleengine_networking_secgroup_v2.new[0].name
     }
 
     resource "flexibleengine_vpc_v1" "new" {
@@ -236,8 +254,6 @@ deployment:
       security_group_id = local.secgroup_id
     }
 
-    data "flexibleengine_availability_zones" "osc-az" {}
-
     resource "random_id" "new" {
       byte_length = 4
     }
@@ -256,49 +272,49 @@ deployment:
       name = "keypair-k8s-${random_id.new.hex}"
     }
 
-    data "flexibleengine_images_image_v2" "image" {
-      name        = "Kafka-v3.3.2_Ubuntu-20.04"
+    data "flexibleengine_images_image" "image" {
+      name_regex  = "^${var.image_name}"
       most_recent = true
     }
 
     resource "flexibleengine_compute_instance_v2" "zookeeper" {
-      availability_zone  = data.flexibleengine_availability_zones.osc-az.names[0]
+      availability_zone  = local.availability_zone
       name               = "kafka-zookeeper-${random_id.new.hex}"
       flavor_id          = var.flavor_id
       security_groups    = [ local.secgroup_name ]
-      image_id           = data.flexibleengine_images_image_v2.image.id
+      image_id           = data.flexibleengine_images_image.image.id
       key_pair           = flexibleengine_compute_keypair_v2.keypair.name
       network {
         uuid = local.subnet_id
       }
       user_data = <<EOF
-        #!bin/bash
-        echo root:${local.admin_passwd} | sudo chpasswd
-        sudo systemctl start docker
-        sudo systemctl enable docker
-        sudo docker run -d --name zookeeper-server --privileged=true -p 2181:2181 -e ALLOW_ANONYMOUS_LOGIN=yes bitnami/zookeeper:3.8.1
-      EOF
+            #!bin/bash
+            echo root:${local.admin_passwd} | sudo chpasswd
+            sudo systemctl start docker
+            sudo systemctl enable docker
+            sudo docker run -d --name zookeeper-server --privileged=true -p 2181:2181 -e ALLOW_ANONYMOUS_LOGIN=yes bitnami/zookeeper:3.8.1
+          EOF
     }
 
     resource "flexibleengine_compute_instance_v2" "kafka-broker" {
       count              = var.worker_nodes_count
-      availability_zone  = data.flexibleengine_availability_zones.osc-az.names[0]
+      availability_zone  = local.availability_zone
       name               = "kafka-broker-${count.index}-${random_id.new.hex}"
       flavor_id          = var.flavor_id
       security_groups    = [ local.secgroup_name ]
-      image_id           = data.flexibleengine_images_image_v2.image.id
+      image_id           = data.flexibleengine_images_image.image.id
       key_pair           = flexibleengine_compute_keypair_v2.keypair.name
       network {
         uuid = local.subnet_id
       }
       user_data = <<EOF
-        #!bin/bash
-        echo root:${local.admin_passwd} | sudo chpasswd
-        sudo systemctl start docker
-        sudo systemctl enable docker
-        private_ip=$(ifconfig | grep -A1 "eth0" | grep 'inet' | awk -F ' ' ' {print $2}'|awk ' {print $1}')
-        sudo docker run -d --name kafka-server --restart always -p 9092:9092 -p 9093:9093  -e KAFKA_BROKER_ID=${count.index}  -e KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://$private_ip:9092 -e KAFKA_LISTENERS=PLAINTEXT://0.0.0.0:9092 -e ALLOW_PLAINTEXT_LISTENER=yes -e KAFKA_CFG_ZOOKEEPER_CONNECT=${flexibleengine_compute_instance_v2.zookeeper.access_ip_v4}:2181 bitnami/kafka:3.3.2
-      EOF
+            #!bin/bash
+            echo root:${local.admin_passwd} | sudo chpasswd
+            sudo systemctl start docker
+            sudo systemctl enable docker
+            private_ip=$(ifconfig | grep -A1 "eth0" | grep 'inet' | awk -F ' ' ' {print $2}'|awk ' {print $1}')
+            sudo docker run -d --name kafka-server --restart always -p 9092:9092 -p 9093:9093  -e KAFKA_BROKER_ID=${count.index}  -e KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://$private_ip:9092 -e KAFKA_LISTENERS=PLAINTEXT://0.0.0.0:9092 -e ALLOW_PLAINTEXT_LISTENER=yes -e KAFKA_CFG_ZOOKEEPER_CONNECT=${flexibleengine_compute_instance_v2.zookeeper.access_ip_v4}:2181 bitnami/kafka:3.3.2
+          EOF
       depends_on = [
         flexibleengine_compute_instance_v2.zookeeper
       ]

--- a/samples/huawei-K8S-autofill.yml
+++ b/samples/huawei-K8S-autofill.yml
@@ -64,6 +64,11 @@ serviceProviderContactDetails:
 deployment:
   # kind, Supported values are terraform, opentofu.
   kind: terraform
+  serviceAvailability:
+    - displayName: Availability Zone
+      varName: availability_zone
+      mandatory: false
+      description: The availability zone to deploy the service instance. If the value is empty, the service instance will be deployed in a random availability zone.
   # Context for deployment: the context including some kind of parameters for the deployment, such as fix_env, fix_variable, env, variable, env_env, env_variable.
   # - fix_env: Values for variable of this type are defined by the managed service provider in the OCL template. Runtime will inject it to deployer as environment variables. This variable is not visible to the end user.
   # - fix_variable: Values for variable of this type are defined by the managed service provider in the OCL template. Runtime will inject it to deployer as usual variables. This variable is not visible to the end user.
@@ -113,6 +118,16 @@ deployment:
         deployResourceKind: security_group
         isAllowCreate: false
   deployer: |
+    variable "region" {
+      type        = string
+      description = "The region to deploy the K8S cluster instance."
+    }
+    
+    variable "availability_zone" {
+      type        = string
+      description = "The availability zone to deploy the K8S cluster instance."
+    }
+    
     variable "flavor_id" {
       type        = string
       default     = "s6.large.2"
@@ -149,13 +164,6 @@ deployment:
       description = "The security group name of all nodes in the K8S cluster instance."
     }
     
-    
-    variable "region" {
-      type        = string
-      default     = "cn-southwest-2"
-      description = "The region to deploy the K8S cluster instance."
-    }
-    
     terraform {
       required_providers {
         huaweicloud = {
@@ -168,6 +176,8 @@ deployment:
     provider "huaweicloud" {
       region = var.region
     }
+    
+    data "huaweicloud_availability_zones" "osc-az" {}
 
     data "huaweicloud_vpcs" "existing" {
       name = var.vpc_name
@@ -182,10 +192,11 @@ deployment:
     }
 
     locals {
-      admin_passwd = var.admin_passwd == "" ? random_password.password.result : var.admin_passwd
-      vpc_id       = length(data.huaweicloud_vpcs.existing.vpcs) > 0 ? data.huaweicloud_vpcs.existing.vpcs[0].id : huaweicloud_vpc.new[0].id
-      subnet_id    = length(data.huaweicloud_vpc_subnets.existing.subnets)> 0 ? data.huaweicloud_vpc_subnets.existing.subnets[0].id : huaweicloud_vpc_subnet.new[0].id
-      secgroup_id  = length(data.huaweicloud_networking_secgroups.existing.security_groups) > 0 ? data.huaweicloud_networking_secgroups.existing.security_groups[0].id : huaweicloud_networking_secgroup.new[0].id
+      availability_zone = var.availability_zone == "" ? data.huaweicloud_availability_zones.osc-az.names[0] : var.availability_zone
+      admin_passwd      = var.admin_passwd == "" ? random_password.password.result : var.admin_passwd
+      vpc_id            = length(data.huaweicloud_vpcs.existing.vpcs) > 0 ? data.huaweicloud_vpcs.existing.vpcs[0].id : huaweicloud_vpc.new[0].id
+      subnet_id         = length(data.huaweicloud_vpc_subnets.existing.subnets)> 0 ? data.huaweicloud_vpc_subnets.existing.subnets[0].id : huaweicloud_vpc_subnet.new[0].id
+      secgroup_id       = length(data.huaweicloud_networking_secgroups.existing.security_groups) > 0 ? data.huaweicloud_networking_secgroups.existing.security_groups[0].id : huaweicloud_networking_secgroup.new[0].id
     }
 
     resource "huaweicloud_vpc" "new" {
@@ -219,7 +230,6 @@ deployment:
       security_group_id = local.secgroup_id
     }
 
-    data "huaweicloud_availability_zones" "osc-az" {}
 
     resource "random_id" "new" {
       byte_length = 4
@@ -246,7 +256,7 @@ deployment:
     }
 
     resource "huaweicloud_compute_instance" "k8s-master" {
-      availability_zone  = data.huaweicloud_availability_zones.osc-az.names[0]
+      availability_zone  = local.availability_zone
       name               = "k8s-master-${random_id.new.hex}"
       flavor_id          = var.flavor_id
       security_group_ids = [ local.secgroup_id ]
@@ -264,7 +274,7 @@ deployment:
 
     resource "huaweicloud_compute_instance" "k8s-node" {
       count              = var.worker_nodes_count
-      availability_zone  = data.huaweicloud_availability_zones.osc-az.names[0]
+      availability_zone  = local.availability_zone
       name               = "k8s-node-${random_id.new.hex}-${count.index}"
       flavor_id          = var.flavor_id
       security_group_ids = [ local.secgroup_id ]

--- a/samples/huawei-K8S.json
+++ b/samples/huawei-K8S.json
@@ -4,7 +4,10 @@
   "csp": "huawei",
   "category": "container",
   "flavor": "1-master-with-3-worker-nodes-normal",
-  "region": "cn-southwest-2",
+  "region": {
+    "area": "Asia China",
+    "name": "cn-southwest-2"
+  },
   "customerServiceName": "default-k8s",
   "serviceHostingType": "self",
   "serviceRequestProperties": {}

--- a/samples/huawei-K8S.yml
+++ b/samples/huawei-K8S.yml
@@ -64,6 +64,11 @@ serviceProviderContactDetails:
 deployment:
   # kind, Supported values are terraform, opentofu.
   kind: terraform
+  serviceAvailability:
+    - displayName: Availability Zone
+      varName: availability_zone
+      mandatory: false
+      description: The availability zone to deploy the service instance. If the value is empty, the service instance will be deployed in a random availability zone.
   # Context for deployment: the context including some kind of parameters for the deployment, such as fix_env, fix_variable, env, variable, env_env, env_variable.
   # - fix_env: Values for variable of this type are defined by the managed service provider in the OCL template. Runtime will inject it to deployer as environment variables. This variable is not visible to the end user.
   # - fix_variable: Values for variable of this type are defined by the managed service provider in the OCL template. Runtime will inject it to deployer as usual variables. This variable is not visible to the end user.
@@ -104,6 +109,16 @@ deployment:
       mandatory: false
       value: "k8s-secgroup-default"
   deployer: |
+    variable "region" {
+      type        = string
+      description = "The region to deploy the K8S cluster instance."
+    }
+    
+    variable "availability_zone" {
+      type        = string
+      description = "The availability zone to deploy the K8S cluster instance."
+    }
+    
     variable "flavor_id" {
       type        = string
       default     = "s6.large.2"
@@ -140,13 +155,6 @@ deployment:
       description = "The security group name of all nodes in the K8S cluster instance."
     }
     
-    
-    variable "region" {
-      type        = string
-      default     = "cn-southwest-2"
-      description = "The region to deploy the K8S cluster instance."
-    }
-    
     terraform {
       required_providers {
         huaweicloud = {
@@ -159,6 +167,8 @@ deployment:
     provider "huaweicloud" {
       region = var.region
     }
+    
+    data "huaweicloud_availability_zones" "osc-az" {}
 
     data "huaweicloud_vpcs" "existing" {
       name = var.vpc_name
@@ -173,10 +183,11 @@ deployment:
     }
 
     locals {
-      admin_passwd = var.admin_passwd == "" ? random_password.password.result : var.admin_passwd
-      vpc_id       = length(data.huaweicloud_vpcs.existing.vpcs) > 0 ? data.huaweicloud_vpcs.existing.vpcs[0].id : huaweicloud_vpc.new[0].id
-      subnet_id    = length(data.huaweicloud_vpc_subnets.existing.subnets)> 0 ? data.huaweicloud_vpc_subnets.existing.subnets[0].id : huaweicloud_vpc_subnet.new[0].id
-      secgroup_id  = length(data.huaweicloud_networking_secgroups.existing.security_groups) > 0 ? data.huaweicloud_networking_secgroups.existing.security_groups[0].id : huaweicloud_networking_secgroup.new[0].id
+      availability_zone = var.availability_zone == "" ? data.huaweicloud_availability_zones.osc-az.names[0] : var.availability_zone
+      admin_passwd      = var.admin_passwd == "" ? random_password.password.result : var.admin_passwd
+      vpc_id            = length(data.huaweicloud_vpcs.existing.vpcs) > 0 ? data.huaweicloud_vpcs.existing.vpcs[0].id : huaweicloud_vpc.new[0].id
+      subnet_id         = length(data.huaweicloud_vpc_subnets.existing.subnets)> 0 ? data.huaweicloud_vpc_subnets.existing.subnets[0].id : huaweicloud_vpc_subnet.new[0].id
+      secgroup_id       = length(data.huaweicloud_networking_secgroups.existing.security_groups) > 0 ? data.huaweicloud_networking_secgroups.existing.security_groups[0].id : huaweicloud_networking_secgroup.new[0].id
     }
 
     resource "huaweicloud_vpc" "new" {
@@ -210,7 +221,6 @@ deployment:
       security_group_id = local.secgroup_id
     }
 
-    data "huaweicloud_availability_zones" "osc-az" {}
 
     resource "random_id" "new" {
       byte_length = 4
@@ -237,7 +247,7 @@ deployment:
     }
 
     resource "huaweicloud_compute_instance" "k8s-master" {
-      availability_zone  = data.huaweicloud_availability_zones.osc-az.names[0]
+      availability_zone  = local.availability_zone
       name               = "k8s-master-${random_id.new.hex}"
       flavor_id          = var.flavor_id
       security_group_ids = [ local.secgroup_id ]
@@ -255,7 +265,7 @@ deployment:
 
     resource "huaweicloud_compute_instance" "k8s-node" {
       count              = var.worker_nodes_count
-      availability_zone  = data.huaweicloud_availability_zones.osc-az.names[0]
+      availability_zone  = local.availability_zone
       name               = "k8s-node-${random_id.new.hex}-${count.index}"
       flavor_id          = var.flavor_id
       security_group_ids = [ local.secgroup_id ]

--- a/samples/huawei-Kafka-autofill.yml
+++ b/samples/huawei-Kafka-autofill.yml
@@ -64,6 +64,11 @@ serviceProviderContactDetails:
 deployment:
   # kind, Supported values are terraform, opentofu.
   kind: terraform
+  serviceAvailability:
+    - displayName: Availability Zone
+      varName: availability_zone
+      mandatory: false
+      description: The availability zone to deploy the service instance. If the value is empty, the service instance will be deployed in a random availability zone.
   # Context for deployment: the context including some kind of parameters for the deployment, such as fix_env, fix_variable, env, variable, env_env, env_variable.
   # - fix_env: Values for variable of this type are defined by the managed service provider in the OCL template. Runtime will inject it to deployer as environment variables. This variable is not visible to the end user.
   # - fix_variable: Values for variable of this type are defined by the managed service provider in the OCL template. Runtime will inject it to deployer as usual variables. This variable is not visible to the end user.
@@ -113,6 +118,16 @@ deployment:
         deployResourceKind: security_group
         isAllowCreate: false
   deployer: |
+    variable "region" {
+      type        = string
+      description = "The region to deploy the Kafka cluster instance."
+    }
+    
+    variable "availability_zone" {
+      type        = string
+      description = "The availability zone to deploy the Kafka cluster instance."
+    }
+    
     variable "flavor_id" {
       type        = string
       default     = "s6.large.2"
@@ -149,12 +164,6 @@ deployment:
       description = "The security group name of all nodes in the Kafka cluster instance."
     }
     
-    variable "region" {
-      type        = string
-      default     = "cn-southwest-2"
-      description = "The region to deploy the Kafka cluster instance."
-    }
-    
     terraform {
       required_providers {
         huaweicloud = {
@@ -167,6 +176,8 @@ deployment:
     provider "huaweicloud" {
       region = var.region
     }
+    
+    data "huaweicloud_availability_zones" "osc-az" {}
 
     data "huaweicloud_vpcs" "existing" {
       name = var.vpc_name
@@ -181,10 +192,11 @@ deployment:
     }
 
     locals {
-      admin_passwd = var.admin_passwd == "" ? random_password.password.result : var.admin_passwd
-      vpc_id       = length(data.huaweicloud_vpcs.existing.vpcs) > 0 ? data.huaweicloud_vpcs.existing.vpcs[0].id : huaweicloud_vpc.new[0].id
-      subnet_id    = length(data.huaweicloud_vpc_subnets.existing.subnets)> 0 ? data.huaweicloud_vpc_subnets.existing.subnets[0].id : huaweicloud_vpc_subnet.new[0].id
-      secgroup_id  = length(data.huaweicloud_networking_secgroups.existing.security_groups) > 0 ? data.huaweicloud_networking_secgroups.existing.security_groups[0].id : huaweicloud_networking_secgroup.new[0].id
+      availability_zone = var.availability_zone == "" ? data.huaweicloud_availability_zones.osc-az.names[0] : var.availability_zone
+      admin_passwd      = var.admin_passwd == "" ? random_password.password.result : var.admin_passwd
+      vpc_id            = length(data.huaweicloud_vpcs.existing.vpcs) > 0 ? data.huaweicloud_vpcs.existing.vpcs[0].id : huaweicloud_vpc.new[0].id
+      subnet_id         = length(data.huaweicloud_vpc_subnets.existing.subnets)> 0 ? data.huaweicloud_vpc_subnets.existing.subnets[0].id : huaweicloud_vpc_subnet.new[0].id
+      secgroup_id       = length(data.huaweicloud_networking_secgroups.existing.security_groups) > 0 ? data.huaweicloud_networking_secgroups.existing.security_groups[0].id : huaweicloud_networking_secgroup.new[0].id
     }
 
     resource "huaweicloud_vpc" "new" {
@@ -240,8 +252,6 @@ deployment:
       security_group_id = local.secgroup_id
     }
 
-    data "huaweicloud_availability_zones" "osc-az" {}
-
     resource "random_id" "new" {
       byte_length = 4
     }
@@ -267,7 +277,7 @@ deployment:
     }
 
     resource "huaweicloud_compute_instance" "zookeeper" {
-      availability_zone  = data.huaweicloud_availability_zones.osc-az.names[0]
+      availability_zone  = local.availability_zone
       name               = "kafka-zookeeper-${random_id.new.hex}"
       flavor_id          = var.flavor_id
       security_group_ids = [ local.secgroup_id ]
@@ -287,7 +297,7 @@ deployment:
 
     resource "huaweicloud_compute_instance" "kafka-broker" {
       count              = var.worker_nodes_count
-      availability_zone  = data.huaweicloud_availability_zones.osc-az.names[0]
+      availability_zone  = local.availability_zone
       name               = "kafka-broker-${random_id.new.hex}-${count.index}"
       flavor_id          = var.flavor_id
       security_group_ids = [ local.secgroup_id ]

--- a/samples/huawei-Kafka-terraform_module.yml
+++ b/samples/huawei-Kafka-terraform_module.yml
@@ -64,6 +64,11 @@ serviceProviderContactDetails:
 deployment:
   # kind, Supported values are terraform, opentofu.
   kind: terraform
+  serviceAvailability:
+    - displayName: Availability Zone
+      varName: availability_zone
+      mandatory: false
+      description: The availability zone to deploy the service instance. If the value is empty, the service instance will be deployed in a random availability zone.
   # Context for deployment: the context including some kind of parameters for the deployment, such as fix_env, fix_variable, env, variable, env_env, env_variable.
   # - fix_env: Values for variable of this type are defined by the managed service provider in the OCL template. Runtime will inject it to deployer as environment variables. This variable is not visible to the end user.
   # - fix_variable: Values for variable of this type are defined by the managed service provider in the OCL template. Runtime will inject it to deployer as usual variables. This variable is not visible to the end user.
@@ -101,6 +106,16 @@ deployment:
       example: "kafka-secgroup-default"
       mandatory: false
   deployer: |
+    variable "region" {
+      type        = string
+      description = "The region to deploy the Kafka cluster instance."
+    }
+    
+    variable "availability_zone" {
+      type        = string
+      description = "The availability zone to deploy the Kafka cluster instance."
+    }
+    
     variable "flavor_id" {
       type        = string
       default     = "s6.large.2"
@@ -137,13 +152,6 @@ deployment:
       description = "The security group name of all nodes in the Kafka cluster instance."
     }
     
-    
-    variable "region" {
-      type        = string
-      default     = "cn-southwest-2"
-      description = "The region to deploy the Kafka cluster instance."
-    }
-    
     terraform {
       required_providers {
         huaweicloud = {
@@ -156,6 +164,8 @@ deployment:
     provider "huaweicloud" {
       region = var.region
     }
+    
+    data "huaweicloud_availability_zones" "osc-az" {}
 
     data "huaweicloud_vpcs" "existing" {
       name = var.vpc_name
@@ -170,10 +180,11 @@ deployment:
     }
 
     locals {
-      admin_passwd = var.admin_passwd == "" ? random_password.password.result : var.admin_passwd
-      vpc_id       = length(data.huaweicloud_vpcs.existing.vpcs) > 0 ? data.huaweicloud_vpcs.existing.vpcs[0].id : huaweicloud_vpc.new[0].id
-      subnet_id    = length(data.huaweicloud_vpc_subnets.existing.subnets)> 0 ? data.huaweicloud_vpc_subnets.existing.subnets[0].id : huaweicloud_vpc_subnet.new[0].id
-      secgroup_id  = length(data.huaweicloud_networking_secgroups.existing.security_groups) > 0 ? data.huaweicloud_networking_secgroups.existing.security_groups[0].id : huaweicloud_networking_secgroup.new[0].id
+      availability_zone = var.availability_zone == "" ? data.huaweicloud_availability_zones.osc-az.names[0] : var.availability_zone
+      admin_passwd      = var.admin_passwd == "" ? random_password.password.result : var.admin_passwd
+      vpc_id            = length(data.huaweicloud_vpcs.existing.vpcs) > 0 ? data.huaweicloud_vpcs.existing.vpcs[0].id : huaweicloud_vpc.new[0].id
+      subnet_id         = length(data.huaweicloud_vpc_subnets.existing.subnets)> 0 ? data.huaweicloud_vpc_subnets.existing.subnets[0].id : huaweicloud_vpc_subnet.new[0].id
+      secgroup_id       = length(data.huaweicloud_networking_secgroups.existing.security_groups) > 0 ? data.huaweicloud_networking_secgroups.existing.security_groups[0].id : huaweicloud_networking_secgroup.new[0].id
     }
 
     resource "huaweicloud_vpc" "new" {
@@ -229,8 +240,6 @@ deployment:
       security_group_id = local.secgroup_id
     }
 
-    data "huaweicloud_availability_zones" "osc-az" {}
-
     resource "random_id" "new" {
       byte_length = 4
     }
@@ -255,13 +264,13 @@ deployment:
     }
 
     module "ecs_kafka_service" {
-        source 					 = "git@github.com:terraform-huaweicloud-modules/terraform-huaweicloud-ecs.git"            
-        count 					 = var.worker_nodes_count
-        availability_zone        = data.huaweicloud_availability_zones.osc-az.names[0]
+        source 			 = "git@github.com:terraform-huaweicloud-modules/terraform-huaweicloud-ecs.git"            
+        count 			 = var.worker_nodes_count
+        availability_zone        = local.availability_zone
         subnet_id                = local.subnet_id
         instance_name            = "kafka-broker-module${random_id.new.hex}-${count.index}"
         instance_flavor_id       = var.flavor_id
-        instance_image_id        = "60197a48-4452-4119-96b2-ds6ab245ecb1"
+        instance_image_id        = data.huaweicloud_images_image.image.id
         security_group_ids       = [ local.secgroup_id ]
         system_disk_size         = 50
         admin_password           = local.admin_passwd
@@ -280,9 +289,9 @@ deployment:
     }
         
     module "ecs_zookeeper_service" {
-        source 					 = "git@github.com:terraform-huaweicloud-modules/terraform-huaweicloud-ecs.git"    
-        availability_zone        = data.huaweicloud_availability_zones.osc-az.names[0]
-        subnet_id          	     = local.subnet_id
+        source 			 = "git@github.com:terraform-huaweicloud-modules/terraform-huaweicloud-ecs.git"    
+        availability_zone        = local.availability_zone
+        subnet_id          	 = local.subnet_id
         instance_name            = "kafka-zookeeper-module${random_id.new.hex}"
         instance_flavor_id       = var.flavor_id
         instance_image_id        = data.huaweicloud_images_image.image.id

--- a/samples/huawei-Kafka.json
+++ b/samples/huawei-Kafka.json
@@ -4,7 +4,10 @@
   "csp": "huawei",
   "category": "middleware",
   "flavor": "1-zookeeper-with-3-worker-nodes-normal",
-  "region": "cn-southwest-2",
+  "region": {
+    "area": "Asia China",
+    "name": "cn-southwest-2"
+  },
   "customerServiceName": "default-kafka",
   "serviceHostingType": "self",
   "serviceRequestProperties": {}

--- a/samples/huawei-mysql.json
+++ b/samples/huawei-mysql.json
@@ -1,0 +1,18 @@
+{
+  "serviceName": "RDS-MySQL",
+  "version": "v1.0.0",
+  "csp": "huawei",
+  "category": "database",
+  "flavor": "2vCPUs-4GB-general",
+  "region": {
+    "area": "Asia China",
+    "name": "cn-southwest-2"
+  },
+  "customerServiceName": "default-kafka",
+  "serviceHostingType": "self",
+  "serviceRequestProperties": {},
+  "availabilityZones" : {
+    "primary_az" : "cn-southwest-2a",
+    "secondary_az" : "cn-southwest-2d"
+  }
+}

--- a/samples/huawei-mysql.yml
+++ b/samples/huawei-mysql.yml
@@ -1,17 +1,17 @@
 # The version of the Xpanse description language
 version: 1.0
 # The category of the service.
-category: middleware
+category: database
 # The Service provided by the ISV, the name will be shown on the console as a service.
-name: Kafka-cluster
+name: RDS-MySQL
 # The version of the service, the end-user can select the version they want to deploy.
 serviceVersion: v1.0.0
 # For the users may have more than one service, the @namespace can be used to separate the clusters.
-description: This is an enhanced Kafka cluster services by ISV-A.
+description: This is an enhanced MySQL server service by ISV-A.
 namespace: ISV-A
 # Icon for the service.
 icon: |
-  data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAGQAAACRAQMAAAAPc4+9AAAAAXNSR0IB2cksfwAAAAlwSFlzAAALEwAACxMBAJqcGAAAAAZQTFRF+/v7Hh8gVD0A0wAAAcVJREFUeJzNlc1twzAMhSX44KNH0CgaTd6gK3kUd4McDVTwq/hjiUyaIkV7qNA2/QCFIh+ppxB+svLNEqqBGTC0ANugBOwmCGDCFOAwIWGDOoqoODtN2BdL6wxD9NMTO9tXPa1PqL5M30W5p8lm5vNcF0t7ahSrVguqNqmMokRW4YQucVjBCBWH1Z2g3WDlW2skoYU+2x8JOtGedBF3k2iXMO0j16iUiI6gxzPdQhnU/s2G9pCO57QY2r6hvjPbKJHq7DRTRXT60avtuTRdbrFJI3mSZhNOqYjVbd99YyK1QKWzEqSWrE0k07U60uPaelflMzaaeu1KBuurHSsn572I1KWy2joX5ZBfWbS/VEt50H5P6aL4JxTuyJ/+QCNPX4PWF3Q8Xe1eF9FsLdD2VaOnaP2hWvs+zI58/7i3vH3nRFtDZpyTUNaZkON5XnBNsp8lrmDMrpvBr+b6pUl+4XbkQdndqnzYGzfuJm1JmIWimIbe6dndd/bk7gVce/cJdo3uIeLJl7+I2xTnPek67mjtDeppE7b03Ov+kSfDe3JweW53njxeGfXkaz28VeYd86+af/H8a7hgJKaebILaFzakLfxyfQLTxVB6K1K9KQAAAABJRU5ErkJggg==
+  data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACYAAAAmCAYAAACoPemuAAAACXBIWXMAAAsTAAALEwEAmpwYAAAEyUlEQVR4nO1XW2geVRA+52yrVrS2hGjFineleKNVSrHgXVD0RSWgVaoijVJaa0l2Zv+GslBERLw81Ae1XkB8ihaxlZhkZ3ZpUqOFasVLRVG0oGjVqFjx1ja/zNnN/tez+dNEC9KBJcnJmdlvbt/MKnVEDof4g+do5IcM8Hq1jk5Rh12Az9dILxmg/Qa5bB/gv+RMwP73gJAvtoCQD+SA6h/ggxq4V8Hggn8fEPBlGnmrQRpzAmoGEHmr8pNLpx2P58fXaOCkCIAG3qSRNrvv0JhGel0BLZ4inLL2/Ogmg/R2K5FRQIs9jG9t5a5GHlTIl08eEyTzDfKOltOFXDYB3W87cxI6GqlfrUnmtIxLIz07KVBoa2mFRtpwCHrrWwZmgL+org0D9GWB8T0a6FVVGmpXPp+ngbcYpG/dQGhf3d/bWkPVncyrK+o3pd400gu15zSgSvFS+V+DjY5ezwui6w3QO3Wp26zCZIZBHqpy/HfVuXPmhLg84FvqPPrDAIEKorYsxaMG6W57uWvgDI30sAZ6vlIG/JpNT4lOEtAmIBQCtpSxJpkjugbp1/rGmRCYBn7MkYJPVLjlWBWGJkt3SVg+67KteRkg7cpTFsSd9hCjE1TYe5QBHnHYfnBCYE5l5LLQQX6xFC81wJ9mwJ6uRIzeyO5LZO+sAOZlzu6UCVEoYXKMQf7TYWC31IcKonPz+2tHZmnkxw1QWBXxTTaC67adnN+zEeubbYC+d3Tm18XAJAqubvLjlRnwvQaop0Zv7cisinN9s6sbIovUcAb6EZd91cWnOXEZZN+p2NN/qod0c1Vd1IJrIl7AHeObh8JoYaHjAd/uNGQ7qnmof0w9pker2vxvGepWMRieq5H7LIUEUVsKytJFZR1CXq3C5DhnnSFvdEcM+DuH4mcZsGdkENuilrrJ9ainiqs25Aa7+SwDtEoAjzO8pZ/m73i3OaogObugaxJ7J0ypoiFlQNdl0TngYXxjUXoN0lsOytgvEW2iwMvrQvuk8JAQblNmLg21q266KC90TE5XQXRm/v+ugRNtFzdIWStIlng+XWWA7q2lI7664Xpt/XBZ+bRIVhPhGDvP/PgK5W8/3iB9VJWO0aYvD0NjgH4ar0/blenZbVZfVingFbY5aqIWP9AYMeB7nB2TRrDPOoC8seosJ1Y7VqpGS92G4tvxBPRh0Tu8ILq2McJhaOTlbkUas4o2avxBRgFXWt2OXs8AvW+A35Pf5UjupvVJbAd3XdqaOP6cckowPNcgfV5gYI/9POtO5mnkVypzk1ZVFfF9qaPJDA38ojiiSskFBunnArs71Oq+o1WhYHShQf6twMhu2SoqzkRttS+lH1L2z+0tNMjfFNjbK+StWpG0SN1hN8i/1MxMiaKQLSRLbLeOi0+LCngrpQhpqsmIc/3BrGthcIHxozs08FPyU+pNvqYMRHfJfibjS5qh0MFW1p0GsTVC3LxQqV8iVvjBa0dWMt8AbXcU+8vqkKU01G6Qvqrzcp899+OVE6RbnmVCvAKyDvQuu3ROSYL4kpo6Abu1LhdqaAHYUMqPNV/uozXNMxWRod0CiPKED/BBD+gGNZ1iixynCCwgVNMunTtnaqAn7J4v352Tez5O154mn3pH5P8u/wCL4t6vwR2T7QAAAABJRU5ErkJggg==
 # Reserved for CSP, aws,azure,ali,huawei and ...
 cloudServiceProvider:
   name: huawei
@@ -30,45 +30,33 @@ billing:
 serviceHostingType: self
 # The flavor of the service, the @category/@name/@version/@flavor can locate the specific service to be deployed.
 flavors:
-  - name: 1-zookeeper-with-3-worker-nodes-normal
-    # The fixed price during the period (the price applied one shot whatever is the service use)
-    fixedPrice: 40
-    # Properties for the service, which can be used by the deployment.
-    properties:
-      worker_nodes_count: 3
-      flavor_id: s6.large.4
-  - name: 1-zookeeper-with-3-worker-nodes-performance
+  - name: 2vCPUs-4GB-general
     # The fixed price during the period (the price applied one shot whatever is the service use)
     fixedPrice: 60
     # Properties for the service, which can be used by the deployment.
     properties:
-      worker_nodes_count: 3
-      flavor_id: s6.xlarge.4
-  - name: 1-zookeeper-with-5-worker-nodes-normal
-    # The fixed price during the period (the price applied one shot whatever is the service use)
-    fixedPrice: 60
-    # Properties for the service, which can be used by the deployment.
-    properties:
-      worker_nodes_count: 5
-      flavor_id: s6.large.4
-  - name: 1-zookeeper-with-5-worker-nodes-performance
+      flavor_id: rds.mysql.n1.large.2.ha
+  - name: 2vCPUs-4GB-dedicated
     # The fixed price during the period (the price applied one shot whatever is the service use)
     fixedPrice: 80
     # Properties for the service, which can be used by the deployment.
     properties:
-      worker_nodes_count: 5
-      flavor_id: s6.xlarge.4
+      flavor_id: rds.mysql.x1.large.2.ha
 # The contact details of the service.
 serviceProviderContactDetails:
-  email: ["test@test.com"]
+  email: [ "test@test.com" ]
 deployment:
   # kind, Supported values are terraform, opentofu.
   kind: terraform
   serviceAvailability:
-    - displayName: Availability Zone
-      varName: availability_zone
-      mandatory: false
-      description: The availability zone to deploy the service instance. If the value is empty, the service instance will be deployed in a random availability zone.
+    - displayName: Primary AZ
+      varName: primary_az
+      mandatory: true
+      description: The primary availability zone to deploy the service instance.
+    - displayName: Secondary AZ
+      varName: secondary_az
+      mandatory: true
+      description: The secondary availability zone to deploy the service instance. Different from primary_az.
   # Context for deployment: the context including some kind of parameters for the deployment, such as fix_env, fix_variable, env, variable, env_env, env_variable.
   # - fix_env: Values for variable of this type are defined by the managed service provider in the OCL template. Runtime will inject it to deployer as environment variables. This variable is not visible to the end user.
   # - fix_variable: Values for variable of this type are defined by the managed service provider in the OCL template. Runtime will inject it to deployer as usual variables. This variable is not visible to the end user.
@@ -79,7 +67,7 @@ deployment:
   # The parameters will be used to generate the API of the managed service.
   variables:
     - name: admin_passwd
-      description: The admin password of all nodes in the Kafka cluster instance. If the value is empty, will create a random password.
+      description: The admin password of all nodes in the MySQL server instance. If the value is empty, will create a random password.
       kind: variable
       dataType: string
       mandatory: false
@@ -88,73 +76,95 @@ deployment:
         maxLength: 16
         pattern: ^(?=.*?[A-Z])(?=.*?[a-z])(?=.*?[0-9])(?=.*?[#?!@$%^&*-]).{8,16}$
     - name: vpc_name
-      description: The vpc name of all nodes in the Kafka cluster instance. If the value is empty, will use the default value to find or create VPC.
+      description: The vpc name of all nodes in the MySQL server instance. If the value is empty, will use the default value to find or create VPC.
       kind: variable
       dataType: string
-      example: "kafka-vpc-default"
+      example: "mysql-vpc-default"
       mandatory: false
-      value: "kafka-vpc-default"
+      value: "mysql-vpc-default"
     - name: subnet_name
-      description: The sub network name of all nodes in the Kafka cluster instance. If the value is empty, will use the default value to find or create subnet.
+      description: The sub network name of all nodes in the MySQL server instance. If the value is empty, will use the default value to find or create subnet.
       kind: variable
       dataType: string
-      example: "kafka-subnet-default"
+      example: "mysql-subnet-default"
       mandatory: false
-      value: "kafka-subnet-default"
+      value: "mysql-subnet-default"
     - name: secgroup_name
-      description: The security group name of all nodes in the Kafka cluster instance. If the value is empty, will use the default value to find or create security group.
+      description: The security group name of all nodes in the MySQL server instance. If the value is empty, will use the default value to find or create security group.
       kind: variable
       dataType: string
-      example: "kafka-secgroup-default"
+      example: "mysql-secgroup-default"
       mandatory: false
-      value: "kafka-secgroup-default"
+      value: "mysql-secgroup-default"
   deployer: |
     variable "region" {
       type        = string
-      description = "The region to deploy the Kafka cluster instance."
-    }
-    
-    variable "availability_zone" {
-      type        = string
-      description = "The availability zone to deploy the Kafka cluster instance."
-    }
-    
-    variable "flavor_id" {
-      type        = string
-      default     = "s6.large.2"
-      description = "The flavor_id of all nodes in the Kafka cluster instance."
+      description = "The region to deploy the mysql service instance."
     }
 
-    variable "worker_nodes_count" {
+    variable "primary_az" {
       type        = string
-      default     = 3
-      description = "The worker nodes count in the Kafka cluster instance."
+      description = "The primary availability zone to deploy the mysql service instance."
+    }
+
+    variable "secondary_az" {
+      type        = string
+      description = "The secondary availability zone to deploy the mysql service instance."
+    }
+
+    variable "flavor_id" {
+      type        = string
+      description = "The flavor_id of the mysql service instance."
+    }
+
+    variable "db_version" {
+      type        = string
+      default     = "8.0"
+      description = "The version of the database to create in the mysql service instance."
     }
 
     variable "admin_passwd" {
       type        = string
       default     = ""
-      description = "The root password of all nodes in the Kafka cluster instance."
+      description = "The root password of the mysql service instance."
+    }
+
+    variable "db_name" {
+      type        = string
+      default     = "test"
+      description = "The database name to create in the mysql service instance."
+    }
+
+    variable "db_port" {
+      type        = number
+      default     = 3306
+      description = "The port of the created database in the mysql service instance."
+    }
+
+    variable "user_name" {
+      type        = string
+      default     = "test"
+      description = "The user name of the created database."
     }
 
     variable "vpc_name" {
       type        = string
-      default     = "kafka-vpc-default"
-      description = "The vpc name of all nodes in the Kafka cluster instance."
+      default     = "rds-vpc-default"
+      description = "The vpc name of the mysql service instance."
     }
 
     variable "subnet_name" {
       type        = string
-      default     = "kafka-subnet-default"
-      description = "The subnet name of all nodes in the Kafka cluster instance."
+      default     = "rds-subnet-default"
+      description = "The subnet name of the mysql service instance."
     }
 
     variable "secgroup_name" {
       type        = string
-      default     = "kafka-secgroup-default"
-      description = "The security group name of all nodes in the Kafka cluster instance."
+      default     = "rds-secgroup-default"
+      description = "The security group name of the mysql service instance."
     }
-    
+
     terraform {
       required_providers {
         huaweicloud = {
@@ -163,12 +173,10 @@ deployment:
         }
       }
     }
-    
+
     provider "huaweicloud" {
       region = var.region
     }
-    
-    data "huaweicloud_availability_zones" "osc-az" {}
 
     data "huaweicloud_vpcs" "existing" {
       name = var.vpc_name
@@ -183,7 +191,6 @@ deployment:
     }
 
     locals {
-      availability_zone = var.availability_zone == "" ? data.huaweicloud_availability_zones.osc-az.names[0] : var.availability_zone
       admin_passwd      = var.admin_passwd == "" ? random_password.password.result : var.admin_passwd
       vpc_id            = length(data.huaweicloud_vpcs.existing.vpcs) > 0 ? data.huaweicloud_vpcs.existing.vpcs[0].id : huaweicloud_vpc.new[0].id
       subnet_id         = length(data.huaweicloud_vpc_subnets.existing.subnets)> 0 ? data.huaweicloud_vpc_subnets.existing.subnets[0].id : huaweicloud_vpc_subnet.new[0].id
@@ -207,7 +214,6 @@ deployment:
     resource "huaweicloud_networking_secgroup" "new" {
       count       = length(data.huaweicloud_networking_secgroups.existing.security_groups) == 0 ? 1 : 0
       name        = var.secgroup_name
-      description = "Kafka cluster security group"
     }
 
     resource "huaweicloud_networking_secgroup_rule" "secgroup_rule_0" {
@@ -226,19 +232,8 @@ deployment:
       direction         = "ingress"
       ethertype         = "IPv4"
       protocol          = "tcp"
-      port_range_min    = 2181
-      port_range_max    = 2181
-      remote_ip_prefix  = "121.37.117.211/32"
-      security_group_id = local.secgroup_id
-    }
-
-    resource "huaweicloud_networking_secgroup_rule" "secgroup_rule_2" {
-      count             = length(data.huaweicloud_networking_secgroups.existing.security_groups) == 0 ? 1 : 0
-      direction         = "ingress"
-      ethertype         = "IPv4"
-      protocol          = "tcp"
-      port_range_min    = 9092
-      port_range_max    = 9093
+      port_range_min    = var.db_port
+      port_range_max    = var.db_port
       remote_ip_prefix  = "121.37.117.211/32"
       security_group_id = local.secgroup_id
     }
@@ -257,61 +252,92 @@ deployment:
       override_special = "#%@"
     }
 
-    resource "huaweicloud_kps_keypair" "keypair" {
-      name     = "keypair-kafka-${random_id.new.hex}"
-      key_file = "keypair-kafka-${random_id.new.hex}.pem"
-    }
-
-    data "huaweicloud_images_image" "image" {
-      name        = "Kafka-v3.3.2_Ubuntu-20.04"
-      most_recent = true
-    }
-
-    resource "huaweicloud_compute_instance" "zookeeper" {
-      availability_zone  = local.availability_zone
-      name               = "kafka-zookeeper-${random_id.new.hex}"
-      flavor_id          = var.flavor_id
-      security_group_ids = [ local.secgroup_id ]
-      image_id           = data.huaweicloud_images_image.image.id
-      key_pair           = huaweicloud_kps_keypair.keypair.name
-      network {
-        uuid = local.subnet_id
+    resource "huaweicloud_vpc_eip" "eip-tf" {
+      publicip {
+        type = "5_sbgp"
       }
-      user_data = <<EOF
-        #!bin/bash
-        echo root:${local.admin_passwd} | sudo chpasswd
-        sudo systemctl start docker
-        sudo systemctl enable docker
-        sudo docker run -d --name zookeeper-server --privileged=true -p 2181:2181 -e ALLOW_ANONYMOUS_LOGIN=yes bitnami/zookeeper:3.8.1
-      EOF
-    }
-
-    resource "huaweicloud_compute_instance" "kafka-broker" {
-      count              = var.worker_nodes_count
-      availability_zone  = local.availability_zone
-      name               = "kafka-broker-${random_id.new.hex}-${count.index}"
-      flavor_id          = var.flavor_id
-      security_group_ids = [ local.secgroup_id ]
-      image_id           = data.huaweicloud_images_image.image.id
-      key_pair           = huaweicloud_kps_keypair.keypair.name
-      network {
-        uuid = local.subnet_id
+      bandwidth {
+        name        = "rds-tf-${random_id.new.hex}"
+        size        = 5
+        share_type  = "PER"
+        charge_mode = "traffic"
       }
-      user_data = <<EOF
-        #!bin/bash
-        echo root:${local.admin_passwd} | sudo chpasswd
-        sudo systemctl start docker
-        sudo systemctl enable docker
-        private_ip=$(ifconfig | grep -A1 "eth0" | grep 'inet' | awk -F ' ' ' {print $2}'|awk ' {print $1}')
-        sudo docker run -d --name kafka-server --restart always -p 9092:9092 -p 9093:9093  -e KAFKA_BROKER_ID=${count.index}  -e KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://$private_ip:9092 -e KAFKA_LISTENERS=PLAINTEXT://0.0.0.0:9092 -e ALLOW_PLAINTEXT_LISTENER=yes -e KAFKA_CFG_ZOOKEEPER_CONNECT=${huaweicloud_compute_instance.zookeeper.access_ip_v4}:2181 bitnami/kafka:3.3.2
-      EOF
-      depends_on = [
-        huaweicloud_compute_instance.zookeeper
-      ]
     }
 
-    output "zookeeper_server" {
-      value = "${huaweicloud_compute_instance.zookeeper.access_ip_v4}:2181"
+
+    resource "huaweicloud_rds_instance" "instance" {
+      name                = "rds-tf-${random_id.new.hex}"
+      flavor              = var.flavor_id
+      ha_replication_mode = "async"
+      vpc_id              = local.vpc_id
+      subnet_id           = local.subnet_id
+      security_group_id   = local.secgroup_id
+      availability_zone   = [
+        var.primary_az,
+        var.secondary_az]
+
+      db {
+        type     = "MySQL"
+        version  = var.db_version
+        password = local.admin_passwd
+        port     = var.db_port
+      }
+
+      volume {
+        type = "ESSD"
+        size = 100
+      }
+
+      backup_strategy {
+        start_time = "01:00-02:00"
+        keep_days  = 1
+      }
+
+      parameters {
+        name  = "lower_case_table_names"
+        value = 1
+      }
+    }
+
+    resource "huaweicloud_vpc_eip_associate" "associated" {
+      public_ip  = huaweicloud_vpc_eip.eip-tf.address
+      network_id = local.subnet_id
+      fixed_ip   = huaweicloud_rds_instance.instance.fixed_ip
+    }
+
+    resource "huaweicloud_rds_mysql_database" "db" {
+      instance_id   = huaweicloud_rds_instance.instance.id
+      name          = var.db_name
+      character_set = "utf8"
+    }
+
+    resource "huaweicloud_rds_mysql_account" "user" {
+      instance_id = huaweicloud_rds_instance.instance.id
+      name        = var.user_name
+      password    = local.admin_passwd
+    }
+
+    resource "huaweicloud_rds_mysql_database_privilege" "privilege" {
+      instance_id = huaweicloud_rds_instance.instance.id
+      db_name     = var.db_name
+
+      users {
+        name     = var.user_name
+        readonly = false
+      }
+    }
+
+    resource "huaweicloud_rds_mysql_binlog" "test" {
+      instance_id            = huaweicloud_rds_instance.instance.id
+      binlog_retention_hours = 6
+    }
+
+    output "rds_instance_public_ips" {
+      value = huaweicloud_vpc_eip.eip-tf.address
+    }
+
+    output "rds_instance_private_ips" {
+      value = huaweicloud_rds_instance.instance.private_ips
     }
 
     output "admin_passwd" {

--- a/samples/openstack-Kafka.yml
+++ b/samples/openstack-Kafka.yml
@@ -64,6 +64,11 @@ serviceProviderContactDetails:
 deployment:
   # kind, Supported values are terraform, opentofu.
   kind: terraform
+  serviceAvailability:
+    - displayName: Availability Zone
+      varName: availability_zone
+      mandatory: false
+      description: The availability zone to deploy the service instance. If the value is empty, the service instance will be deployed in a random availability zone.
   # Context for deployment: the context including some kind of parameters for the deployment, such as fix_env, fix_variable, env, variable, env_env, env_variable.
   # - fix_env: Values for variable of this type are defined by the managed service provider in the OCL template. Runtime will inject it to deployer as environment variables. This variable is not visible to the end user.
   # - fix_variable: Values for variable of this type are defined by the managed service provider in the OCL template. Runtime will inject it to deployer as usual variables. This variable is not visible to the end user.
@@ -115,6 +120,16 @@ deployment:
       mandatory: false
       value: "kafka-secgroup-default"
   deployer: |
+    variable "region" {
+      type        = string
+      description = "The region to deploy the Kafka cluster instance."
+    }
+    
+    variable "availability_zone" {
+      type        = string
+      description = "The availability zone to deploy the Kafka cluster instance."
+    }
+    
     variable "flavor_id" {
       type        = string
       default     = "cirros256"
@@ -150,12 +165,6 @@ deployment:
       default     = "kafka-secgroup-default"
       description = "The security group name of all nodes in the Kafka cluster instance."
     }
-     
-    variable "region" {
-      type        = string
-      default     = "RegionOne"
-      description = "The region to deploy the Kafka cluster instance."
-    }
     
     terraform {
       required_providers {
@@ -163,11 +172,14 @@ deployment:
           source  = "terraform-provider-openstack/openstack"
           version = "~> 1.53.0"
         }
+      }
     }
     
     provider "openstack" {
       region = var.region
     }
+    
+    data "openstack_compute_availability_zones_v2" "osc-az" {}
 
     data "openstack_networking_network_v2" "existing" {
       name  = var.vpc_name
@@ -185,11 +197,12 @@ deployment:
     }
 
     locals {
-      admin_passwd  = var.admin_passwd == "" ? random_password.password.result : var.admin_passwd
-      vpc_id        = length(data.openstack_networking_network_v2.existing) > 0 ? data.openstack_networking_network_v2.existing[0].id : openstack_networking_network_v2.new[0].id
-      subnet_id     = length(data.openstack_networking_subnet_v2.existing) > 0 ? data.openstack_networking_subnet_v2.existing[0].id : openstack_networking_subnet_v2.new[0].id
-      secgroup_id   = length(data.openstack_networking_secgroup_v2.existing) > 0 ? data.openstack_networking_secgroup_v2.existing[0].id : openstack_networking_secgroup_v2.new[0].id
-      secgroup_name = length(data.openstack_networking_secgroup_v2.existing) > 0 ? data.openstack_networking_secgroup_v2.existing[0].name : openstack_networking_secgroup_v2.new[0].name
+      availability_zone = var.availability_zone == "" ? data.openstack_compute_availability_zones_v2.osc-az.names[0] : var.availability_zone
+      admin_passwd      = var.admin_passwd == "" ? random_password.password.result : var.admin_passwd
+      vpc_id            = length(data.openstack_networking_network_v2.existing) > 0 ? data.openstack_networking_network_v2.existing[0].id : openstack_networking_network_v2.new[0].id
+      subnet_id         = length(data.openstack_networking_subnet_v2.existing) > 0 ? data.openstack_networking_subnet_v2.existing[0].id : openstack_networking_subnet_v2.new[0].id
+      secgroup_id       = length(data.openstack_networking_secgroup_v2.existing) > 0 ? data.openstack_networking_secgroup_v2.existing[0].id : openstack_networking_secgroup_v2.new[0].id
+      secgroup_name     = length(data.openstack_networking_secgroup_v2.existing) > 0 ? data.openstack_networking_secgroup_v2.existing[0].name : openstack_networking_secgroup_v2.new[0].name
     }
 
     resource "openstack_networking_network_v2" "new" {
@@ -244,8 +257,6 @@ deployment:
       security_group_id = local.secgroup_id
     }
 
-    data "openstack_compute_availability_zones_v2" "osc-az" {}
-
     resource "random_id" "new" {
       byte_length = 4
     }
@@ -270,7 +281,7 @@ deployment:
     }
 
     resource "openstack_compute_instance_v2" "zookeeper" {
-      availability_zone  = data.openstack_compute_availability_zones_v2.osc-az.names[0]
+      availability_zone  = local.availability_zone
       name               = "kafka-zookeeper-${random_id.new.hex}"
       flavor_name        = var.flavor_id
       security_groups    = [ local.secgroup_name ]
@@ -290,7 +301,7 @@ deployment:
 
     resource "openstack_compute_instance_v2" "kafka-broker" {
       count              = var.worker_nodes_count
-      availability_zone  = data.openstack_compute_availability_zones_v2.osc-az.names[0]
+      availability_zone  = local.availability_zone
       name               = "kafka-broker-${count.index}-${random_id.new.hex}"
       flavor_name        = var.flavor_id
       security_groups    = [ local.secgroup_name ]

--- a/samples/plus-server-Kafka.yml
+++ b/samples/plus-server-Kafka.yml
@@ -68,6 +68,11 @@ serviceProviderContactDetails:
 deployment:
   # kind, Supported values are terraform, opentofu.
   kind: terraform
+  serviceAvailability:
+    - displayName: Availability Zone
+      varName: availability_zone
+      mandatory: false
+      description: The availability zone to deploy the service instance. If the value is empty, the service instance will be deployed in a random availability zone.
   # Context for deployment: the context including some kind of parameters for the deployment, such as fix_env, fix_variable, env, variable, env_env, env_variable.
   # - fix_env: Values for variable of this type are defined by the managed service provider in the OCL template. Runtime will inject it to deployer as environment variables. This variable is not visible to the end user.
   # - fix_variable: Values for variable of this type are defined by the managed service provider in the OCL template. Runtime will inject it to deployer as usual variables. This variable is not visible to the end user.
@@ -119,6 +124,16 @@ deployment:
       value: "kafka-secgroup-default"
       mandatory: false
   deployer: |
+    variable "region" {
+      type        = string
+      description = "The region to deploy the Kafka cluster instance."
+    }
+    
+    variable "availability_zone" {
+      type        = string
+      description = "The availability zone to deploy the Kafka cluster instance."
+    }
+    
     variable "flavor_name" {
       type        = string
       default     = "cirros256"
@@ -160,23 +175,20 @@ deployment:
       description = "The security group name of all nodes in the Kafka cluster instance."
     }
     
-    variable "region" {
-      type        = string
-      default     = "RegionOne"
-      description = "The region to deploy the Kafka cluster instance."
-    }
-    
     terraform {
       required_providers {
         openstack = {
           source  = "terraform-provider-openstack/openstack"
           version = "~> 1.53.0"
         }
+      }
     }
     
     provider "openstack" {
       region = var.region
     }
+    
+    data "openstack_compute_availability_zones_v2" "osc-az" {}
 
     data "openstack_networking_network_v2" "existing" {
       name  = var.vpc_name
@@ -194,11 +206,12 @@ deployment:
     }
 
     locals {
-      admin_passwd  = var.admin_passwd == "" ? random_password.password.result : var.admin_passwd
-      vpc_id        = length(data.openstack_networking_network_v2.existing) > 0 ? data.openstack_networking_network_v2.existing[0].id : openstack_networking_network_v2.new[0].id
-      subnet_id     = length(data.openstack_networking_subnet_v2.existing) > 0 ? data.openstack_networking_subnet_v2.existing[0].id : openstack_networking_subnet_v2.new[0].id
-      secgroup_id   = length(data.openstack_networking_secgroup_v2.existing) > 0 ? data.openstack_networking_secgroup_v2.existing[0].id : openstack_networking_secgroup_v2.new[0].id
-      secgroup_name = length(data.openstack_networking_secgroup_v2.existing) > 0 ? data.openstack_networking_secgroup_v2.existing[0].name : openstack_networking_secgroup_v2.new[0].name
+      availability_zone = var.availability_zone == "" ? data.openstack_compute_availability_zones_v2.osc-az.names[0] : var.availability_zone
+      admin_passwd      = var.admin_passwd == "" ? random_password.password.result : var.admin_passwd
+      vpc_id            = length(data.openstack_networking_network_v2.existing) > 0 ? data.openstack_networking_network_v2.existing[0].id : openstack_networking_network_v2.new[0].id
+      subnet_id         = length(data.openstack_networking_subnet_v2.existing) > 0 ? data.openstack_networking_subnet_v2.existing[0].id : openstack_networking_subnet_v2.new[0].id
+      secgroup_id       = length(data.openstack_networking_secgroup_v2.existing) > 0 ? data.openstack_networking_secgroup_v2.existing[0].id : openstack_networking_secgroup_v2.new[0].id
+      secgroup_name     = length(data.openstack_networking_secgroup_v2.existing) > 0 ? data.openstack_networking_secgroup_v2.existing[0].name : openstack_networking_secgroup_v2.new[0].name
     }
 
     resource "openstack_networking_network_v2" "new" {
@@ -253,8 +266,6 @@ deployment:
       security_group_id = local.secgroup_id
     }
 
-    data "openstack_compute_availability_zones_v2" "osc-az" {}
-
     resource "random_id" "new" {
       byte_length = 4
     }
@@ -274,7 +285,7 @@ deployment:
     }
 
     resource "openstack_compute_instance_v2" "zookeeper" {
-      availability_zone  = data.openstack_compute_availability_zones_v2.osc-az.names[0]
+      availability_zone  = local.availability_zone
       name               = "kafka-zookeeper-${random_id.new.hex}"
       flavor_name        = var.flavor_name
       security_groups    = [ local.secgroup_name ]
@@ -294,7 +305,7 @@ deployment:
 
     resource "openstack_compute_instance_v2" "kafka-broker" {
       count              = var.worker_nodes_count
-      availability_zone  = data.openstack_compute_availability_zones_v2.osc-az.names[0]
+      availability_zone  = local.availability_zone
       name               = "kafka-broker-${count.index}-${random_id.new.hex}"
       flavor_name        = var.flavor_name
       security_groups    = [ local.secgroup_name ]

--- a/samples/regio-cloud-Kafka.yml
+++ b/samples/regio-cloud-Kafka.yml
@@ -68,6 +68,11 @@ serviceProviderContactDetails:
 deployment:
   # kind, Supported values are terraform, opentofu.
   kind: terraform
+  serviceAvailability:
+    - displayName: Availability Zone
+      varName: availability_zone
+      mandatory: false
+      description: The availability zone to deploy the service instance. If the value is empty, the service instance will be deployed in a random availability zone.
   # Context for deployment: the context including some kind of parameters for the deployment, such as fix_env, fix_variable, env, variable, env_env, env_variable.
   # - fix_env: Values for variable of this type are defined by the managed service provider in the OCL template. Runtime will inject it to deployer as environment variables. This variable is not visible to the end user.
   # - fix_variable: Values for variable of this type are defined by the managed service provider in the OCL template. Runtime will inject it to deployer as usual variables. This variable is not visible to the end user.
@@ -119,6 +124,16 @@ deployment:
       value: "kafka-secgroup-default"
       mandatory: false
   deployer: |
+    variable "region" {
+      type        = string
+      description = "The region to deploy the Kafka cluster instance."
+    }
+    
+    variable "availability_zone" {
+      type        = string
+      description = "The availability zone to deploy the Kafka cluster instance."
+    }
+    
     variable "flavor_name" {
       type        = string
       default     = "cirros256"
@@ -160,23 +175,20 @@ deployment:
       description = "The security group name of all nodes in the Kafka cluster instance."
     }
     
-    variable "region" {
-      type        = string
-      default     = "RegionOne"
-      description = "The region to deploy the Kafka cluster instance."
-    }
-    
     terraform {
       required_providers {
         openstack = {
           source  = "terraform-provider-openstack/openstack"
           version = "~> 1.53.0"
         }
+      }
     }
     
     provider "openstack" {
       region = var.region
     }
+    
+    data "openstack_compute_availability_zones_v2" "osc-az" {}
 
     data "openstack_networking_network_v2" "existing" {
       name  = var.vpc_name
@@ -194,11 +206,12 @@ deployment:
     }
 
     locals {
-      admin_passwd  = var.admin_passwd == "" ? random_password.password.result : var.admin_passwd
-      vpc_id        = length(data.openstack_networking_network_v2.existing) > 0 ? data.openstack_networking_network_v2.existing[0].id : openstack_networking_network_v2.new[0].id
-      subnet_id     = length(data.openstack_networking_subnet_v2.existing) > 0 ? data.openstack_networking_subnet_v2.existing[0].id : openstack_networking_subnet_v2.new[0].id
-      secgroup_id   = length(data.openstack_networking_secgroup_v2.existing) > 0 ? data.openstack_networking_secgroup_v2.existing[0].id : openstack_networking_secgroup_v2.new[0].id
-      secgroup_name = length(data.openstack_networking_secgroup_v2.existing) > 0 ? data.openstack_networking_secgroup_v2.existing[0].name : openstack_networking_secgroup_v2.new[0].name
+      availability_zone = var.availability_zone == "" ? data.openstack_compute_availability_zones_v2.osc-az.names[0] : var.availability_zone
+      admin_passwd      = var.admin_passwd == "" ? random_password.password.result : var.admin_passwd
+      vpc_id            = length(data.openstack_networking_network_v2.existing) > 0 ? data.openstack_networking_network_v2.existing[0].id : openstack_networking_network_v2.new[0].id
+      subnet_id         = length(data.openstack_networking_subnet_v2.existing) > 0 ? data.openstack_networking_subnet_v2.existing[0].id : openstack_networking_subnet_v2.new[0].id
+      secgroup_id       = length(data.openstack_networking_secgroup_v2.existing) > 0 ? data.openstack_networking_secgroup_v2.existing[0].id : openstack_networking_secgroup_v2.new[0].id
+      secgroup_name     = length(data.openstack_networking_secgroup_v2.existing) > 0 ? data.openstack_networking_secgroup_v2.existing[0].name : openstack_networking_secgroup_v2.new[0].name
     }
 
     resource "openstack_networking_network_v2" "new" {
@@ -253,8 +266,6 @@ deployment:
       security_group_id = local.secgroup_id
     }
 
-    data "openstack_compute_availability_zones_v2" "osc-az" {}
-
     resource "random_id" "new" {
       byte_length = 4
     }
@@ -274,7 +285,7 @@ deployment:
     }
 
     resource "openstack_compute_instance_v2" "zookeeper" {
-      availability_zone  = data.openstack_compute_availability_zones_v2.osc-az.names[0]
+      availability_zone  = local.availability_zone
       name               = "kafka-zookeeper-${random_id.new.hex}"
       flavor_name        = var.flavor_name
       security_groups    = [ local.secgroup_name ]
@@ -294,7 +305,7 @@ deployment:
 
     resource "openstack_compute_instance_v2" "kafka-broker" {
       count              = var.worker_nodes_count
-      availability_zone  = data.openstack_compute_availability_zones_v2.osc-az.names[0]
+      availability_zone  = local.availability_zone
       name               = "kafka-broker-${count.index}-${random_id.new.hex}"
       flavor_name        = var.flavor_name
       security_groups    = [ local.secgroup_name ]


### PR DESCRIPTION
fixes #1439 
Register service template with AZ configs:
![chrome_8q6jIiMMyC](https://github.com/eclipse-xpanse/xpanse/assets/121531362/09543909-526a-44ae-b471-6cac6dccb8bf)

New openApi of service with AZ configs:
![chrome_yl5YjCYpZT](https://github.com/eclipse-xpanse/xpanse/assets/121531362/367824a6-1215-4e67-8aff-f3ca599450dd)
![chrome_aZEPX0HKPb](https://github.com/eclipse-xpanse/xpanse/assets/121531362/cbdf5dc8-5fb3-4892-9b20-b87d7bdf913c)

Throw exception without lost required AZ in the deploy request:
![chrome_CXKaLWswn2](https://github.com/eclipse-xpanse/xpanse/assets/121531362/b8ff85a0-ad20-4228-96ef-79b2442fa1b6)

Deploy success with required AZ in the deploy request:
![chrome_kFeb5Rt1Nr](https://github.com/eclipse-xpanse/xpanse/assets/121531362/0da598af-003e-49ec-aa8d-e882b0bc4c8e)
Terraform variables contains AZ variables:
![notepad++_LXatctTAC2](https://github.com/eclipse-xpanse/xpanse/assets/121531362/05d60311-019f-4bdf-b977-60d449feecfa)
