### PR TITLE
refactor methods about check permissions and user info without auth

### DIFF
--- a/modules/api/src/main/java/org/eclipse/xpanse/api/config/ServiceTemplateEntityConverter.java
+++ b/modules/api/src/main/java/org/eclipse/xpanse/api/config/ServiceTemplateEntityConverter.java
@@ -7,6 +7,7 @@ package org.eclipse.xpanse.api.config;
 
 import java.util.List;
 import java.util.Objects;
+import org.apache.commons.lang3.StringUtils;
 import org.eclipse.xpanse.api.controllers.ServiceCatalogApi;
 import org.eclipse.xpanse.modules.database.servicetemplate.ServiceTemplateEntity;
 import org.eclipse.xpanse.modules.models.servicetemplate.FlavorBasic;
@@ -35,7 +36,11 @@ public class ServiceTemplateEntityConverter {
             serviceTemplateDetailVo.setIcon(serviceTemplateEntity.getOcl().getIcon());
             serviceTemplateDetailVo.setDescription(
                     serviceTemplateEntity.getOcl().getDescription());
-            serviceTemplateDetailVo.setNamespace(serviceTemplateEntity.getOcl().getNamespace());
+            if (StringUtils.isNotEmpty(serviceTemplateEntity.getNamespace())) {
+                serviceTemplateDetailVo.setNamespace(serviceTemplateEntity.getNamespace());
+            } else {
+                serviceTemplateDetailVo.setNamespace(serviceTemplateEntity.getOcl().getNamespace());
+            }
             serviceTemplateDetailVo.setBilling(serviceTemplateEntity.getOcl().getBilling());
             serviceTemplateDetailVo.setFlavors(serviceTemplateEntity.getOcl().getFlavors());
             serviceTemplateDetailVo.setDeployment(serviceTemplateEntity.getOcl().getDeployment());

--- a/modules/api/src/main/java/org/eclipse/xpanse/api/controllers/CspServiceTemplateApi.java
+++ b/modules/api/src/main/java/org/eclipse/xpanse/api/controllers/CspServiceTemplateApi.java
@@ -17,7 +17,6 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.annotation.Resource;
 import jakarta.validation.Valid;
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
 import org.eclipse.xpanse.api.config.ServiceTemplateEntityConverter;
@@ -29,7 +28,7 @@ import org.eclipse.xpanse.modules.models.servicetemplate.ReviewRegistrationReque
 import org.eclipse.xpanse.modules.models.servicetemplate.enums.ServiceHostingType;
 import org.eclipse.xpanse.modules.models.servicetemplate.enums.ServiceRegistrationState;
 import org.eclipse.xpanse.modules.models.servicetemplate.view.ServiceTemplateDetailVo;
-import org.eclipse.xpanse.modules.security.IdentityProviderManager;
+import org.eclipse.xpanse.modules.security.UserServiceHelper;
 import org.eclipse.xpanse.modules.servicetemplate.ServiceTemplateManage;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -58,7 +57,7 @@ public class CspServiceTemplateApi {
     @Resource
     private ServiceTemplateManage serviceTemplateManage;
     @Resource
-    private IdentityProviderManager identityProviderManager;
+    private UserServiceHelper userServiceHelper;
 
     /**
      * List service templates with query params.
@@ -88,10 +87,9 @@ public class CspServiceTemplateApi {
             @Parameter(name = "serviceRegistrationState", description = "state of registration")
             @RequestParam(name = "serviceRegistrationState", required = false)
             ServiceRegistrationState serviceRegistrationState) {
-        Optional<Csp> cspOptional = identityProviderManager.getCspFromMetadata();
-        Csp cspName = cspOptional.orElse(null);
+        Csp csp = userServiceHelper.getCurrentUserManageCsp();
         ServiceTemplateQueryModel queryRequest =
-                new ServiceTemplateQueryModel(categoryName, cspName, serviceName, serviceVersion,
+                new ServiceTemplateQueryModel(categoryName, csp, serviceName, serviceVersion,
                         serviceHostingType, serviceRegistrationState, false);
         List<ServiceTemplateEntity> serviceTemplateEntities =
                 serviceTemplateManage.listServiceTemplates(queryRequest);

--- a/modules/api/src/main/java/org/eclipse/xpanse/api/controllers/ExistingCloudResourcesApi.java
+++ b/modules/api/src/main/java/org/eclipse/xpanse/api/controllers/ExistingCloudResourcesApi.java
@@ -13,16 +13,14 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.annotation.Resource;
 import java.util.List;
-import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.eclipse.xpanse.modules.models.common.enums.Csp;
 import org.eclipse.xpanse.modules.models.service.deploy.enums.DeployResourceKind;
 import org.eclipse.xpanse.modules.orchestrator.OrchestratorPlugin;
 import org.eclipse.xpanse.modules.orchestrator.PluginManager;
-import org.eclipse.xpanse.modules.security.IdentityProviderManager;
+import org.eclipse.xpanse.modules.security.UserServiceHelper;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.access.annotation.Secured;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -47,7 +45,7 @@ public class ExistingCloudResourcesApi {
     private PluginManager pluginManager;
 
     @Resource
-    private IdentityProviderManager identityProviderManager;
+    private UserServiceHelper userServiceHelper;
 
     /**
      * List existing cloud resources based on type.
@@ -66,13 +64,9 @@ public class ExistingCloudResourcesApi {
             @Parameter(name = "deployResourceKind", description = "kind of the CloudResource")
             @PathVariable("deployResourceKind") DeployResourceKind deployResourceKind) {
 
-        Optional<String> userIdOptional = identityProviderManager.getCurrentLoginUserId();
-        if (userIdOptional.isEmpty()) {
-            throw new AccessDeniedException(
-                    "No permissions to view resources of services belonging to other users.");
-        }
+        String userId = userServiceHelper.getCurrentUserId();
         OrchestratorPlugin orchestratorPlugin = pluginManager.getOrchestratorPlugin(csp);
-        return orchestratorPlugin.getExistingResourceNamesWithKind(userIdOptional.get(), region,
+        return orchestratorPlugin.getExistingResourceNamesWithKind(userId, region,
                 deployResourceKind);
     }
 }

--- a/modules/api/src/main/java/org/eclipse/xpanse/api/controllers/ServiceMigrationApi.java
+++ b/modules/api/src/main/java/org/eclipse/xpanse/api/controllers/ServiceMigrationApi.java
@@ -18,7 +18,6 @@ import jakarta.validation.Valid;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
 import org.activiti.engine.runtime.ProcessInstance;
@@ -30,7 +29,7 @@ import org.eclipse.xpanse.modules.deployment.migration.consts.MigrateConstants;
 import org.eclipse.xpanse.modules.models.workflow.migrate.MigrateRequest;
 import org.eclipse.xpanse.modules.models.workflow.migrate.enums.MigrationStatus;
 import org.eclipse.xpanse.modules.models.workflow.migrate.view.ServiceMigrationDetails;
-import org.eclipse.xpanse.modules.security.IdentityProviderManager;
+import org.eclipse.xpanse.modules.security.UserServiceHelper;
 import org.eclipse.xpanse.modules.workflow.utils.WorkflowUtils;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -61,7 +60,7 @@ public class ServiceMigrationApi {
     private DeployServiceEntityHandler deployServiceEntityHandler;
 
     @Resource
-    private IdentityProviderManager identityProviderManager;
+    private UserServiceHelper userServiceHelper;
 
     @Resource
     private WorkflowUtils workflowUtils;
@@ -140,13 +139,7 @@ public class ServiceMigrationApi {
     }
 
     private String getUserId() {
-        Optional<String> userIdOptional = identityProviderManager.getCurrentLoginUserId();
-        String userId = userIdOptional.orElse(null);
-        if (StringUtils.isBlank(userId)) {
-            throw new AccessDeniedException(
-                    "No permissions to migrate services belonging to other users.");
-        }
-        return userId;
+        return userServiceHelper.getCurrentUserId();
     }
 
     private Map<String, Object> getMigrateProcessVariable(MigrateRequest migrateRequest,

--- a/modules/api/src/main/java/org/eclipse/xpanse/api/controllers/UserCloudCredentialsApi.java
+++ b/modules/api/src/main/java/org/eclipse/xpanse/api/controllers/UserCloudCredentialsApi.java
@@ -12,18 +12,16 @@ import static org.eclipse.xpanse.modules.security.common.RoleConstants.ROLE_USER
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.annotation.Resource;
 import jakarta.validation.Valid;
 import java.util.List;
-import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.eclipse.xpanse.modules.credential.CredentialCenter;
 import org.eclipse.xpanse.modules.models.common.enums.Csp;
-import org.eclipse.xpanse.modules.models.common.exceptions.UserNotLoggedInException;
 import org.eclipse.xpanse.modules.models.credential.AbstractCredentialInfo;
 import org.eclipse.xpanse.modules.models.credential.CreateCredential;
 import org.eclipse.xpanse.modules.models.credential.enums.CredentialType;
-import org.eclipse.xpanse.modules.security.IdentityProviderManager;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.eclipse.xpanse.modules.security.UserServiceHelper;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.security.access.annotation.Secured;
@@ -49,15 +47,13 @@ import org.springframework.web.bind.annotation.RestController;
 @Secured({ROLE_ADMIN, ROLE_USER})
 public class UserCloudCredentialsApi {
 
-    private final CredentialCenter credentialCenter;
-    private final IdentityProviderManager identityProviderManager;
 
-    @Autowired
-    public UserCloudCredentialsApi(CredentialCenter credentialCenter,
-            IdentityProviderManager identityProviderManager) {
-        this.credentialCenter = credentialCenter;
-        this.identityProviderManager = identityProviderManager;
-    }
+    @Resource
+    private CredentialCenter credentialCenter;
+
+    @Resource
+    private UserServiceHelper userServiceHelper;
+
 
     /**
      * Get all cloud provider credentials added by the user for a cloud service provider.
@@ -141,11 +137,7 @@ public class UserCloudCredentialsApi {
     }
 
     private String getUserId() {
-        Optional<String> userIdOptional = identityProviderManager.getCurrentLoginUserId();
-        if (userIdOptional.isEmpty()) {
-            throw new UserNotLoggedInException("Unable to get current login information");
-        }
-        return userIdOptional.get();
+        return userServiceHelper.getCurrentUserId();
     }
 
 }

--- a/modules/api/src/main/java/org/eclipse/xpanse/api/controllers/WorkFlowApi.java
+++ b/modules/api/src/main/java/org/eclipse/xpanse/api/controllers/WorkFlowApi.java
@@ -16,12 +16,11 @@ import jakarta.annotation.Resource;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.eclipse.xpanse.modules.deployment.migration.consts.MigrateConstants;
 import org.eclipse.xpanse.modules.models.workflow.TaskStatus;
 import org.eclipse.xpanse.modules.models.workflow.WorkFlowTask;
-import org.eclipse.xpanse.modules.security.IdentityProviderManager;
+import org.eclipse.xpanse.modules.security.UserServiceHelper;
 import org.eclipse.xpanse.modules.workflow.utils.WorkflowUtils;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -50,7 +49,7 @@ public class WorkFlowApi {
     private WorkflowUtils workflowUtils;
 
     @Resource
-    private IdentityProviderManager identityProviderManager;
+    private UserServiceHelper userServiceHelper;
 
     /**
      * Query tasks of the given user by status.
@@ -62,8 +61,8 @@ public class WorkFlowApi {
     public List<WorkFlowTask> queryTasks(
             @Parameter(name = "status", description = "the status of task")
             @RequestParam(name = "status", required = false) TaskStatus status) {
-        Optional<String> userIdOptional = identityProviderManager.getCurrentLoginUserId();
-        return workflowUtils.queryAllTasks(status, userIdOptional.orElse(null));
+        String currentUserId = userServiceHelper.getCurrentUserId();
+        return workflowUtils.queryAllTasks(status, currentUserId);
     }
 
     /**

--- a/modules/api/src/test/java/org/eclipse/xpanse/api/exceptions/handler/DeploymentExceptionHandlerTest.java
+++ b/modules/api/src/test/java/org/eclipse/xpanse/api/exceptions/handler/DeploymentExceptionHandlerTest.java
@@ -30,6 +30,7 @@ import org.eclipse.xpanse.modules.models.service.deploy.exceptions.VariableInval
 import org.eclipse.xpanse.modules.orchestrator.OrchestratorPlugin;
 import org.eclipse.xpanse.modules.orchestrator.PluginManager;
 import org.eclipse.xpanse.modules.security.IdentityProviderManager;
+import org.eclipse.xpanse.modules.security.UserServiceHelper;
 import org.eclipse.xpanse.modules.workflow.utils.WorkflowUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -45,8 +46,8 @@ import org.springframework.web.context.WebApplicationContext;
 
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = {ServiceDeployerApi.class, DeployService.class, WorkflowUtils.class,
-        DeploymentExceptionHandler.class, IdentityProviderManager.class, CspPluginValidator.class,
-        PluginManager.class})
+        DeploymentExceptionHandler.class, UserServiceHelper.class, IdentityProviderManager.class,
+        CspPluginValidator.class, PluginManager.class})
 @WebMvcTest
 class DeploymentExceptionHandlerTest {
     private MockMvc mockMvc;

--- a/modules/database/src/main/java/org/eclipse/xpanse/modules/database/service/DatabaseDeployServiceStorage.java
+++ b/modules/database/src/main/java/org/eclipse/xpanse/modules/database/service/DatabaseDeployServiceStorage.java
@@ -86,8 +86,15 @@ public class DatabaseDeployServiceStorage implements DeployServiceStorage {
                     predicateList.add(
                             criteriaBuilder.isNotNull(root.get("serviceDeploymentState")));
 
-                    predicateList.add(criteriaBuilder.equal(root.get("userId"),
-                            serviceQuery.getUserId()));
+                    if (Objects.nonNull(serviceQuery.getUserId())) {
+                        predicateList.add(criteriaBuilder.equal(root.get("userId"),
+                                serviceQuery.getUserId()));
+                    }
+
+                    if (Objects.nonNull(serviceQuery.getNamespace())) {
+                        predicateList.add(criteriaBuilder.equal(root.get("namespace"),
+                                serviceQuery.getNamespace()));
+                    }
 
                     query.where(criteriaBuilder.and(predicateList.toArray(new Predicate[0])))
                             .getRestriction();

--- a/modules/database/src/main/java/org/eclipse/xpanse/modules/database/service/ServiceQueryModel.java
+++ b/modules/database/src/main/java/org/eclipse/xpanse/modules/database/service/ServiceQueryModel.java
@@ -29,4 +29,6 @@ public class ServiceQueryModel {
 
     private String userId;
 
+    private String namespace;
+
 }

--- a/modules/database/src/main/java/org/eclipse/xpanse/modules/database/userpolicy/DatabaseUserPolicyStorage.java
+++ b/modules/database/src/main/java/org/eclipse/xpanse/modules/database/userpolicy/DatabaseUserPolicyStorage.java
@@ -61,8 +61,11 @@ public class DatabaseUserPolicyStorage implements UserPolicyStorage {
                                 queryModel.getPolicy()));
 
                     }
-                    predicateList.add(criteriaBuilder.equal(root.get("userId"),
-                            queryModel.getUserId()));
+
+                    if (Objects.nonNull(queryModel.getUserId())) {
+                        predicateList.add(criteriaBuilder.equal(root.get("userId"),
+                                queryModel.getUserId()));
+                    }
 
                     return query.where(criteriaBuilder.and(predicateList.toArray(new Predicate[0])))
                             .getRestriction();

--- a/modules/database/src/main/java/org/eclipse/xpanse/modules/database/userpolicy/UserPolicyEntity.java
+++ b/modules/database/src/main/java/org/eclipse/xpanse/modules/database/userpolicy/UserPolicyEntity.java
@@ -43,24 +43,26 @@ public class UserPolicyEntity extends CreateModifiedTime {
     /**
      * The id of user who created the policy.
      */
+    @Column(name = "USER_ID", nullable = false)
     private String userId;
 
     /**
      * The valid policy created by the user.
      */
-    @Column(name = "POLICY", length = Integer.MAX_VALUE)
+    @Column(name = "POLICY", length = Integer.MAX_VALUE, nullable = false)
     private String policy;
 
     /**
      * The csp which the policy belongs to.
      */
     @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
     private Csp csp;
 
     /**
      * Is the policy enabled.
      */
-    @Column(columnDefinition = "boolean default true")
+    @Column(columnDefinition = "boolean default true", nullable = false)
     private Boolean enabled;
 
 }

--- a/modules/database/src/test/java/org/eclipse/xpanse/modules/database/service/ServiceQueryModelTest.java
+++ b/modules/database/src/test/java/org/eclipse/xpanse/modules/database/service/ServiceQueryModelTest.java
@@ -14,20 +14,21 @@ import org.eclipse.xpanse.modules.models.common.enums.Csp;
 import org.eclipse.xpanse.modules.models.service.deploy.enums.ServiceDeploymentState;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.BeanUtils;
 
 /**
  * Test of ServiceQueryModel.
  */
 class ServiceQueryModelTest {
 
-    private static final Csp csp = Csp.HUAWEI;
-    private static final Category category = Category.COMPUTE;
-    private static final String serviceName = "kafka";
-    private static final String serviceVersion = "1.0.0";
-    private static final ServiceDeploymentState serviceState =
-            ServiceDeploymentState.DEPLOY_SUCCESS;
-    private static final String userId = "defaultUserId";
-    private static ServiceQueryModel serviceQueryTest;
+    private final Csp csp = Csp.HUAWEI;
+    private final Category category = Category.COMPUTE;
+    private final String serviceName = "kafka";
+    private final String serviceVersion = "1.0.0";
+    private final ServiceDeploymentState serviceState = ServiceDeploymentState.DEPLOY_SUCCESS;
+    private final String userId = "defaultUserId";
+    private final String namespace = "defaultNamespace";
+    private ServiceQueryModel serviceQueryTest;
 
     @BeforeEach
     void setUp() {
@@ -38,78 +39,44 @@ class ServiceQueryModelTest {
         serviceQueryTest.setServiceVersion(serviceVersion);
         serviceQueryTest.setServiceState(serviceState);
         serviceQueryTest.setUserId(userId);
+        serviceQueryTest.setNamespace(namespace);
     }
 
     @Test
-    void testGetterAndSetter() {
+    void testGetters() {
         assertEquals(csp, serviceQueryTest.getCsp());
         assertEquals(category, serviceQueryTest.getCategory());
         assertEquals(serviceName, serviceQueryTest.getServiceName());
         assertEquals(serviceVersion, serviceQueryTest.getServiceVersion());
         assertEquals(userId, serviceQueryTest.getUserId());
         assertEquals(serviceState, serviceQueryTest.getServiceState());
+        assertEquals(namespace, serviceQueryTest.getNamespace());
     }
 
     @Test
     void testEqualsAndHashCode() {
-        assertEquals(serviceQueryTest, serviceQueryTest);
-        assertEquals(serviceQueryTest.hashCode(), serviceQueryTest.hashCode());
-
         Object obj = new Object();
         assertNotEquals(serviceQueryTest, obj);
-        assertNotEquals(serviceQueryTest, null);
         assertNotEquals(serviceQueryTest.hashCode(), obj.hashCode());
 
-        ServiceQueryModel serviceQueryTest1 = new ServiceQueryModel();
-        ServiceQueryModel serviceQueryTest2 = new ServiceQueryModel();
-        assertNotEquals(serviceQueryTest, serviceQueryTest1);
-        assertNotEquals(serviceQueryTest, serviceQueryTest2);
-        assertEquals(serviceQueryTest1, serviceQueryTest2);
-        assertNotEquals(serviceQueryTest.hashCode(), serviceQueryTest1.hashCode());
-        assertNotEquals(serviceQueryTest.hashCode(), serviceQueryTest2.hashCode());
-        assertEquals(serviceQueryTest1.hashCode(), serviceQueryTest2.hashCode());
+        ServiceQueryModel test = new ServiceQueryModel();
+        assertNotEquals(serviceQueryTest, test);
+        assertNotEquals(serviceQueryTest.hashCode(), test.hashCode());
 
-        serviceQueryTest1.setCsp(csp);
-        assertNotEquals(serviceQueryTest, serviceQueryTest1);
-        assertNotEquals(serviceQueryTest1, serviceQueryTest2);
-        assertNotEquals(serviceQueryTest.hashCode(), serviceQueryTest1.hashCode());
-        assertNotEquals(serviceQueryTest1.hashCode(), serviceQueryTest2.hashCode());
-
-        serviceQueryTest1.setCategory(category);
-        assertNotEquals(serviceQueryTest, serviceQueryTest1);
-        assertNotEquals(serviceQueryTest1, serviceQueryTest2);
-        assertNotEquals(serviceQueryTest.hashCode(), serviceQueryTest1.hashCode());
-        assertNotEquals(serviceQueryTest1.hashCode(), serviceQueryTest2.hashCode());
-
-        serviceQueryTest1.setServiceName(serviceName);
-        assertNotEquals(serviceQueryTest, serviceQueryTest1);
-        assertNotEquals(serviceQueryTest1, serviceQueryTest2);
-        assertNotEquals(serviceQueryTest.hashCode(), serviceQueryTest1.hashCode());
-        assertNotEquals(serviceQueryTest1.hashCode(), serviceQueryTest2.hashCode());
-
-        serviceQueryTest1.setServiceVersion(serviceVersion);
-        assertNotEquals(serviceQueryTest, serviceQueryTest1);
-        assertNotEquals(serviceQueryTest1, serviceQueryTest2);
-        assertNotEquals(serviceQueryTest.hashCode(), serviceQueryTest1.hashCode());
-        assertNotEquals(serviceQueryTest1.hashCode(), serviceQueryTest2.hashCode());
-
-        serviceQueryTest1.setServiceState(serviceState);
-        assertNotEquals(serviceQueryTest, serviceQueryTest1);
-        assertNotEquals(serviceQueryTest1, serviceQueryTest2);
-        assertNotEquals(serviceQueryTest.hashCode(), serviceQueryTest1.hashCode());
-        assertNotEquals(serviceQueryTest1.hashCode(), serviceQueryTest2.hashCode());
-
-        serviceQueryTest1.setUserId(userId);
-        assertEquals(serviceQueryTest, serviceQueryTest1);
-        assertNotEquals(serviceQueryTest1, serviceQueryTest2);
-        assertEquals(serviceQueryTest.hashCode(), serviceQueryTest1.hashCode());
-        assertNotEquals(serviceQueryTest1.hashCode(), serviceQueryTest2.hashCode());
+        BeanUtils.copyProperties(serviceQueryTest, test);
+        assertEquals(serviceQueryTest, test);
+        assertEquals(serviceQueryTest.hashCode(), test.hashCode());
     }
 
     @Test
     void testToString() {
-        String expectedString = "ServiceQueryModel(csp=HUAWEI, category=COMPUTE, serviceName=kafka,"
-                + " serviceVersion=1.0.0, serviceState=DEPLOY_SUCCESS, userId=defaultUserId)";
+        String expectedString = "ServiceQueryModel(csp=" + csp
+                + ", category=" + category
+                + ", serviceName=" + serviceName
+                + ", serviceVersion=" + serviceVersion
+                + ", serviceState=" + serviceState
+                + ", userId=" + userId
+                + ", namespace=" + namespace + ")";
         assertEquals(expectedString, serviceQueryTest.toString());
     }
 

--- a/modules/monitor/src/test/java/org/eclipse/xpanse/modules/monitor/ServiceMetricsAdapterTest.java
+++ b/modules/monitor/src/test/java/org/eclipse/xpanse/modules/monitor/ServiceMetricsAdapterTest.java
@@ -8,7 +8,6 @@ import static org.mockito.Mockito.when;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.UUID;
 import org.eclipse.xpanse.modules.database.resource.DeployResourceEntity;
 import org.eclipse.xpanse.modules.database.resource.DeployResourceStorage;
@@ -32,7 +31,7 @@ import org.eclipse.xpanse.modules.orchestrator.deployment.DeployResourceHandler;
 import org.eclipse.xpanse.modules.orchestrator.monitor.ResourceMetricsRequest;
 import org.eclipse.xpanse.modules.orchestrator.monitor.ServiceMetricsRequest;
 import org.eclipse.xpanse.modules.orchestrator.servicestate.ServiceStateManageRequest;
-import org.eclipse.xpanse.modules.security.IdentityProviderManager;
+import org.eclipse.xpanse.modules.security.UserServiceHelper;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -43,7 +42,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = {ServiceMetricsAdapter.class, PluginManager.class,
-        DeployResourceStorage.class, DeployServiceStorage.class, IdentityProviderManager.class})
+        DeployResourceStorage.class, DeployServiceStorage.class, UserServiceHelper.class})
 class ServiceMetricsAdapterTest {
 
     private final String resourceId = "8d1495ae-8420-4172-93c1-746c09b4a005";
@@ -58,7 +57,7 @@ class ServiceMetricsAdapterTest {
     @MockBean
     private OrchestratorPlugin orchestratorPlugin;
     @MockBean
-    private IdentityProviderManager identityProviderManager;
+    private UserServiceHelper userServiceHelper;
     @Autowired
     private ServiceMetricsAdapter serviceMetricsAdapterUnderTest;
 
@@ -88,7 +87,7 @@ class ServiceMetricsAdapterTest {
         when(mockPluginManager.getOrchestratorPlugin(any(Csp.class))).thenReturn(
                 getOrchestratorPlugin(Csp.HUAWEI, expectedResult));
         when(orchestratorPlugin.getMetricsForService(any())).thenReturn(expectedResult);
-        when(identityProviderManager.getCurrentLoginUserId()).thenReturn(Optional.of(userId));
+        when(userServiceHelper.currentUserIsOwner(userId)).thenReturn(true);
         // Run the test
         final List<Metric> result =
                 serviceMetricsAdapterUnderTest.getMetricsByServiceId(serviceId, null, null, null,
@@ -162,7 +161,7 @@ class ServiceMetricsAdapterTest {
         when(mockPluginManager.getOrchestratorPlugin(Csp.HUAWEI)).thenReturn(
                 getOrchestratorPlugin(Csp.HUAWEI, expectedResult));
         when(orchestratorPlugin.getMetricsForService(any())).thenReturn(expectedResult);
-        when(identityProviderManager.getCurrentLoginUserId()).thenReturn(Optional.of(userId));
+        when(userServiceHelper.currentUserIsOwner(userId)).thenReturn(true);
         // Run the test
         final List<Metric> result =
                 serviceMetricsAdapterUnderTest.getMetricsByResourceId(resourceId, null, null, null,
@@ -239,7 +238,7 @@ class ServiceMetricsAdapterTest {
 
             @Override
             public List<String> getExistingResourceNamesWithKind(String userId, String region,
-                                                           DeployResourceKind kind) {
+                                                                 DeployResourceKind kind) {
                 return new ArrayList<>();
             }
 

--- a/modules/policy/src/test/java/org/eclipse/xpanse/modules/policy/policyman/UserPolicyManagerTest.java
+++ b/modules/policy/src/test/java/org/eclipse/xpanse/modules/policy/policyman/UserPolicyManagerTest.java
@@ -9,7 +9,6 @@ import static org.mockito.Mockito.when;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 import org.eclipse.xpanse.modules.database.userpolicy.DatabaseUserPolicyStorage;
 import org.eclipse.xpanse.modules.database.userpolicy.UserPolicyEntity;
@@ -23,7 +22,7 @@ import org.eclipse.xpanse.modules.models.policy.userpolicy.UserPolicyQueryReques
 import org.eclipse.xpanse.modules.models.policy.userpolicy.UserPolicyUpdateRequest;
 import org.eclipse.xpanse.modules.policy.PolicyManager;
 import org.eclipse.xpanse.modules.policy.UserPolicyManager;
-import org.eclipse.xpanse.modules.security.IdentityProviderManager;
+import org.eclipse.xpanse.modules.security.UserServiceHelper;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -39,7 +38,7 @@ class UserPolicyManagerTest {
     @Mock
     private PolicyManager mockPolicyManager;
     @Mock
-    private IdentityProviderManager mockIdentityProviderManager;
+    private UserServiceHelper mockUserServiceHelper;
     @Mock
     private DatabaseUserPolicyStorage mockUserPolicyStorage;
     @InjectMocks
@@ -117,7 +116,7 @@ class UserPolicyManagerTest {
         expectedResult.setCsp(Csp.HUAWEI);
         expectedResult.setEnabled(true);
 
-        when(mockIdentityProviderManager.getCurrentLoginUserId()).thenReturn(Optional.of(userId));
+        when(mockUserServiceHelper.getCurrentUserId()).thenReturn(userId);
 
         // Configure DatabaseUserPolicyStorage.listPolicies(...).
         final UserPolicyQueryRequest queryModel = new UserPolicyQueryRequest();
@@ -135,7 +134,8 @@ class UserPolicyManagerTest {
         userPolicyEntity1.setCsp(Csp.HUAWEI);
         userPolicyEntity1.setEnabled(true);
 
-        when(mockUserPolicyStorage.store(any(UserPolicyEntity.class))).thenReturn(userPolicyEntity1);
+        when(mockUserPolicyStorage.store(any(UserPolicyEntity.class))).thenReturn(
+                userPolicyEntity1);
 
         // Run the test
         final UserPolicy result = userPolicyManagerUnderTest.addUserPolicy(createRequest);
@@ -153,7 +153,7 @@ class UserPolicyManagerTest {
         createRequest.setPolicy("policy");
         createRequest.setEnabled(true);
 
-        when(mockIdentityProviderManager.getCurrentLoginUserId()).thenReturn(Optional.of(userId));
+        when(mockUserServiceHelper.getCurrentUserId()).thenReturn(userId);
 
         // Configure DatabaseUserPolicyStorage.listPolicies(...).
         final UserPolicyEntity userPolicyEntity = new UserPolicyEntity();
@@ -219,7 +219,8 @@ class UserPolicyManagerTest {
         userPolicyEntity.setEnabled(true);
         when(mockUserPolicyStorage.findPolicyById(policyId)).thenReturn(userPolicyEntity);
 
-        when(mockIdentityProviderManager.getCurrentLoginUserId()).thenReturn(Optional.of(userId));
+        when(mockUserServiceHelper.getCurrentUserId()).thenReturn(userId);
+        when(mockUserServiceHelper.currentUserIsOwner(userId)).thenReturn(true);
 
         // Configure DatabaseUserPolicyStorage.listPolicies(...).
         final UserPolicyQueryRequest queryModel = new UserPolicyQueryRequest();
@@ -267,7 +268,7 @@ class UserPolicyManagerTest {
         userPolicyEntity.setEnabled(true);
         when(mockUserPolicyStorage.findPolicyById(policyId)).thenReturn(userPolicyEntity);
 
-        when(mockIdentityProviderManager.getCurrentLoginUserId()).thenReturn(Optional.of(userId));
+        when(mockUserServiceHelper.currentUserIsOwner(userId)).thenReturn(true);
 
         // Configure DatabaseUserPolicyStorage.listPolicies(...).
         final UserPolicyQueryRequest queryModel = new UserPolicyQueryRequest();
@@ -324,8 +325,7 @@ class UserPolicyManagerTest {
         userPolicyEntity.setEnabled(true);
         when(mockUserPolicyStorage.findPolicyById(policyId)).thenReturn(userPolicyEntity);
 
-        when(mockIdentityProviderManager.getCurrentLoginUserId()).thenReturn(
-                Optional.of("userId2"));
+        when(mockUserServiceHelper.currentUserIsOwner(userId)).thenReturn(false);
 
         // Run the test
         assertThatThrownBy(() -> userPolicyManagerUnderTest.updateUserPolicy(updateRequest))
@@ -359,7 +359,9 @@ class UserPolicyManagerTest {
 
         when(mockUserPolicyStorage.findPolicyById(id1)).thenReturn(userPolicyEntity);
 
-        when(mockIdentityProviderManager.getCurrentLoginUserId()).thenReturn(Optional.of(userId));
+        when(mockUserServiceHelper.getCurrentUserId()).thenReturn(userId);
+
+        when(mockUserServiceHelper.currentUserIsOwner(userId)).thenReturn(true);
 
         final UserPolicyQueryRequest queryModel = new UserPolicyQueryRequest();
 
@@ -392,7 +394,7 @@ class UserPolicyManagerTest {
         userPolicyEntity.setEnabled(true);
         when(mockUserPolicyStorage.findPolicyById(policyId)).thenReturn(userPolicyEntity);
 
-        when(mockIdentityProviderManager.getCurrentLoginUserId()).thenReturn(Optional.of(userId));
+        when(mockUserServiceHelper.currentUserIsOwner(userId)).thenReturn(true);
 
         // Run the test
         final UserPolicy result = userPolicyManagerUnderTest.getUserPolicyDetails(policyId);
@@ -436,8 +438,7 @@ class UserPolicyManagerTest {
         userPolicyEntity.setEnabled(true);
         when(mockUserPolicyStorage.findPolicyById(policyId)).thenReturn(userPolicyEntity);
 
-        when(mockIdentityProviderManager.getCurrentLoginUserId()).thenReturn(
-                Optional.of("userId2"));
+        when(mockUserServiceHelper.currentUserIsOwner(userId)).thenReturn(false);
 
         // Run the test
         assertThatThrownBy(() -> userPolicyManagerUnderTest.getUserPolicyDetails(policyId))
@@ -456,7 +457,7 @@ class UserPolicyManagerTest {
         userPolicyEntity.setEnabled(true);
         when(mockUserPolicyStorage.findPolicyById(policyId)).thenReturn(userPolicyEntity);
 
-        when(mockIdentityProviderManager.getCurrentLoginUserId()).thenReturn(Optional.of(userId));
+        when(mockUserServiceHelper.currentUserIsOwner(userId)).thenReturn(true);
 
         // Run the test
         userPolicyManagerUnderTest.deleteUserPolicy(policyId);
@@ -477,8 +478,7 @@ class UserPolicyManagerTest {
         userPolicyEntity.setEnabled(true);
         when(mockUserPolicyStorage.findPolicyById(policyId)).thenReturn(userPolicyEntity);
 
-        when(mockIdentityProviderManager.getCurrentLoginUserId()).thenReturn(
-                Optional.of("userId2"));
+        when(mockUserServiceHelper.currentUserIsOwner(userId)).thenReturn(false);
 
         // Run the test
         assertThatThrownBy(() -> userPolicyManagerUnderTest.deleteUserPolicy(policyId))

--- a/modules/security/src/main/java/org/eclipse/xpanse/modules/security/IdentityProviderManager.java
+++ b/modules/security/src/main/java/org/eclipse/xpanse/modules/security/IdentityProviderManager.java
@@ -9,12 +9,8 @@ package org.eclipse.xpanse.modules.security;
 import jakarta.annotation.Resource;
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.StringUtils;
-import org.eclipse.xpanse.modules.models.common.enums.Csp;
-import org.eclipse.xpanse.modules.models.common.exceptions.UnsupportedEnumValueException;
 import org.eclipse.xpanse.modules.security.common.CurrentUserInfo;
 import org.eclipse.xpanse.modules.security.common.CurrentUserInfoHolder;
 import org.springframework.beans.factory.annotation.Value;
@@ -45,7 +41,7 @@ public class IdentityProviderManager {
     @Bean
     public void loadActiveIdentityProviderServices() {
         if (!webSecurityIsEnabled) {
-            log.info("Web security is disabled.");
+            log.info("Security is disabled, authentication and authorization are not required.");
             activeIdentityProviderService = null;
             return;
         }
@@ -53,17 +49,18 @@ public class IdentityProviderManager {
                 applicationContext.getBeansOfType(IdentityProviderService.class)
                         .values().stream().toList();
         if (CollectionUtils.isEmpty(identityProviderServices)) {
-            log.info("No active identity providers found.");
-            activeIdentityProviderService = null;
-        } else {
-            if (identityProviderServices.size() > 1) {
-                throw new IllegalStateException(
-                        "More than one identity provider service is active.");
-            }
-            activeIdentityProviderService = identityProviderServices.getFirst();
-            log.info("Identity provider service with type:{} is active.",
-                    activeIdentityProviderService.getIdentityProviderType());
+            String errorMsg = "Security is enabled, but no identity provider service is active.";
+            log.error(errorMsg);
+            throw new IllegalStateException(errorMsg);
         }
+        if (identityProviderServices.size() > 1) {
+            throw new IllegalStateException("More than one identity provider service is active.");
+        }
+        activeIdentityProviderService = identityProviderServices.getFirst();
+        log.info("Identity provider service:{} with type:{} is active.",
+                activeIdentityProviderService.getClass().getName(),
+                activeIdentityProviderService.getIdentityProviderType());
+
     }
 
     /**
@@ -78,53 +75,5 @@ public class IdentityProviderManager {
             return currentUserInfo;
         }
         return null;
-    }
-
-
-    /**
-     * Get current login user id.
-     *
-     * @return current login user id.
-     */
-    public Optional<String> getCurrentLoginUserId() {
-        CurrentUserInfo currentUserInfo = getCurrentUserInfo();
-        if (Objects.nonNull(currentUserInfo)) {
-            return Optional.ofNullable(currentUserInfo.getUserId());
-        } else {
-            return Optional.empty();
-        }
-    }
-
-    /**
-     * Get current login user namespace.
-     *
-     * @return current login user namespace.
-     */
-    public Optional<String> getUserNamespace() {
-        CurrentUserInfo currentUserInfo = getCurrentUserInfo();
-        if (Objects.isNull(currentUserInfo)) {
-            return Optional.empty();
-        }
-        return StringUtils.isBlank(currentUserInfo.getNamespace())
-                ? Optional.ofNullable(currentUserInfo.getUserId())
-                : Optional.ofNullable(currentUserInfo.getNamespace());
-    }
-
-    /**
-     * Get csp from metadata fo current login user.
-     *
-     * @return csp of current login user.
-     */
-    public Optional<Csp> getCspFromMetadata() {
-        CurrentUserInfo currentUserInfo = getCurrentUserInfo();
-        if (Objects.nonNull(currentUserInfo) && StringUtils.isNotBlank(currentUserInfo.getCsp())) {
-            try {
-                Csp csp = Csp.getByValue(currentUserInfo.getCsp());
-                return Optional.of(csp);
-            } catch (UnsupportedEnumValueException e) {
-                log.error("Unsupported csp value:{}", currentUserInfo.getCsp());
-            }
-        }
-        return Optional.empty();
     }
 }

--- a/modules/security/src/main/java/org/eclipse/xpanse/modules/security/UserServiceHelper.java
+++ b/modules/security/src/main/java/org/eclipse/xpanse/modules/security/UserServiceHelper.java
@@ -1,0 +1,151 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * SPDX-FileCopyrightText: Huawei Inc.
+ *
+ */
+
+package org.eclipse.xpanse.modules.security;
+
+import jakarta.annotation.Resource;
+import java.util.Objects;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.eclipse.xpanse.modules.models.common.enums.Csp;
+import org.eclipse.xpanse.modules.models.common.exceptions.UnsupportedEnumValueException;
+import org.eclipse.xpanse.modules.models.common.exceptions.UserNotLoggedInException;
+import org.eclipse.xpanse.modules.security.common.CurrentUserInfo;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.util.CollectionUtils;
+
+/**
+ * The service helper provider methods to get all info of the current user.
+ */
+@Slf4j
+@Component
+public class UserServiceHelper {
+
+    private static final String NO_AUTH_DEFAULT_USER_ID = "no-auth-user-id";
+
+    @Value("${enable.web.security:true}")
+    private Boolean webSecurityIsEnabled;
+    @Value("${enable.role.protection:true}")
+    private Boolean roleProtectionIsEnabled;
+    @Resource
+    private IdentityProviderManager identityProviderManager;
+
+    /**
+     * Check if the current user has the role.
+     *
+     * @param role the role.
+     * @return true if the current user has the role, false otherwise.
+     */
+    public boolean currentUserHasRole(String role) {
+        if (!webSecurityIsEnabled) {
+            return true;
+        }
+        if (!roleProtectionIsEnabled) {
+            return true;
+        }
+        CurrentUserInfo currentUserInfo = getCurrentUserInfo();
+        return Objects.nonNull(currentUserInfo) && !CollectionUtils.isEmpty(
+                currentUserInfo.getRoles()) && currentUserInfo.getRoles().contains(role);
+    }
+
+    /**
+     * Check if the current user is the owner user.
+     *
+     * @param ownerId the owner id.
+     * @return true if the current user is the owner user, false otherwise.
+     */
+    public boolean currentUserIsOwner(String ownerId) {
+        if (!webSecurityIsEnabled) {
+            return true;
+        }
+        return StringUtils.equals(ownerId, getCurrentUserId());
+    }
+
+
+    /**
+     * Check if the current user can manage the namespace.
+     *
+     * @param ownerNamespace the owner namespace.
+     * @return true if the current user has the owner namespace, false otherwise.
+     */
+    public boolean currentUserCanManageNamespace(String ownerNamespace) {
+        if (!webSecurityIsEnabled) {
+            return true;
+        }
+        return StringUtils.equals(ownerNamespace, getCurrentUserManageNamespace());
+    }
+
+    /**
+     * Check if the current user can manage the csp.
+     *
+     * @param ownerCsp the owner csp.
+     * @return true if the current user can manage the csp, false otherwise.
+     */
+    public boolean currentUserCanManageCsp(Csp ownerCsp) {
+        if (!webSecurityIsEnabled) {
+            return true;
+        }
+        return Objects.equals(ownerCsp, getCurrentUserManageCsp());
+    }
+
+    /**
+     * Get the current user id.
+     */
+    public String getCurrentUserId() {
+        if (!webSecurityIsEnabled) {
+            return NO_AUTH_DEFAULT_USER_ID;
+        }
+        return getCurrentUserInfo().getUserId();
+    }
+
+    /**
+     * Get id of current login user.
+     *
+     * @return current login user id.
+     */
+    private CurrentUserInfo getCurrentUserInfo() {
+        CurrentUserInfo currentUserInfo = identityProviderManager.getCurrentUserInfo();
+        if (Objects.isNull(currentUserInfo)) {
+            throw new UserNotLoggedInException("Unable to get current login information");
+        }
+        return currentUserInfo;
+    }
+
+    /**
+     * Get the namespace managed by the current user .
+     */
+    public String getCurrentUserManageNamespace() {
+        if (!webSecurityIsEnabled) {
+            return null;
+        }
+        CurrentUserInfo userInfo = getCurrentUserInfo();
+        return StringUtils.isBlank(userInfo.getNamespace())
+                ? userInfo.getUserId()
+                : userInfo.getNamespace();
+    }
+
+    /**
+     * Get the csp managed by the current user.
+     */
+    public Csp getCurrentUserManageCsp() {
+        if (!webSecurityIsEnabled) {
+            return null;
+        }
+        CurrentUserInfo currentUserInfo = getCurrentUserInfo();
+        if (StringUtils.isNotBlank(currentUserInfo.getCsp())) {
+            try {
+                return Csp.getByValue(currentUserInfo.getCsp());
+            } catch (UnsupportedEnumValueException e) {
+                log.error("Unsupported csp value:{}", currentUserInfo.getCsp());
+                return null;
+            }
+        }
+        return null;
+    }
+
+
+}

--- a/modules/security/src/test/java/org/eclipse/xpanse/modules/security/UserServiceHelperTest.java
+++ b/modules/security/src/test/java/org/eclipse/xpanse/modules/security/UserServiceHelperTest.java
@@ -1,0 +1,349 @@
+package org.eclipse.xpanse.modules.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Map;
+import org.eclipse.xpanse.modules.models.common.enums.Csp;
+import org.eclipse.xpanse.modules.models.common.exceptions.UserNotLoggedInException;
+import org.eclipse.xpanse.modules.security.common.CurrentUserInfo;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceHelperTest {
+
+    private final String userId = "userId";
+    private final String namespace = "namespace";
+    private final Csp csp = Csp.HUAWEI;
+    private final List<String> roles = List.of("admin", "csp", "isv", "user");
+    @Mock
+    private IdentityProviderManager mockIdentityProviderManager;
+    @InjectMocks
+    private UserServiceHelper userServiceHelperUnderTest;
+
+    void setUpSecurityConfig(boolean webSecurityIsEnabled, boolean roleProtectionIsEnabled) {
+        ReflectionTestUtils.setField(userServiceHelperUnderTest, "webSecurityIsEnabled",
+                webSecurityIsEnabled);
+        ReflectionTestUtils.setField(userServiceHelperUnderTest, "roleProtectionIsEnabled",
+                roleProtectionIsEnabled);
+    }
+
+    CurrentUserInfo getMockCurrentUserInfo() {
+        final CurrentUserInfo currentUserInfo = new CurrentUserInfo();
+        currentUserInfo.setUserId(userId);
+        currentUserInfo.setRoles(roles);
+        currentUserInfo.setMetadata(Map.of(namespace, namespace, "csp", csp.toValue()));
+        currentUserInfo.setNamespace(namespace);
+        currentUserInfo.setCsp(csp.toValue());
+        return currentUserInfo;
+    }
+
+    @Test
+    void testCurrentUserHasRole() {
+        // Setup without auth
+        setUpSecurityConfig(false, true);
+        // Run the test
+        final boolean result = userServiceHelperUnderTest.currentUserHasRole("user");
+        // Verify the results
+        assertThat(result).isTrue();
+
+        // Setup with auth but no role protection
+        setUpSecurityConfig(true, false);
+        // Run the test
+        final boolean result1 = userServiceHelperUnderTest.currentUserHasRole("user");
+        // Verify the results
+        assertThat(result1).isTrue();
+
+
+        // Setup
+        setUpSecurityConfig(true, true);
+        final CurrentUserInfo currentUserInfo = new CurrentUserInfo();
+        currentUserInfo.setUserId("userId");
+        currentUserInfo.setRoles(List.of("user"));
+        when(mockIdentityProviderManager.getCurrentUserInfo()).thenReturn(currentUserInfo);
+        // Run the test
+        final boolean result2 = userServiceHelperUnderTest.currentUserHasRole("user");
+        // Verify the results
+        assertThat(result2).isTrue();
+        // Run the test
+        final boolean result3 = userServiceHelperUnderTest.currentUserHasRole("isv");
+        // Verify the results
+        assertThat(result3).isFalse();
+    }
+
+    @Test
+    void testCurrentUserIsOwner() {
+        when(mockIdentityProviderManager.getCurrentUserInfo()).thenReturn(getMockCurrentUserInfo());
+        // Setup without auth
+        setUpSecurityConfig(false, true);
+        // Run the test
+        final boolean result = userServiceHelperUnderTest.currentUserIsOwner("userId");
+        // Verify the results
+        assertThat(result).isTrue();
+
+
+        // Setup
+        setUpSecurityConfig(true, true);
+        // Run the test
+        final boolean result1 = userServiceHelperUnderTest.currentUserIsOwner("userId");
+        // Verify the results
+        assertThat(result1).isTrue();
+        // Run the test
+        final boolean result2 = userServiceHelperUnderTest.currentUserIsOwner("userId2");
+        // Verify the results
+        assertThat(result2).isFalse();
+    }
+
+    @Test
+    void testCurrentUserIsOwner_IdentityProviderManagerReturnsAbsent() {
+        when(mockIdentityProviderManager.getCurrentUserInfo()).thenReturn(null);
+        // Setup without auth
+        setUpSecurityConfig(false, true);
+        // Run the test
+        final boolean result = userServiceHelperUnderTest.currentUserIsOwner("ownerId");
+        // Verify the results
+        assertThat(result).isTrue();
+        // Run the test
+        final boolean result1 = userServiceHelperUnderTest.currentUserIsOwner("ownerId1");
+        // Verify the results
+        assertThat(result1).isTrue();
+
+        // Setup without auth
+        setUpSecurityConfig(true, true);
+        // Run the test
+        assertThatThrownBy(() -> userServiceHelperUnderTest.currentUserIsOwner("ownerId"))
+                .isInstanceOf(UserNotLoggedInException.class);
+    }
+
+    @Test
+    void testCurrentUserCanManageNamespace() {
+        // Setup without auth
+        setUpSecurityConfig(false, true);
+        // Run the test
+        final boolean result =
+                userServiceHelperUnderTest.currentUserCanManageNamespace(namespace);
+        // Verify the results
+        assertThat(result).isTrue();
+
+        // Run the test
+        final boolean result1 =
+                userServiceHelperUnderTest.currentUserCanManageNamespace("namespace1");
+        // Verify the results
+        assertThat(result1).isTrue();
+
+
+        // Setup
+        setUpSecurityConfig(true, true);
+        when(mockIdentityProviderManager.getCurrentUserInfo()).thenReturn(getMockCurrentUserInfo());
+        // Run the test
+        final boolean result2 =
+                userServiceHelperUnderTest.currentUserCanManageNamespace(namespace);
+        // Verify the results
+        assertThat(result2).isTrue();
+        // Run the test
+        final boolean result3 =
+                userServiceHelperUnderTest.currentUserCanManageNamespace("namespace1");
+        // Verify the results
+        assertThat(result3).isFalse();
+    }
+
+    @Test
+    void testCurrentUserCanManageNamespace_IdentityProviderManagerReturnsAbsent() {
+        when(mockIdentityProviderManager.getCurrentUserInfo()).thenReturn(null);
+        // Setup without auth
+        setUpSecurityConfig(false, true);
+        // Run the test
+        final boolean result = userServiceHelperUnderTest.currentUserCanManageNamespace(
+                namespace);
+        // Verify the results
+        assertThat(result).isTrue();
+        // Run the test
+        final boolean result1 = userServiceHelperUnderTest.currentUserCanManageNamespace(
+                "namespace1");
+        // Verify the results
+        assertThat(result1).isTrue();
+
+        // Setup without auth
+        setUpSecurityConfig(true, true);
+        // Run the test
+        assertThatThrownBy(() ->
+                userServiceHelperUnderTest.currentUserCanManageNamespace(namespace))
+                .isInstanceOf(UserNotLoggedInException.class);
+
+    }
+
+    @Test
+    void testCurrentUserCanManageCsp() {
+        when(mockIdentityProviderManager.getCurrentUserInfo()).thenReturn(getMockCurrentUserInfo());
+        // Setup without auth
+        setUpSecurityConfig(false, true);
+        // Run the test
+        final boolean result = userServiceHelperUnderTest.currentUserCanManageCsp(Csp.HUAWEI);
+        // Verify the results
+        assertThat(result).isTrue();
+        // Run the test
+        final boolean result1 = userServiceHelperUnderTest.currentUserCanManageCsp(Csp.OPENSTACK);
+        // Verify the results
+        assertThat(result1).isTrue();
+
+        // Setup without auth
+        setUpSecurityConfig(true, true);
+        // Run the test
+        final boolean result2 = userServiceHelperUnderTest.currentUserCanManageCsp(Csp.HUAWEI);
+        // Verify the results
+        assertThat(result2).isTrue();
+        // Run the test
+        final boolean result3 = userServiceHelperUnderTest.currentUserCanManageCsp(Csp.OPENSTACK);
+        // Verify the results
+        assertThat(result3).isFalse();
+    }
+
+    @Test
+    void testCurrentUserCanManageCsp_IdentityProviderManagerReturnsAbsent() {
+        when(mockIdentityProviderManager.getCurrentUserInfo()).thenReturn(null);
+        // Setup without auth
+        setUpSecurityConfig(false, true);
+        // Run the test
+        final boolean result = userServiceHelperUnderTest.currentUserCanManageCsp(Csp.HUAWEI);
+        // Verify the results
+        assertThat(result).isTrue();
+        // Run the test
+        final boolean result1 = userServiceHelperUnderTest.currentUserCanManageCsp(Csp.OPENSTACK);
+        // Verify the results
+        assertThat(result1).isTrue();
+
+        // Setup without auth
+        setUpSecurityConfig(true, true);
+        // Run the test
+        assertThatThrownBy(() -> userServiceHelperUnderTest.currentUserCanManageCsp(Csp.HUAWEI))
+                .isInstanceOf(UserNotLoggedInException.class);
+
+    }
+
+    @Test
+    void testGetCurrentUserId() {
+        when(mockIdentityProviderManager.getCurrentUserInfo()).thenReturn(getMockCurrentUserInfo());
+        // Setup without auth
+        setUpSecurityConfig(false, true);
+        // Run the test
+        final String result = userServiceHelperUnderTest.getCurrentUserId();
+        // Verify the results
+        assertThat(result).isNotNull();
+        assertThat(result).isEqualTo("no-auth-user-id");
+
+        // Setup
+        setUpSecurityConfig(true, true);
+        // Run the test
+        final String result1 = userServiceHelperUnderTest.getCurrentUserId();
+        // Verify the results
+        assertThat(result1).isNotNull();
+        assertThat(result1).isEqualTo(userId);
+    }
+
+    @Test
+    void testGetCurrentUserId_IdentityProviderManagerReturnsAbsent() {
+        // Setup
+        when(mockIdentityProviderManager.getCurrentUserInfo()).thenReturn(null);
+        // Setup without auth
+        setUpSecurityConfig(false, true);
+        // Run the test
+        final String result = userServiceHelperUnderTest.getCurrentUserId();
+        // Verify the results
+        assertThat(result).isNotNull();
+        assertThat(result).isEqualTo("no-auth-user-id");
+
+
+        // Setup
+        setUpSecurityConfig(true, true);
+        // Run the test
+        assertThatThrownBy(() -> userServiceHelperUnderTest.getCurrentUserId())
+                .isInstanceOf(UserNotLoggedInException.class);
+    }
+
+    @Test
+    void testGetNamespaceManagedByCurrentUser() {
+        when(mockIdentityProviderManager.getCurrentUserInfo()).thenReturn(getMockCurrentUserInfo());
+        // Setup without auth
+        setUpSecurityConfig(false, true);
+        // Run the test
+        final String result = userServiceHelperUnderTest.getCurrentUserManageNamespace();
+        // Verify the results
+        assertThat(result).isNull();
+
+        // Setup
+        setUpSecurityConfig(true, true);
+        // Run the test
+        final String result1 = userServiceHelperUnderTest.getCurrentUserManageNamespace();
+        // Verify the results
+        assertThat(result1).isNotNull();
+        assertThat(result1).isEqualTo(namespace);
+    }
+
+    @Test
+    void testGetNamespaceManagedByCurrentUser_IdentityProviderManagerReturnsAbsent() {
+        // Setup
+        when(mockIdentityProviderManager.getCurrentUserInfo()).thenReturn(null);
+
+        // Setup without auth
+        setUpSecurityConfig(false, true);
+        // Run the test
+        final String result = userServiceHelperUnderTest.getCurrentUserManageNamespace();
+        // Verify the results
+        assertThat(result).isNull();
+
+
+        // Setup
+        setUpSecurityConfig(true, true);
+        // Run the test
+        assertThatThrownBy(() ->
+                userServiceHelperUnderTest.getCurrentUserManageNamespace())
+                .isInstanceOf(UserNotLoggedInException.class);
+    }
+
+    @Test
+    void testGetCspManagedByCurrentUser() {
+        Csp csp = Csp.HUAWEI;
+        when(mockIdentityProviderManager.getCurrentUserInfo()).thenReturn(getMockCurrentUserInfo());
+        // Setup without auth
+        setUpSecurityConfig(false, true);
+        // Run the test
+        final Csp result = userServiceHelperUnderTest.getCurrentUserManageCsp();
+        // Verify the results
+        assertThat(result).isNull();
+
+        // Setup
+        setUpSecurityConfig(true, true);
+        // Run the test
+        final Csp result1 = userServiceHelperUnderTest.getCurrentUserManageCsp();
+        // Verify the results
+        assertThat(result1).isNotNull();
+        assertThat(result1).isEqualTo(csp);
+    }
+
+    @Test
+    void testGetCspManagedByCurrentUser_IdentityProviderManagerReturnsAbsent() {
+        // Setup
+        when(mockIdentityProviderManager.getCurrentUserInfo()).thenReturn(null);
+
+        // Setup without auth
+        setUpSecurityConfig(false, true);
+        // Run the test
+        final Csp result = userServiceHelperUnderTest.getCurrentUserManageCsp();
+        // Verify the results
+        assertThat(result).isNull();
+
+
+        // Setup
+        setUpSecurityConfig(true, true);
+        // Run the test
+        assertThatThrownBy(() -> userServiceHelperUnderTest.getCurrentUserManageCsp())
+                .isInstanceOf(UserNotLoggedInException.class);
+    }
+}

--- a/runtime/src/test/java/org/eclipse/xpanse/runtime/ServiceDeployerApiTest.java
+++ b/runtime/src/test/java/org/eclipse/xpanse/runtime/ServiceDeployerApiTest.java
@@ -328,7 +328,6 @@ class ServiceDeployerApiTest extends ApisTestCommon {
         if (waitUntilExceptedState(serviceId, ServiceDeploymentState.DEPLOY_SUCCESS)) {
             listDeployedServices();
         }
-        testListDeployedServices();
         if (waitUntilExceptedState(serviceId, ServiceDeploymentState.DEPLOY_SUCCESS)) {
             testDestroy(serviceId);
         }

--- a/runtime/src/test/java/org/eclipse/xpanse/runtime/modules/security/RequiredRoleDescriptionCustomizerTest.java
+++ b/runtime/src/test/java/org/eclipse/xpanse/runtime/modules/security/RequiredRoleDescriptionCustomizerTest.java
@@ -6,13 +6,8 @@ import io.swagger.v3.oas.models.ExternalDocumentation;
 import io.swagger.v3.oas.models.Operation;
 import java.util.List;
 import org.eclipse.xpanse.api.controllers.AdminServicesApi;
-import org.eclipse.xpanse.modules.database.DatabaseManager;
 import org.eclipse.xpanse.modules.deployment.deployers.opentofu.tofumaker.TofuMakerManager;
 import org.eclipse.xpanse.modules.deployment.deployers.terraform.terraformboot.TerraformBootManager;
-import org.eclipse.xpanse.modules.observability.OpenTelemetryCollectorHealthCheck;
-import org.eclipse.xpanse.modules.orchestrator.PluginManager;
-import org.eclipse.xpanse.modules.policy.PolicyManager;
-import org.eclipse.xpanse.modules.security.IdentityProviderManager;
 import org.eclipse.xpanse.modules.security.RequiredRoleDescriptionCustomizer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -23,8 +18,7 @@ import org.springframework.web.method.HandlerMethod;
 @ExtendWith(SpringExtension.class)
 class RequiredRoleDescriptionCustomizerTest {
 
-    private RequiredRoleDescriptionCustomizer
-            requiredRoleDescriptionCustomizerUnderTest;
+    private RequiredRoleDescriptionCustomizer requiredRoleDescriptionCustomizerUnderTest;
 
     @BeforeEach
     void setUp() {
@@ -43,10 +37,7 @@ class RequiredRoleDescriptionCustomizerTest {
         operation.externalDocs(externalDocs);
 
         final AdminServicesApi adminServicesApi = new AdminServicesApi(
-                new IdentityProviderManager(), new PluginManager(),
-                new DatabaseManager(), new TerraformBootManager(),
-                new TofuMakerManager(), new PolicyManager(),
-                new OpenTelemetryCollectorHealthCheck());
+                new TerraformBootManager(), new TofuMakerManager());
 
         final HandlerMethod handlerMethod =
                 new HandlerMethod(adminServicesApi, "healthCheck", null);


### PR DESCRIPTION
fixes https://github.com/eclipse-xpanse/xpanse/issues/1495
When Xpanse is running without authentication and authorization, the services shown as below:
System health without identity service:
![noauth_system_health_without_identity](https://github.com/eclipse-xpanse/xpanse/assets/121531362/96a84c44-885a-4dc6-8fb4-641020be099c)
Registered service templates with null namespace:
![service-templates-with-null-namespace](https://github.com/eclipse-xpanse/xpanse/assets/121531362/4410b8be-23f5-45e1-b61c-9f7839215215)
All service templates with different csp can be reviewed:
![service-templates-with-null-namespace](https://github.com/eclipse-xpanse/xpanse/assets/121531362/9664c7f3-3a3c-4cbd-ba60-8b124a24e363
Manage user policy with `no-auth-user-id`:
![manage-user-policy-with-noauth-user-id](https://github.com/eclipse-xpanse/xpanse/assets/121531362/d8250bee-10c4-4ba1-8655-102deb428872)
Manage user credential with `no-auth-user-id`:
![manage-user-credentails-with-noauth-user-id](https://github.com/eclipse-xpanse/xpanse/assets/121531362/27ff4b2e-cd80-485b-aca2-6ec92a206aa8)
Deployed services with `no-auth-user-id`:
![deploy-services-with-noauth-user-id](https://github.com/eclipse-xpanse/xpanse/assets/121531362/d1a52f9e-198b-4533-8014-833f7f221529)
Migrate services with `no-auth-user-id` and deal failed task manually:
![deploy-services-with-noauth-user-id](https://github.com/eclipse-xpanse/xpanse/assets/121531362/1270f3ab-cfc6-4fb7-b52b-721562932ed5)


