### PR TITLE
Secure services based on lock config

### DIFF
--- a/modules/api/src/main/java/org/eclipse/xpanse/api/exceptions/handler/DeploymentExceptionHandler.java
+++ b/modules/api/src/main/java/org/eclipse/xpanse/api/exceptions/handler/DeploymentExceptionHandler.java
@@ -18,6 +18,7 @@ import org.eclipse.xpanse.modules.models.service.deploy.exceptions.InvalidDeploy
 import org.eclipse.xpanse.modules.models.service.deploy.exceptions.InvalidServiceStateException;
 import org.eclipse.xpanse.modules.models.service.deploy.exceptions.PluginNotFoundException;
 import org.eclipse.xpanse.modules.models.service.deploy.exceptions.ServiceDetailsNotAccessible;
+import org.eclipse.xpanse.modules.models.service.deploy.exceptions.ServiceLockedException;
 import org.eclipse.xpanse.modules.models.service.deploy.exceptions.ServiceNotDeployedException;
 import org.eclipse.xpanse.modules.models.service.deploy.exceptions.VariableInvalidException;
 import org.springframework.core.Ordered;
@@ -168,6 +169,18 @@ public class DeploymentExceptionHandler {
     public Response handleActivitiTaskNotFoundException(
             ActivitiTaskNotFoundException ex) {
         return Response.errorResponse(ResultType.ACTIVITI_TASK_NOT_FOUND,
+                Collections.singletonList(ex.getMessage()));
+    }
+
+    /**
+     * Exception handler for ServiceLockedException.
+     */
+    @ExceptionHandler({ServiceLockedException.class})
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ResponseBody
+    public Response handleServiceLockedException(
+            ServiceLockedException ex) {
+        return Response.errorResponse(ResultType.SERVICE_LOCKED,
                 Collections.singletonList(ex.getMessage()));
     }
 }

--- a/modules/api/src/test/java/org/eclipse/xpanse/api/exceptions/handler/DeploymentExceptionHandlerTest.java
+++ b/modules/api/src/test/java/org/eclipse/xpanse/api/exceptions/handler/DeploymentExceptionHandlerTest.java
@@ -25,6 +25,7 @@ import org.eclipse.xpanse.modules.models.service.deploy.exceptions.FlavorInvalid
 import org.eclipse.xpanse.modules.models.service.deploy.exceptions.InvalidDeploymentVariableException;
 import org.eclipse.xpanse.modules.models.service.deploy.exceptions.InvalidServiceStateException;
 import org.eclipse.xpanse.modules.models.service.deploy.exceptions.PluginNotFoundException;
+import org.eclipse.xpanse.modules.models.service.deploy.exceptions.ServiceLockedException;
 import org.eclipse.xpanse.modules.models.service.deploy.exceptions.ServiceNotDeployedException;
 import org.eclipse.xpanse.modules.models.service.deploy.exceptions.VariableInvalidException;
 import org.eclipse.xpanse.modules.orchestrator.OrchestratorPlugin;
@@ -154,5 +155,15 @@ class DeploymentExceptionHandlerTest {
         this.mockMvc.perform(get("/xpanse/services")).andExpect(status().is(400))
                 .andExpect(jsonPath("$.resultType").value("Variable Validation Failed")).andExpect(
                         jsonPath("$.details[0]").value("Variable validation failed: [test error]"));
+    }
+
+    @Test
+    void testServiceIsLockedException() throws Exception {
+        when(serviceDetailsViewManager.listDeployedServices(any(), any(), any(), any(),
+                any())).thenThrow(new ServiceLockedException("test error"));
+
+        this.mockMvc.perform(get("/xpanse/services")).andExpect(status().is(400))
+                .andExpect(jsonPath("$.resultType").value("Service Locked")).andExpect(
+                        jsonPath("$.details[0]").value("test error"));
     }
 }

