### PR TITLE
make all role protection in the API layer optional

### DIFF
--- a/modules/api/src/test/resources/ocl_terraform_test.yml
+++ b/modules/api/src/test/resources/ocl_terraform_test.yml
@@ -5,7 +5,7 @@ category: others
 # The Service provided by the ISV, the name will be shown on the console as a service.
 name: terraform-test
 # The version of the service, the end-user can select the version they want to deploy.
-serviceVersion: v1.0.0
+serviceVersion: 1.0.0
 # For the users may have more than one service, the @namespace can be used to separate the clusters.
 description: terraform test with local script.
 namespace: ISV-A

--- a/modules/deployment/src/test/resources/ocl_terraform_from_git_test.yml
+++ b/modules/deployment/src/test/resources/ocl_terraform_from_git_test.yml
@@ -5,7 +5,7 @@ category: others
 # The Service provided by the ISV, the name will be shown on the console as a service.
 name: terraform-test
 # The version of the service, the end-user can select the version they want to deploy.
-serviceVersion: v1.0.0
+serviceVersion: 1.0.0
 # For the users may have more than one service, the @namespace can be used to separate the clusters.
 description: terraform test with script from git repo.
 namespace: ISV-A

--- a/modules/deployment/src/test/resources/ocl_terraform_test.yml
+++ b/modules/deployment/src/test/resources/ocl_terraform_test.yml
@@ -5,7 +5,7 @@ category: others
 # The Service provided by the ISV, the name will be shown on the console as a service.
 name: terraform-test
 # The version of the service, the end-user can select the version they want to deploy.
-serviceVersion: v1.0.0
+serviceVersion: 1.0.0
 # For the users may have more than one service, the @namespace can be used to separate the clusters.
 description: terraform test with local script.
 namespace: ISV-A

--- a/modules/models/src/test/resources/ocl_terraform_test.yml
+++ b/modules/models/src/test/resources/ocl_terraform_test.yml
@@ -5,7 +5,7 @@ category: others
 # The Service provided by the ISV, the name will be shown on the console as a service.
 name: terraform-test
 # The version of the service, the end-user can select the version they want to deploy.
-serviceVersion: v1.0.0
+serviceVersion: 1.0.0
 # For the users may have more than one service, the @namespace can be used to separate the clusters.
 description: terraform test with local script.
 namespace: ISV-A

--- a/modules/security/src/main/java/org/eclipse/xpanse/modules/security/IdentityProviderManager.java
+++ b/modules/security/src/main/java/org/eclipse/xpanse/modules/security/IdentityProviderManager.java
@@ -17,6 +17,7 @@ import org.eclipse.xpanse.modules.models.common.enums.Csp;
 import org.eclipse.xpanse.modules.models.common.exceptions.UnsupportedEnumValueException;
 import org.eclipse.xpanse.modules.security.common.CurrentUserInfo;
 import org.eclipse.xpanse.modules.security.common.CurrentUserInfoHolder;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.stereotype.Component;
