### PR TITLE
Update service status based on different task results

### DIFF
--- a/modules/deployment/src/main/java/org/eclipse/xpanse/modules/deployment/DeployResultManager.java
+++ b/modules/deployment/src/main/java/org/eclipse/xpanse/modules/deployment/DeployResultManager.java
@@ -46,13 +46,11 @@ public class DeployResultManager {
      * @throws RuntimeException exception thrown in case of errors.
      */
     public DeployServiceEntity updateDeployServiceEntityWithDeployResult(
-            DeployResult deployResult, DeployServiceEntity storedEntity)
-            throws RuntimeException {
+            DeployResult deployResult, DeployServiceEntity storedEntity) throws RuntimeException {
         if (Objects.nonNull(deployResult.getState()) && Objects.nonNull(storedEntity)) {
             log.info("Deploy task update deploy service entity with id:{}", deployResult.getId());
             DeployServiceEntity deployServiceEntityToStore = new DeployServiceEntity();
             BeanUtils.copyProperties(storedEntity, deployServiceEntityToStore);
-            deployServiceEntityToStore.setLastStartedAt(OffsetDateTime.now());
             updateEntityWithDeployResult(deployResult, deployServiceEntityToStore);
             return deployServiceEntityHandler.storeAndFlush(deployServiceEntityToStore);
         } else {
@@ -66,14 +64,18 @@ public class DeployResultManager {
         if (StringUtils.isNotBlank(deployResult.getMessage())) {
             deployServiceEntity.setResultMessage(deployResult.getMessage());
         }
-        deployServiceEntity.setServiceState(getServiceState(deployResult.getState()));
         deployServiceEntity.setServiceDeploymentState(
                 getServiceDeploymentState(deployResult.getState()));
 
-        boolean taskExecutedSuccess = deployResult.getState() == DeployerTaskStatus.DESTROY_SUCCESS
-                || deployResult.getState() == DeployerTaskStatus.ROLLBACK_SUCCESS
-                || deployResult.getState() == DeployerTaskStatus.PURGE_SUCCESS
-                || deployResult.getState() == DeployerTaskStatus.DEPLOY_SUCCESS;
+        DeployerTaskStatus deployerTaskStatus = deployResult.getState();
+
+        updateServiceState(deployerTaskStatus, deployServiceEntity);
+
+        boolean taskExecutedSuccess = deployerTaskStatus == DeployerTaskStatus.DESTROY_SUCCESS
+                || deployerTaskStatus == DeployerTaskStatus.MODIFICATION_SUCCESSFUL
+                || deployerTaskStatus == DeployerTaskStatus.ROLLBACK_SUCCESS
+                || deployerTaskStatus == DeployerTaskStatus.PURGE_SUCCESS
+                || deployerTaskStatus == DeployerTaskStatus.DEPLOY_SUCCESS;
 
         if (CollectionUtils.isEmpty(deployResult.getPrivateProperties())) {
             if (taskExecutedSuccess) {
@@ -102,12 +104,19 @@ public class DeployResultManager {
         sensitiveDataHandler.maskSensitiveFields(deployServiceEntity);
     }
 
-    private ServiceState getServiceState(DeployerTaskStatus state) {
+    private void updateServiceState(DeployerTaskStatus state,
+                                    DeployServiceEntity deployServiceEntity) {
         if (state == DeployerTaskStatus.DEPLOY_SUCCESS
                 || state == DeployerTaskStatus.MODIFICATION_SUCCESSFUL) {
-            return ServiceState.RUNNING;
+            deployServiceEntity.setServiceState(ServiceState.RUNNING);
+            deployServiceEntity.setLastStartedAt(OffsetDateTime.now());
         }
-        return ServiceState.NOT_RUNNING;
+        if (state == DeployerTaskStatus.DEPLOY_FAILED
+                || state == DeployerTaskStatus.DESTROY_SUCCESS
+                || state == DeployerTaskStatus.PURGE_SUCCESS) {
+            deployServiceEntity.setServiceState(ServiceState.NOT_RUNNING);
+        }
+        // case other cases, do not change the state of service.
     }
 
     private ServiceDeploymentState getServiceDeploymentState(


### PR DESCRIPTION
fixes #1562 
Service state before modification:
![chrome_AaHEfqJTc9](https://github.com/eclipse-xpanse/xpanse/assets/121531362/720cac17-1b18-470d-acc0-d73fb1d5b9be)
Service state after modification failure:
![chrome_7B04Em5ffk](https://github.com/eclipse-xpanse/xpanse/assets/121531362/6740f774-8fc0-4f67-a2a7-67fc58d79b01)

fixes  #1565 
Service state before deletion:
![chrome_7B04Em5ffk](https://github.com/eclipse-xpanse/xpanse/assets/121531362/6740f774-8fc0-4f67-a2a7-67fc58d79b01)
Service state after deletion failure:
![image](https://github.com/eclipse-xpanse/xpanse/assets/121531362/fa307341-01f0-4b56-9e0c-2b43d70b9921)
Service state after deletion success:
![image](https://github.com/eclipse-xpanse/xpanse/assets/121531362/8e456b22-e1a1-47be-bb81-4db0a3903f58)

