### PR TITLE
make authentication in API layer optional

### DIFF
--- a/modules/api/src/main/java/org/eclipse/xpanse/api/controllers/AuthorizationApi.java
+++ b/modules/api/src/main/java/org/eclipse/xpanse/api/controllers/AuthorizationApi.java
@@ -19,6 +19,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.eclipse.xpanse.modules.models.security.TokenResponse;
 import org.eclipse.xpanse.modules.security.IdentityProviderManager;
 import org.eclipse.xpanse.modules.security.IdentityProviderService;
+import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -30,8 +31,9 @@ import org.springframework.web.bind.annotation.RestController;
  * REST interface methods for authentication.
  */
 @Slf4j
-@RestController
+@Profile("oauth")
 @CrossOrigin
+@RestController
 public class AuthorizationApi {
 
     @Resource
@@ -65,9 +67,9 @@ public class AuthorizationApi {
     @GetMapping(value = "/auth/token")
     TokenResponse getAccessToken(
             @Parameter(name = "code", required = true, description = "The authorization code.")
-                    String code,
+            String code,
             @Parameter(name = "state", description = "Opaque value used to maintain state.")
-                    String state) {
+            String state) {
         IdentityProviderService identityProviderService =
                 identityProviderManager.getActiveIdentityProviderService();
         if (Objects.nonNull(identityProviderService)) {

--- a/modules/security/src/main/java/org/eclipse/xpanse/modules/security/noauth/OpenApiNoAuthConfig.java
+++ b/modules/security/src/main/java/org/eclipse/xpanse/modules/security/noauth/OpenApiNoAuthConfig.java
@@ -1,0 +1,40 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * SPDX-FileCopyrightText: Huawei Inc.
+ *
+ */
+
+package org.eclipse.xpanse.modules.security.noauth;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+
+/**
+ * Configuration springdoc without security oauth2.
+ */
+@Profile({"noauth"})
+@Configuration
+public class OpenApiNoAuthConfig {
+
+    @Value("${app.version}")
+    private String appVersion;
+
+    /**
+     * Config open api.
+     *
+     * @return the open api
+     */
+    @Bean
+    public OpenAPI customOpenApi() {
+
+        Info info = new Info().title("XpanseAPI").version(appVersion)
+                .description("RESTful Services to interact with Xpanse runtime.");
+
+        return new OpenAPI().info(info);
+    }
+}

--- a/runtime/src/main/resources/application-noauth.properties
+++ b/runtime/src/main/resources/application-noauth.properties
@@ -1,0 +1,8 @@
+#
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Huawei Inc.
+#
+#
+## exclude spring security auto configuration
+spring.autoconfigure.exclude[0]=org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration
+spring.autoconfigure.exclude[1]=org.springframework.boot.actuate.autoconfigure.security.servlet.ManagementWebSecurityAutoConfiguration


### PR DESCRIPTION
fixes #1498 
When  the application  is running with the profile `noauth`,  all the APIs can be called successfully without authentication.
![image](https://github.com/eclipse-xpanse/xpanse/assets/121531362/22dd9318-9c12-46bc-9558-7590fc25bcab)
![chrome_e9ZJc0MuOw](https://github.com/eclipse-xpanse/xpanse/assets/121531362/c5cf3370-3e10-4d4c-aaf4-5c274201cc1a)
![chrome_AKpax2ZHQG](https://github.com/eclipse-xpanse/xpanse/assets/121531362/6626920c-f3fa-495f-b1bd-7b12fe09861c)