@@ -35,11 +36,19 @@ public class IdentityProviderManager {
     @Resource
     private ApplicationContext applicationContext;
 
+    @Value("${enable.web.security:false}")
+    private Boolean webSecurityIsEnabled;
+
     /**
      * Instantiates active IdentityProviderService.
      */
     @Bean
     public void loadActiveIdentityProviderServices() {
+        if (!webSecurityIsEnabled) {
+            log.info("Web security is disabled.");
+            activeIdentityProviderService = null;
+            return;
+        }
         List<IdentityProviderService> identityProviderServices =
                 applicationContext.getBeansOfType(IdentityProviderService.class)
                         .values().stream().toList();

--- a/modules/security/src/main/java/org/eclipse/xpanse/modules/security/OpenApiOauth2Config.java
+++ b/modules/security/src/main/java/org/eclipse/xpanse/modules/security/OpenApiOauth2Config.java
@@ -48,6 +48,9 @@ public class OpenApiOauth2Config {
     @Value("${authorization.metadata.scope}")
     private String metadataScope;
 
+    @Value("${enable.role.protection:false}")
+    private Boolean roleProtectionIsEnabled;
+
     /**
      * Config open api.
      *
@@ -58,10 +61,7 @@ public class OpenApiOauth2Config {
 
         OAuthFlows oauthFlows = new OAuthFlows();
         OAuthFlow oauthFlow = new OAuthFlow().authorizationUrl(authorizationUrl).tokenUrl(tokenUrl)
-                .scopes(new Scopes().addString(openidScope, "mandatory must be selected.")
-                        .addString(profileScope, "mandatory must be selected.")
-                        .addString(rolesScope, "mandatory must be selected.")
-                        .addString(metadataScope, "mandatory must be selected."));
+                .scopes(getScopes());
         oauthFlows.authorizationCode(oauthFlow);
 
         SecurityScheme securityScheme = new SecurityScheme();
@@ -76,5 +76,16 @@ public class OpenApiOauth2Config {
                 .description("RESTful Services to interact with Xpanse runtime.");
 
         return new OpenAPI().info(info).components(components).addSecurityItem(securityRequirement);
+    }
+
+    private Scopes getScopes() {
+        Scopes scopes = new Scopes();
+        if (roleProtectionIsEnabled) {
+            scopes.addString(rolesScope, "mandatory must be selected.");
+        }
+        scopes.addString(openidScope, "mandatory must be selected.");
+        scopes.addString(profileScope, "mandatory must be selected.");
+        scopes.addString(metadataScope, "mandatory must be selected.");
+        return scopes;
     }
 }

--- a/modules/security/src/main/java/org/eclipse/xpanse/modules/security/RequiredRoleDescriptionCustomizer.java
+++ b/modules/security/src/main/java/org/eclipse/xpanse/modules/security/RequiredRoleDescriptionCustomizer.java
@@ -9,16 +9,18 @@ package org.eclipse.xpanse.modules.security;
 import io.swagger.v3.oas.models.Operation;
 import java.util.Objects;
 import org.springdoc.core.customizers.OperationCustomizer;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 import org.springframework.security.access.annotation.Secured;
-import org.springframework.stereotype.Component;
 import org.springframework.web.method.HandlerMethod;
 
 /**
  * Customizer for appending required role to description of Swagger Annotation operation.
  */
 @Profile("oauth")
-@Component
+@Configuration
+@ConditionalOnProperty(name = "enable.role.protection", havingValue = "true", matchIfMissing = true)
 public class RequiredRoleDescriptionCustomizer implements OperationCustomizer {
 
     @Override

--- a/runtime/src/main/resources/application-noauth.properties
+++ b/runtime/src/main/resources/application-noauth.properties
@@ -3,6 +3,8 @@
 # SPDX-FileCopyrightText: Huawei Inc.
 #
 #
+enable.web.security=false
+enable.role.protection=false
 ## exclude spring security auto configuration
 spring.autoconfigure.exclude[0]=org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration
 spring.autoconfigure.exclude[1]=org.springframework.boot.actuate.autoconfigure.security.servlet.ManagementWebSecurityAutoConfiguration

--- a/runtime/src/main/resources/application-oauth.properties
+++ b/runtime/src/main/resources/application-oauth.properties
@@ -3,6 +3,8 @@
 # SPDX-FileCopyrightText: Huawei Inc.
 #
 #
+enable.web.security=true
+enable.role.protection=true
 # set authorization server endpoint
 authorization.server.endpoint=
 # set authorization client id for api
@@ -30,7 +32,6 @@ springdoc.swagger-ui.oauth.clientId=${authorization.swagger.ui.client.id}
 # spring security oauth2 config
 logging.level.org.springframework.web=info
 logging.level.org.springframework.security=debug
-
 authorization.openid.scope=
 authorization.profile.scope=
 authorization.metadata.scope=

--- a/samples/develop/huawei-compute-opentofu-dev.yml
+++ b/samples/develop/huawei-compute-opentofu-dev.yml
@@ -41,6 +41,9 @@ flavors:
     # Properties for the service, which can be used by the deployment.
     properties:
       flavor_id: s6.large.2
+    modificationImpact:
+      isDataLost: true
+      isServiceInterrupted: true
   - name: 2vCPUs-8GB-normal
     # The fixed price during the period (the price applied one shot whatever is the service use)
     fixedPrice: 30

--- a/samples/develop/huawei-compute-terraform-dev.yml
+++ b/samples/develop/huawei-compute-terraform-dev.yml
@@ -5,7 +5,7 @@ category: compute
 # The Service provided by the ISV, the name will be shown on the console as a service.
 name: terraform-ecs
 # The version of the service, the end-user can select the version they want to deploy.
-serviceVersion: 0.0.1
+serviceVersion: 1.0.0
 # For the users may have more than one service, the @namespace can be used to separate the clusters.
 description: This is an ehanced compute services by ISV-A.
 namespace: ISV-A

--- a/samples/develop/openstack-compute-terraform-dev.yml
+++ b/samples/develop/openstack-compute-terraform-dev.yml
@@ -5,7 +5,7 @@ category: compute
 # The Service provided by the ISV, the name will be shown on the console as a service.
 name: openstack-ecs
 # The version of the service, the end-user can select the version they want to deploy.
-serviceVersion: v1.0.0
+serviceVersion: 1.0.0
 # For the users may have more than one service, the @namespace can be used to separate the clusters.
 description: This is an ehanced compute services by ISV-A.
 namespace: ISV-A


### PR DESCRIPTION
fixes #1493
When the configuration property `enable.role.protection` is true:
Authorize with the user 'csp-huawei' only has role 'csp':
![chrome_ccigFeKtfO](https://github.com/eclipse-xpanse/xpanse/assets/121531362/3d8f6b60-edaf-42a1-a5c0-a51c2532d5a6)
Request the API required role admin or isv or user, and the service returns 403.
![image](https://github.com/eclipse-xpanse/xpanse/assets/121531362/a4d6679c-9b35-4716-9fab-54fd87c42a98)


When the configuration property `enable.role.protection` is false:
Authorize with the user 'csp-huawei' only has role 'csp':
![image](https://github.com/eclipse-xpanse/xpanse/assets/121531362/301a124a-7533-4f95-a1f2-18f17bb35200)
Request the same API and the service returns 200.
![image](https://github.com/eclipse-xpanse/xpanse/assets/121531362/307a0698-9594-443a-9a48-ddcc108f8a27)


