### PR TITLE
add debug logging to HuaweiCloud SDK conditionally

### DIFF
--- a/plugins/flexibleengine/src/main/java/org/eclipse/xpanse/plugins/flexibleengine/common/FlexibleEngineClient.java
+++ b/plugins/flexibleengine/src/main/java/org/eclipse/xpanse/plugins/flexibleengine/common/FlexibleEngineClient.java
@@ -36,6 +36,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.eclipse.xpanse.modules.models.monitor.exceptions.ClientApiCallFailedException;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 /**
@@ -44,6 +45,9 @@ import org.springframework.stereotype.Component;
 @Slf4j
 @Component
 public class FlexibleEngineClient extends FlexibleEngineCredentials {
+
+    @Value("${flexibleengine.sdk.enable.http.debug.logs:false}")
+    private boolean sdkHttpDebugLogsEnabled;
 
     @Resource
     private FlexibleEngineRetryStrategy retryStrategy;
@@ -162,7 +166,7 @@ public class FlexibleEngineClient extends FlexibleEngineCredentials {
 
     private HttpConfig getHttpConfig() {
         HttpConfig httpConfig = HttpConfig.getDefaultHttpConfig();
-        if (log.isInfoEnabled()) {
+        if (sdkHttpDebugLogsEnabled) {
             HttpListener requestListener =
                     HttpListener.forRequestListener(this::outputRequestInfo);
             httpConfig.addHttpListener(requestListener);

--- a/plugins/huaweicloud/src/main/java/org/eclipse/xpanse/plugins/huaweicloud/common/HuaweiCloudClient.java
+++ b/plugins/huaweicloud/src/main/java/org/eclipse/xpanse/plugins/huaweicloud/common/HuaweiCloudClient.java
@@ -25,6 +25,7 @@ import com.huaweicloud.sdk.vpc.v2.VpcClient;
 import com.huaweicloud.sdk.vpc.v2.region.VpcRegion;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 /**
@@ -33,6 +34,9 @@ import org.springframework.stereotype.Component;
 @Slf4j
 @Component
 public class HuaweiCloudClient extends HuaweiCloudCredentials {
+
+    @Value("${huaweicloud.sdk.enable.http.debug.logs:false}")
+    private boolean sdkHttpDebugLogsEnabled;
 
     /**
      * Get HuaweiCloud CES Client.
@@ -56,6 +60,7 @@ public class HuaweiCloudClient extends HuaweiCloudCredentials {
      */
     public EcsClient getEcsClient(ICredential credential, String regionName) {
         return EcsClient.newBuilder()
+                .withHttpConfig(getHttpConfig())
                 .withCredential(credential)
                 .withRegion(EcsRegion.valueOf(regionName))
                 .build();
@@ -69,6 +74,7 @@ public class HuaweiCloudClient extends HuaweiCloudCredentials {
      */
     public VpcClient getVpcClient(ICredential credential, String regionName) {
         return VpcClient.newBuilder()
+                .withHttpConfig(getHttpConfig())
                 .withCredential(credential)
                 .withRegion(VpcRegion.valueOf(regionName))
                 .build();
@@ -78,10 +84,11 @@ public class HuaweiCloudClient extends HuaweiCloudCredentials {
      * Get HuaweiCloud Eip Client.
      *
      * @param credential ICredential
-     * @param regionName  region.
+     * @param regionName region.
      */
     public EipClient getEipClient(ICredential credential, String regionName) {
         return EipClient.newBuilder()
+                .withHttpConfig(getHttpConfig())
                 .withCredential(credential)
                 .withRegion(EipRegion.valueOf(regionName))
                 .build();
@@ -91,10 +98,11 @@ public class HuaweiCloudClient extends HuaweiCloudCredentials {
      * Get HuaweiCloud Evs Client.
      *
      * @param credential ICredential
-     * @param regionName  region.
+     * @param regionName region.
      */
     public EvsClient getEvsClient(ICredential credential, String regionName) {
         return EvsClient.newBuilder()
+                .withHttpConfig(getHttpConfig())
                 .withCredential(credential)
                 .withRegion(EvsRegion.valueOf(regionName))
                 .build();
@@ -108,6 +116,7 @@ public class HuaweiCloudClient extends HuaweiCloudCredentials {
      */
     public IamClient getIamClient(ICredential globalCredential, String regionName) {
         return IamClient.newBuilder()
+                .withHttpConfig(getHttpConfig())
                 .withCredential(globalCredential)
                 .withRegion(IamRegion.valueOf(regionName))
                 .build();
@@ -120,6 +129,7 @@ public class HuaweiCloudClient extends HuaweiCloudCredentials {
      */
     public BssClient getBssClient(ICredential globalCredential) {
         return BssClient.newBuilder()
+                .withHttpConfig(getHttpConfig())
                 .withCredential(globalCredential)
                 .withRegion(BssRegion.CN_NORTH_1)
                 .build();
@@ -127,7 +137,7 @@ public class HuaweiCloudClient extends HuaweiCloudCredentials {
 
     private HttpConfig getHttpConfig() {
         HttpConfig httpConfig = HttpConfig.getDefaultHttpConfig();
-        if (log.isInfoEnabled()) {
+        if (sdkHttpDebugLogsEnabled) {
             HttpListener requestListener =
                     HttpListener.forRequestListener(this::outputRequestInfo);
             httpConfig.addHttpListener(requestListener);

--- a/runtime/src/main/resources/application.properties
+++ b/runtime/src/main/resources/application.properties
@@ -51,3 +51,5 @@ flexibleengine.auto.approve.service.template.enabled=false
 openstack.auto.approve.service.template.enabled=false
 scs.auto.approve.service.template.enabled=false
 region.azs.cache.expire.time.in.minutes=60
+huaweicloud.sdk.enable.http.debug.logs=false
+flexibleengine.sdk.enable.http.debug.logs=false

--- a/runtime/src/main/resources/logback.xml
+++ b/runtime/src/main/resources/logback.xml
@@ -32,4 +32,5 @@
   <root level="error">
     <appender-ref ref="Console"/>
   </root>
+  <logger name="HuaweiCloud-SDK-Access" level="INFO"/>
 </configuration>


### PR DESCRIPTION
fixes https://github.com/eclipse-xpanse/xpanse/issues/1673

By default, the Huawei Cloud SDK only outputs access logs:
![image](https://github.com/eclipse-xpanse/xpanse/assets/121531362/78ef2f56-3313-44bf-a0cc-bbe32ee1d077)

When configuring `huaweicloud.sdk.debug.http.listener.enabled=true`, the Huawei Cloud SDK will also output debug logs:
![image](https://github.com/eclipse-xpanse/xpanse/assets/121531362/e3ae33c5-1ae8-48a1-8e28-ff779730f2f4)