--- a/modules/deployment/src/main/java/org/eclipse/xpanse/modules/deployment/DeployService.java
+++ b/modules/deployment/src/main/java/org/eclipse/xpanse/modules/deployment/DeployService.java
@@ -281,14 +281,18 @@ public class DeployService {
 
         DeployTask modifyTask = new DeployTask();
         modifyTask.setId(deployServiceEntity.getId());
-        deployServiceEntity.getDeployRequest().getServiceRequestProperties()
-                .putAll(modifyRequest.getServiceRequestProperties());
         DeployRequest deployRequest = deployServiceEntity.getDeployRequest();
-        deployRequest.setFlavor(modifyRequest.getFlavor());
         if (StringUtils.isEmpty(modifyRequest.getCustomerServiceName())) {
             deployRequest.setCustomerServiceName(deployServiceEntity.getCustomerServiceName());
         } else {
             deployRequest.setCustomerServiceName(modifyRequest.getCustomerServiceName());
+        }
+        if (StringUtils.isNotBlank(modifyRequest.getFlavor())) {
+            deployRequest.setFlavor(modifyRequest.getFlavor());
+        }
+        if (Objects.nonNull(modifyRequest.getServiceRequestProperties())
+                && !modifyRequest.getServiceRequestProperties().isEmpty()) {
+            deployRequest.setServiceRequestProperties(modifyRequest.getServiceRequestProperties());
         }
         ServiceTemplateEntity existingServiceTemplate =
                 serviceTemplateStorage.getServiceTemplateById(

--- a/modules/models/src/main/java/org/eclipse/xpanse/modules/models/response/ResultType.java
+++ b/modules/models/src/main/java/org/eclipse/xpanse/modules/models/response/ResultType.java
@@ -61,6 +61,7 @@ public enum ResultType {
     ACTIVITI_TASK_NOT_FOUND("Migrating activiti Task Not Found"),
     SERVICE_MIGRATION_FAILED_EXCEPTION("Service Migration Failed Exception"),
     SERVICE_MIGRATION_NOT_FOUND("Service Migration Not Found"),
+    SERVICE_LOCKED("Service Locked"),
     INVALID_GIT_REPO_DETAILS("Invalid Git Repo Details");
 
     private final String value;

--- a/modules/models/src/main/java/org/eclipse/xpanse/modules/models/service/deploy/exceptions/ServiceLockedException.java
+++ b/modules/models/src/main/java/org/eclipse/xpanse/modules/models/service/deploy/exceptions/ServiceLockedException.java
@@ -1,0 +1,17 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * SPDX-FileCopyrightText: Huawei Inc.
+ */
+
+package org.eclipse.xpanse.modules.models.service.deploy.exceptions;
+
+/**
+ * Exception thrown when the service is locked for modification or destruction.
+ */
+public class ServiceLockedException extends RuntimeException {
+    public ServiceLockedException(String message) {
+        super(message);
+    }
+
+}
+

--- a/runtime/src/test/java/org/eclipse/xpanse/runtime/ExistingCloudResourcesApiTest.java
+++ b/runtime/src/test/java/org/eclipse/xpanse/runtime/ExistingCloudResourcesApiTest.java
@@ -31,9 +31,12 @@ import java.util.Collections;
 import java.util.List;
 import org.eclipse.xpanse.modules.models.common.enums.Csp;
 import org.eclipse.xpanse.modules.models.credential.enums.CredentialType;
+import org.eclipse.xpanse.modules.models.response.Response;
+import org.eclipse.xpanse.modules.models.response.ResultType;
 import org.eclipse.xpanse.modules.models.service.deploy.enums.DeployResourceKind;
 import org.eclipse.xpanse.runtime.util.ApisTestCommon;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -410,6 +413,78 @@ class ExistingCloudResourcesApiTest extends ApisTestCommon {
     @WithJwt(file = "jwt_user.json")
     void testGetExistingResourceNamesWithKindForScs() throws Exception {
         testGetExistingResourceNamesWithKindForCspWithOsClient(Csp.SCS);
+    }
+
+
+    @Test
+    @WithJwt(file = "jwt_user.json")
+    void testGetExistingResourceNamesWithKindThrowsException() throws Exception {
+        getExistingResourceNamesWithKindThrowsClientApiCallFailedException(Csp.HUAWEI,
+                "cn-southwest-2");
+        getExistingResourceNamesWithKindThrowsClientApiCallFailedException(Csp.FLEXIBLE_ENGINE,
+                "eu-west-0");
+        getExistingResourceNamesWithKindThrowsClientApiCallFailedException(Csp.OPENSTACK,
+                "RegionOne");
+        getExistingResourceNamesWithKindThrowsClientApiCallFailedException(Csp.SCS, "RegionOne");
+    }
+
+
+    void getExistingResourceNamesWithKindThrowsClientApiCallFailedException(Csp csp, String region)
+            throws Exception {
+        final MockHttpServletResponse listVpcResponse =
+                getExistingResourceNamesWithKind(DeployResourceKind.VPC, csp, region);
+        Response vpcResponse =
+                objectMapper.readValue(listVpcResponse.getContentAsString(), Response.class);
+        Assertions.assertEquals(HttpStatus.BAD_GATEWAY.value(), listVpcResponse.getStatus());
+        Assertions.assertEquals(vpcResponse.getResultType(), ResultType.BACKEND_FAILURE);
+
+        final MockHttpServletResponse listSubnetResponse =
+                getExistingResourceNamesWithKind(DeployResourceKind.SUBNET, csp, region);
+        Response subnetResponse =
+                objectMapper.readValue(listSubnetResponse.getContentAsString(), Response.class);
+        Assertions.assertEquals(HttpStatus.BAD_GATEWAY.value(), listSubnetResponse.getStatus());
+        Assertions.assertEquals(subnetResponse.getResultType(), ResultType.BACKEND_FAILURE);
+
+        final MockHttpServletResponse listSecurityGroupResponse =
+                getExistingResourceNamesWithKind(DeployResourceKind.SECURITY_GROUP, csp, region);
+        Response securityGroupResponse =
+                objectMapper.readValue(listSecurityGroupResponse.getContentAsString(),
+                        Response.class);
+        Assertions.assertEquals(HttpStatus.BAD_GATEWAY.value(),
+                listSecurityGroupResponse.getStatus());
+        Assertions.assertEquals(securityGroupResponse.getResultType(), ResultType.BACKEND_FAILURE);
+
+        final MockHttpServletResponse listSecurityGroupRuleResponse =
+                getExistingResourceNamesWithKind(DeployResourceKind.SECURITY_GROUP_RULE, csp,
+                        region);
+        Response securityGroupRuleResponse =
+                objectMapper.readValue(listSecurityGroupRuleResponse.getContentAsString(),
+                        Response.class);
+        Assertions.assertEquals(HttpStatus.BAD_GATEWAY.value(),
+                listSecurityGroupRuleResponse.getStatus());
+        Assertions.assertEquals(securityGroupRuleResponse.getResultType(),
+                ResultType.BACKEND_FAILURE);
+
+        final MockHttpServletResponse listPublicIpResponse =
+                getExistingResourceNamesWithKind(DeployResourceKind.PUBLIC_IP, csp, region);
+        Response publicIpResponse =
+                objectMapper.readValue(listPublicIpResponse.getContentAsString(), Response.class);
+        Assertions.assertEquals(HttpStatus.BAD_GATEWAY.value(), listPublicIpResponse.getStatus());
+        Assertions.assertEquals(publicIpResponse.getResultType(), ResultType.BACKEND_FAILURE);
+
+        final MockHttpServletResponse listVolumeResponse =
+                getExistingResourceNamesWithKind(DeployResourceKind.VOLUME, csp, region);
+        Response volumeResponse =
+                objectMapper.readValue(listVolumeResponse.getContentAsString(), Response.class);
+        Assertions.assertEquals(HttpStatus.BAD_GATEWAY.value(), listVolumeResponse.getStatus());
+        Assertions.assertEquals(volumeResponse.getResultType(), ResultType.BACKEND_FAILURE);
+
+        final MockHttpServletResponse listKeypairResponse =
+                getExistingResourceNamesWithKind(DeployResourceKind.KEYPAIR, csp, region);
+        Response keypairResponse =
+                objectMapper.readValue(listKeypairResponse.getContentAsString(), Response.class);
+        Assertions.assertEquals(HttpStatus.BAD_GATEWAY.value(), listKeypairResponse.getStatus());
+        Assertions.assertEquals(keypairResponse.getResultType(), ResultType.BACKEND_FAILURE);
     }
 
     void testGetExistingResourceNamesWithKindForCspWithOsClient(Csp csp) throws Exception {


### PR DESCRIPTION
fixes #1534 
When deployed service with lock config `{"destroyLocked":true,"modifyLocked":true}`
![image](https://github.com/eclipse-xpanse/xpanse/assets/121531362/4147c2b5-8012-479a-abdf-7960a40a9f76)
Destroy the service failed:
![chrome_rBHVkDmtoJ](https://github.com/eclipse-xpanse/xpanse/assets/121531362/53c58aba-ce20-4084-ac2e-7a75ff918366)
Modify the service failed:
![chrome_Qz6BM4XQXK](https://github.com/eclipse-xpanse/xpanse/assets/121531362/cb692c46-5814-4f29-bbaa-b2b63cbec5a4)
Migrate the service failed:
![chrome_JO24kAC5qV](https://github.com/eclipse-xpanse/xpanse/assets/121531362/07d3b706-0d7e-4df2-ac67-21abdf26a52c)

