### PR TITLE
Add API to redeploy services with failed state

### DIFF
--- a/modules/api/src/main/java/org/eclipse/xpanse/api/controllers/ServiceStateManageApi.java
+++ b/modules/api/src/main/java/org/eclipse/xpanse/api/controllers/ServiceStateManageApi.java
@@ -119,8 +119,9 @@ public class ServiceStateManageApi {
             ServiceStateManagementTaskType taskType,
             @Parameter(name = "taskStatus", description = "status of the task")
             @RequestParam(name = "taskStatus", required = false) TaskStatus taskStatus) {
-        return serviceStateManager.listServiceStateManagementTasks(UUID.fromString(serviceId),
-                taskType, taskStatus);
+        UUID uuid = UUID.fromString(serviceId);
+        serviceStateManager.getDeployServiceEntity(uuid);
+        return serviceStateManager.listServiceStateManagementTasks(uuid, taskType, taskStatus);
     }
 
 
@@ -139,7 +140,9 @@ public class ServiceStateManageApi {
     public void deleteManagementTasksByServiceId(
             @Parameter(name = "serviceId", description = "id of the service")
             @PathVariable(name = "serviceId") String serviceId) {
-        serviceStateManager.deleteManagementTasksByServiceId(UUID.fromString(serviceId));
+        UUID uuid = UUID.fromString(serviceId);
+        serviceStateManager.getDeployServiceEntity(uuid);
+        serviceStateManager.deleteManagementTasksByServiceId(uuid);
     }
 
 

--- a/modules/deployment/src/main/java/org/eclipse/xpanse/modules/deployment/DeployResultManager.java
+++ b/modules/deployment/src/main/java/org/eclipse/xpanse/modules/deployment/DeployResultManager.java
@@ -63,10 +63,11 @@ public class DeployResultManager {
                                               DeployServiceEntity deployServiceEntity) {
         if (StringUtils.isNotBlank(deployResult.getMessage())) {
             deployServiceEntity.setResultMessage(deployResult.getMessage());
+        } else {
+            deployServiceEntity.setResultMessage(null);
         }
         if (deployResult.getState() == DeployerTaskStatus.MODIFICATION_SUCCESSFUL) {
             DeployRequest modifyRequest = deployServiceEntity.getDeployRequest();
-            deployServiceEntity.setResultMessage(null);
             deployServiceEntity.setFlavor(modifyRequest.getFlavor());
             deployServiceEntity.setCustomerServiceName(modifyRequest.getCustomerServiceName());
         }

--- a/modules/deployment/src/main/java/org/eclipse/xpanse/modules/deployment/DeployServiceEntityToDeployTaskConverter.java
+++ b/modules/deployment/src/main/java/org/eclipse/xpanse/modules/deployment/DeployServiceEntityToDeployTaskConverter.java
@@ -37,6 +37,7 @@ public class DeployServiceEntityToDeployTaskConverter {
         ServiceTemplateEntity serviceTemplateEntity = serviceTemplateStorage.getServiceTemplateById(
                 deployServiceEntity.getServiceTemplateId());
         deployTask.setOcl(serviceTemplateEntity.getOcl());
+        deployTask.setServiceTemplateId(serviceTemplateEntity.getId());
         return deployTask;
 
     }

--- a/modules/deployment/src/main/java/org/eclipse/xpanse/modules/deployment/ServiceStateManager.java
+++ b/modules/deployment/src/main/java/org/eclipse/xpanse/modules/deployment/ServiceStateManager.java
@@ -211,9 +211,8 @@ public class ServiceStateManager {
      */
     public List<ServiceStateManagementTaskDetails> listServiceStateManagementTasks(
             UUID serviceId, ServiceStateManagementTaskType taskType, TaskStatus taskStatus) {
-        DeployServiceEntity deployedService = getDeployServiceEntity(serviceId);
         ServiceStateManagementTaskEntity taskQuery = new ServiceStateManagementTaskEntity();
-        taskQuery.setServiceId(deployedService.getId());
+        taskQuery.setServiceId(serviceId);
         taskQuery.setTaskType(taskType);
         taskQuery.setTaskStatus(taskStatus);
         List<ServiceStateManagementTaskEntity> taskEntities = taskStorage.queryTasks(taskQuery);
@@ -228,9 +227,8 @@ public class ServiceStateManager {
      * @param serviceId service id.
      */
     public void deleteManagementTasksByServiceId(UUID serviceId) {
-        DeployServiceEntity deployService = getDeployServiceEntity(serviceId);
         ServiceStateManagementTaskEntity taskQuery = new ServiceStateManagementTaskEntity();
-        taskQuery.setServiceId(deployService.getId());
+        taskQuery.setServiceId(serviceId);
         List<ServiceStateManagementTaskEntity> taskEntities = taskStorage.queryTasks(taskQuery);
         taskStorage.batchRemove(taskEntities);
     }
@@ -364,7 +362,13 @@ public class ServiceStateManager {
     }
 
 
-    private DeployServiceEntity getDeployServiceEntity(UUID serviceId) {
+    /**
+     * Get the deployed service entity with the service id.
+     *
+     * @param serviceId service id.
+     * @return DeployServiceEntity.
+     */
+    public DeployServiceEntity getDeployServiceEntity(UUID serviceId) {
         DeployServiceEntity deployedService = deployServiceStorage.findDeployServiceById(serviceId);
         if (Objects.nonNull(deployedService)) {
             if (isNotOwnerOrAdminUser(deployedService)) {

--- a/modules/deployment/src/main/java/org/eclipse/xpanse/modules/deployment/deployers/opentofu/callbacks/OpenTofuDeploymentResultCallbackManager.java
+++ b/modules/deployment/src/main/java/org/eclipse/xpanse/modules/deployment/deployers/opentofu/callbacks/OpenTofuDeploymentResultCallbackManager.java
@@ -130,6 +130,8 @@ public class OpenTofuDeploymentResultCallbackManager {
         deployResult.setId(taskId);
         if (Boolean.FALSE.equals(result.getCommandSuccessful())) {
             deployResult.setMessage(result.getCommandStdError());
+        } else {
+            deployResult.setMessage(null);
         }
         deployResult.setState(getDeployerTaskStatus(scenario, result.getCommandSuccessful()));
         deployResult.getPrivateProperties()

--- a/modules/deployment/src/main/java/org/eclipse/xpanse/modules/deployment/deployers/terraform/callbacks/TerraformDeploymentResultCallbackManager.java
+++ b/modules/deployment/src/main/java/org/eclipse/xpanse/modules/deployment/deployers/terraform/callbacks/TerraformDeploymentResultCallbackManager.java
@@ -130,6 +130,8 @@ public class TerraformDeploymentResultCallbackManager {
         deployResult.setId(taskId);
         if (Boolean.FALSE.equals(result.getCommandSuccessful())) {
             deployResult.setMessage(result.getCommandStdError());
+        } else {
+            deployResult.setMessage(null);
         }
         deployResult.setState(getDeployerTaskStatus(scenario, result.getCommandSuccessful()));
         deployResult.getPrivateProperties()

--- a/runtime/src/test/java/org/eclipse/xpanse/runtime/IsvServiceDeployerApiTest.java
+++ b/runtime/src/test/java/org/eclipse/xpanse/runtime/IsvServiceDeployerApiTest.java
@@ -171,7 +171,7 @@ class IsvServiceDeployerApiTest extends ApisTestCommon {
     void purgeService(UUID taskId) throws Exception {
         // SetUp
         String successMsg =
-                String.format("Purging task for service with ID %s has started.", taskId);
+                String.format("Task for purging managed service %s has started.", taskId);
         Response response = Response.successResponse(Collections.singletonList(successMsg));
         String result = objectMapper.writeValueAsString(response);
         // Run the test

--- a/runtime/src/test/java/org/eclipse/xpanse/runtime/ServiceDeployerApiTest.java
+++ b/runtime/src/test/java/org/eclipse/xpanse/runtime/ServiceDeployerApiTest.java
@@ -19,9 +19,11 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 
 import com.c4_soft.springaddons.security.oauth2.test.annotations.WithJwt;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.huaweicloud.sdk.core.invoker.SyncInvoker;
 import com.huaweicloud.sdk.ecs.v2.model.NovaAvailabilityZone;
+import com.huaweicloud.sdk.ecs.v2.model.NovaListAvailabilityZonesRequest;
 import com.huaweicloud.sdk.ecs.v2.model.NovaListAvailabilityZonesResponse;
 import jakarta.annotation.Resource;
 import java.io.File;
@@ -32,10 +34,10 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.eclipse.xpanse.modules.database.service.DatabaseDeployServiceStorage;
 import org.eclipse.xpanse.modules.database.service.DeployServiceEntity;
+import org.eclipse.xpanse.modules.database.servicetemplate.DatabaseServiceTemplateStorage;
 import org.eclipse.xpanse.modules.models.billing.enums.BillingMode;
 import org.eclipse.xpanse.modules.models.common.enums.Category;
 import org.eclipse.xpanse.modules.models.common.enums.Csp;
@@ -67,9 +69,7 @@ import org.eclipse.xpanse.modules.policy.policyman.generated.model.EvalResult;
 import org.eclipse.xpanse.modules.policy.policyman.generated.model.ValidatePolicyList;
 import org.eclipse.xpanse.modules.policy.policyman.generated.model.ValidateResponse;
 import org.eclipse.xpanse.runtime.util.ApisTestCommon;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.openstack4j.api.OSClient;
@@ -87,28 +87,41 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 /**
  * Test for ServiceDeployerApi.
  */
-@Slf4j
+@SuppressWarnings("unchecked")
 @ExtendWith(SpringExtension.class)
-@SpringBootTest(properties = {"spring.profiles.active=oauth,zitadel,zitadel-testbed",
-        "OS_AUTH_URL=http://127.0.0.1/v3/identity"})
+@SpringBootTest(properties = {
+        "spring.profiles.active=oauth,zitadel,zitadel-testbed",
+        "http.request.retry.max.attempts=2",
+        "http.request.retry.delay.milliseconds=1000",
+        "OS_AUTH_URL=http://127.0.0.1/v3/identity"
+})
 @AutoConfigureMockMvc
 class ServiceDeployerApiTest extends ApisTestCommon {
     private static final long waitTime = 60 * 1000;
     @Resource
     private DatabaseDeployServiceStorage deployServiceStorage;
+    @Resource
+    private DatabaseServiceTemplateStorage serviceTemplateStorage;
     @MockBean
     private PoliciesValidateApi mockPoliciesValidateApi;
     @MockBean
     private PoliciesEvaluationApi mockPoliciesEvaluationApi;
 
-    @BeforeEach
-    void setUp() {
+    @Test
+    @WithJwt(file = "jwt_user.json")
+    void testGetAzsApi() throws Exception {
         mockOsFactory = mockStatic(OSFactory.class);
+        testGetAvailabilityZonesApiThrowsException();
+        testGetAvailabilityZonesApiWell();
+        mockOsFactory.close();
     }
 
-    @AfterEach
-    void tearDown() {
-        mockOsFactory.close();
+    @Test
+    @WithJwt(file = "jwt_all_roles.json")
+    void testDeployApis() throws Exception {
+        testDeployApisThrowExceptions();
+        testDeployApisWithDeployerTerraformLocal();
+        testDeployApisWithDeployerOpenTofuLocal();
     }
 
     void setMockPoliciesValidateApi() {
@@ -123,10 +136,7 @@ class ServiceDeployerApiTest extends ApisTestCommon {
         servicePolicy.setServiceTemplateId(serviceTemplate.getServiceTemplateId());
         servicePolicy.setPolicy("servicePolicy");
         servicePolicy.setEnabled(true);
-        mockMvc.perform(post("/xpanse/service/policies").content(
-                                objectMapper.writeValueAsString(servicePolicy))
-                        .contentType(MediaType.APPLICATION_JSON).accept(MediaType.APPLICATION_JSON))
-                .andReturn().getResponse();
+        addServiceFlavorPolicies(servicePolicy);
 
         ServicePolicyCreateRequest serviceFlavorPolicy = new ServicePolicyCreateRequest();
         serviceFlavorPolicy.setServiceTemplateId(serviceTemplate.getServiceTemplateId());
@@ -135,11 +145,15 @@ class ServiceDeployerApiTest extends ApisTestCommon {
         serviceFlavorPolicy.setFlavorNameList(flavors);
         serviceFlavorPolicy.setPolicy("serviceFlavorPolicy");
         serviceFlavorPolicy.setEnabled(true);
+        addServiceFlavorPolicies(serviceFlavorPolicy);
+    }
+
+    void addServiceFlavorPolicies(ServicePolicyCreateRequest serviceFlavorPolicy)
+            throws Exception {
         mockMvc.perform(post("/xpanse/service/policies").content(
                                 objectMapper.writeValueAsString(serviceFlavorPolicy))
                         .contentType(MediaType.APPLICATION_JSON).accept(MediaType.APPLICATION_JSON))
                 .andReturn().getResponse();
-
     }
 
     UserPolicy addUserPolicy(UserPolicyCreateRequest userPolicy) throws Exception {
@@ -165,20 +179,16 @@ class ServiceDeployerApiTest extends ApisTestCommon {
                 evalResult);
     }
 
-    @Test
-    @WithJwt(file = "jwt_user.json")
-    void testGetAvailabilityZonesWell() throws Exception {
+    void testGetAvailabilityZonesApiWell() throws Exception {
         testGetAvailabilityZonesForHuaweiCloud();
         testGetAvailabilityZonesForFlexibleEngine();
         testGetAvailabilityZonesForOpenstack();
         testGetAvailabilityZonesForScs();
     }
 
-    @Test
-    @WithJwt(file = "jwt_user.json")
-    void testGetAvailabilityZonesThrowsException() throws Exception {
-        getAvailabilityZonesThrowsClientApiCallFailedException(Csp.HUAWEI, "cn-southwest-2");
-        getAvailabilityZonesThrowsClientApiCallFailedException(Csp.FLEXIBLE_ENGINE, "eu-west-0");
+    void testGetAvailabilityZonesApiThrowsException() throws Exception {
+        getAvailabilityZonesThrowsClientApiCallFailedException(Csp.HUAWEI, "cn-southwest");
+        getAvailabilityZonesThrowsClientApiCallFailedException(Csp.FLEXIBLE_ENGINE, "eu-west");
         getAvailabilityZonesThrowsClientApiCallFailedException(Csp.OPENSTACK, "RegionOne");
         getAvailabilityZonesThrowsClientApiCallFailedException(Csp.SCS, "RegionOne");
     }
@@ -207,7 +217,8 @@ class ServiceDeployerApiTest extends ApisTestCommon {
     }
 
     void mockListAvailabilityZonesInvoker(NovaListAvailabilityZonesResponse mockResponse) {
-        SyncInvoker mockInvoker = mock(SyncInvoker.class);
+        SyncInvoker<NovaListAvailabilityZonesRequest, NovaListAvailabilityZonesResponse>
+                mockInvoker = mock(SyncInvoker.class);
         when(mockEcsClient.novaListAvailabilityZonesInvoker(any())).thenReturn(mockInvoker);
         when(mockInvoker.retryTimes(anyInt())).thenReturn(mockInvoker);
         when(mockInvoker.retryCondition(any())).thenReturn(mockInvoker);
@@ -294,38 +305,45 @@ class ServiceDeployerApiTest extends ApisTestCommon {
                 .getResponse();
     }
 
-    @Test
-    @WithJwt(file = "jwt_all_roles.json")
-    void testDeployApisWellWithDeployerTerraformLocal() throws Exception {
+
+    void testDeployApisWithDeployerTerraformLocal() throws Exception {
         // Setup
         Ocl ocl = new OclLoader().getOcl(
                 URI.create("file:src/test/resources/ocl_terraform_test.yml").toURL());
-        ocl.setName("serviceDeployApiTest-1");
-        testDeployerWithOclAndPolicy(ocl, "policy-1");
+        testDeployerWithOclAndPolicy(ocl);
 
         Ocl oclFromGit = new OclLoader().getOcl(
                 URI.create("file:src/test/resources/ocl_terraform_from_git_test.yml").toURL());
-        oclFromGit.setName("serviceDeployApiTest-2");
-        testDeployerWithOclAndPolicy(oclFromGit, "policy-2");
+        testDeployerWithOclAndPolicy(oclFromGit);
     }
 
-    void testDeployerWithOclAndPolicy(Ocl ocl, String policy) throws Exception {
+    void testDeployerWithOclAndPolicy(Ocl ocl) throws Exception {
+        UUID uuid = UUID.randomUUID();
+        ocl.setName("test-" + uuid);
         ServiceTemplateDetailVo serviceTemplate = registerServiceTemplate(ocl);
-        if (Objects.isNull(serviceTemplate)) {
-            log.error("Register service template failed.");
+        if (Objects.isNull(serviceTemplate.getServiceTemplateId())) {
             return;
         }
         approveServiceTemplateRegistration(serviceTemplate.getServiceTemplateId());
         setMockPoliciesValidateApi();
         UserPolicyCreateRequest userPolicyCreateRequest = new UserPolicyCreateRequest();
         userPolicyCreateRequest.setCsp(serviceTemplate.getCsp());
-        userPolicyCreateRequest.setPolicy(policy);
+        userPolicyCreateRequest.setPolicy("policy-" + uuid);
         UserPolicy userPolicy = addUserPolicy(userPolicyCreateRequest);
         addServicePolicies(serviceTemplate);
         addCredentialForHuaweiCloud();
-        mockPolicyEvaluationResult(true);
-
+        // Set up the deployment with policy evaluation failed.
+        mockPolicyEvaluationResult(false);
         UUID serviceId = deployService(serviceTemplate);
+        Assertions.assertTrue(
+                waitUntilExceptedState(serviceId, ServiceDeploymentState.DEPLOY_FAILED));
+
+        // Set up the deployment with policy evaluation successful and redeploy.
+        mockPolicyEvaluationResult(true);
+        testRedeploy(serviceId);
+        Assertions.assertTrue(
+                waitUntilExceptedState(serviceId, ServiceDeploymentState.DEPLOY_SUCCESS));
+
         ServiceLockConfig serviceLockConfig = new ServiceLockConfig();
         serviceLockConfig.setDestroyLocked(false);
         serviceLockConfig.setModifyLocked(false);
@@ -342,33 +360,27 @@ class ServiceDeployerApiTest extends ApisTestCommon {
         } else {
             testPurge(serviceId);
         }
-        unregisterServiceTemplate(serviceTemplate.getServiceTemplateId());
+        serviceTemplateStorage.removeById(serviceTemplate.getServiceTemplateId());
         deleteUserPolicy(userPolicy.getUserPolicyId());
     }
 
-    @Test
-    @WithJwt(file = "jwt_all_roles.json")
-    void testDeployApisWellWithDeployerOpenTofuLocal() throws Exception {
+    void testDeployApisWithDeployerOpenTofuLocal() throws Exception {
         // Setup
         Ocl ocl = new OclLoader().getOcl(
                 URI.create("file:src/test/resources/ocl_terraform_test.yml").toURL());
-        ocl.setName("serviceDeployApiTest-3");
         ocl.getDeployment().setKind(DeployerKind.OPEN_TOFU);
-        testDeployerWithOclAndPolicy(ocl, "policy-3");
+        testDeployerWithOclAndPolicy(ocl);
 
         Ocl oclFromGit = new OclLoader().getOcl(
                 URI.create("file:src/test/resources/ocl_terraform_from_git_test.yml").toURL());
-        oclFromGit.setName("serviceDeployApiTest-4");
         oclFromGit.getDeployment().setKind(DeployerKind.OPEN_TOFU);
-        testDeployerWithOclAndPolicy(oclFromGit, "policy-4");
+        testDeployerWithOclAndPolicy(oclFromGit);
     }
 
-    @Test
-    @WithJwt(file = "jwt_all_roles.json")
-    void testDeployApisThrowsException() throws Exception {
+    void testDeployApisThrowExceptions() throws Exception {
         Ocl ocl = new OclLoader().getOcl(
                 URI.create("file:src/test/resources/ocl_terraform_test.yml").toURL());
-        ocl.setName("serviceDeployApiTest-5");
+        ocl.setName("error-test-" + UUID.randomUUID());
         ocl.getFlavors().setIsDowngradeAllowed(false);
         ServiceFlavorWithPrice defaultFlavor = ocl.getFlavors().getServiceFlavors().getFirst();
         ServiceFlavorWithPrice lowerPriorityFlavor = new ServiceFlavorWithPrice();
@@ -385,13 +397,14 @@ class ServiceDeployerApiTest extends ApisTestCommon {
             testApisThrowServiceFlavorDowngradeNotAllowed(serviceId, defaultFlavor,
                     lowerPriorityFlavor);
         }
-        testApisThrowsServiceLockedException(serviceId);
+        testDeployApiFailedWithVariableInvalidException();
         testApisThrowsServiceDeploymentNotFoundException();
+        testApisThrowsInvalidServiceStateException(serviceId);
+        testApisThrowsServiceLockedException(serviceId);
         testApisThrowsAccessDeniedException(serviceId);
         deployServiceStorage.deleteDeployService(
                 deployServiceStorage.findDeployServiceById(serviceId));
-        unregisterServiceTemplate(serviceTemplate.getServiceTemplateId());
-
+        serviceTemplateStorage.removeById(serviceTemplate.getServiceTemplateId());
     }
 
     void testApisThrowServiceFlavorDowngradeNotAllowed(UUID serviceId,
@@ -410,17 +423,10 @@ class ServiceDeployerApiTest extends ApisTestCommon {
         modifyRequest.setFlavor(lowerPriorityFlavor.getName());
         modifyRequest.setServiceRequestProperties(new HashMap<>());
         // Run the test
-        final MockHttpServletResponse modifyResponse = mockMvc.perform(
-                        put("/xpanse/services/modify/{id}", serviceId)
-                                .content(objectMapper.writeValueAsString(modifyRequest))
-                                .contentType(MediaType.APPLICATION_JSON)
-                                .accept(MediaType.APPLICATION_JSON))
-                .andReturn().getResponse();
-
+        final MockHttpServletResponse modifyResponse = modifyService(serviceId, modifyRequest);
         // Verify the results
         assertEquals(HttpStatus.BAD_REQUEST.value(), modifyResponse.getStatus());
         assertEquals(result, modifyResponse.getContentAsString());
-
     }
 
     void testApisThrowsServiceLockedException(UUID serviceId) throws Exception {
@@ -428,54 +434,170 @@ class ServiceDeployerApiTest extends ApisTestCommon {
         serviceLockConfig.setDestroyLocked(true);
         serviceLockConfig.setModifyLocked(true);
         testChangeLockConfig(serviceId, serviceLockConfig);
+        testModifyThrowsServiceLockedException(serviceId);
         testDestroyThrowsServiceLockedException(serviceId);
     }
 
     void testApisThrowsServiceDeploymentNotFoundException() throws Exception {
-        testGetServiceDetailsThrowsServiceNotDeployedException();
-        testChangeLockConfigThrowsServiceNotDeployedException();
-        testDestroyThrowsServiceNotDeployedException();
-        testPurgeThrowsServiceNotDeployedException();
+        UUID serviceId = UUID.randomUUID();
+        Response expectedResponse = Response.errorResponse(ResultType.SERVICE_DEPLOYMENT_NOT_FOUND,
+                Collections.singletonList(
+                        String.format("Service with id %s not found.", serviceId)));
+        String result = objectMapper.writeValueAsString(expectedResponse);
+
+        // Run the test
+        final MockHttpServletResponse detailResponse = getServiceDetails(serviceId);
+        // Verify the results
+        assertEquals(HttpStatus.BAD_REQUEST.value(), detailResponse.getStatus());
+        assertEquals(result, detailResponse.getContentAsString());
+
+        ServiceLockConfig lockConfig = new ServiceLockConfig();
+        lockConfig.setDestroyLocked(true);
+        lockConfig.setModifyLocked(true);
+        // Run the test
+        final MockHttpServletResponse changeLockResponse = changeLockConfig(serviceId, lockConfig);
+        // Verify the results
+        assertEquals(HttpStatus.BAD_REQUEST.value(), changeLockResponse.getStatus());
+        assertEquals(result, changeLockResponse.getContentAsString());
+
+        // Run the test
+        final MockHttpServletResponse modifyResponse = redeployService(serviceId);
+        assertEquals(HttpStatus.BAD_REQUEST.value(), modifyResponse.getStatus());
+        assertEquals(result, modifyResponse.getContentAsString());
+
+        // Run the test
+        final MockHttpServletResponse redeployResponse = redeployService(serviceId);
+        assertEquals(HttpStatus.BAD_REQUEST.value(), redeployResponse.getStatus());
+        assertEquals(result, redeployResponse.getContentAsString());
+
+        // Run the test
+        final MockHttpServletResponse destroyResponse = destroyService(serviceId);
+        // Verify the results
+        assertEquals(HttpStatus.BAD_REQUEST.value(), destroyResponse.getStatus());
+        assertEquals(result, destroyResponse.getContentAsString());
+
+        // Run the test
+        final MockHttpServletResponse purgeResponse = purgeService(serviceId);
+        assertEquals(HttpStatus.BAD_REQUEST.value(), purgeResponse.getStatus());
+        assertEquals(result, purgeResponse.getContentAsString());
     }
 
-    void testApisThrowsAccessDeniedException(UUID serviceId) throws Exception {
+    void testApisThrowsInvalidServiceStateException(UUID serviceId) throws Exception {
+
+        // SetUp modify
+        String modifyResult = setInvalidStateAndGetExceptedResult(serviceId,
+                ServiceDeploymentState.DESTROYING, "modify");
+        ModifyRequest modifyRequest = new ModifyRequest();
+        modifyRequest.setFlavor("flavor-error");
+
+        // Run the test
+        final MockHttpServletResponse modifyResponse = modifyService(serviceId, modifyRequest);
+        assertEquals(HttpStatus.BAD_REQUEST.value(), modifyResponse.getStatus());
+        assertEquals(modifyResult, modifyResponse.getContentAsString());
+
+        // SetUp redeploy
+        String redeployResult = setInvalidStateAndGetExceptedResult(serviceId,
+                ServiceDeploymentState.DEPLOY_SUCCESS, "redeploy");
+        // Run the test
+        final MockHttpServletResponse redeployResponse = redeployService(serviceId);
+        assertEquals(HttpStatus.BAD_REQUEST.value(), redeployResponse.getStatus());
+        assertEquals(redeployResult, redeployResponse.getContentAsString());
+
+        // SetUp destroy
+        String destroyResult = setInvalidStateAndGetExceptedResult(serviceId,
+                ServiceDeploymentState.DEPLOYING, "destroy");
+        // Run the test
+        final MockHttpServletResponse destroyResponse = destroyService(serviceId);
+        assertEquals(HttpStatus.BAD_REQUEST.value(), destroyResponse.getStatus());
+        assertEquals(destroyResult, destroyResponse.getContentAsString());
+
+        // SetUp purge
+        String purgeResult = setInvalidStateAndGetExceptedResult(serviceId,
+                ServiceDeploymentState.DEPLOYING, "purge");
+        // Run the test
+        final MockHttpServletResponse purgeResponse = purgeService(serviceId);
+        assertEquals(HttpStatus.BAD_REQUEST.value(), purgeResponse.getStatus());
+        assertEquals(purgeResult, purgeResponse.getContentAsString());
+    }
+
+
+    String setInvalidStateAndGetExceptedResult(UUID serviceId,
+                                               ServiceDeploymentState state, String action)
+            throws JsonProcessingException {
         DeployServiceEntity deployServiceEntity =
                 deployServiceStorage.findDeployServiceById(serviceId);
-        deployServiceEntity.setUserId("unique");
+        deployServiceEntity.setServiceDeploymentState(state);
         deployServiceStorage.storeAndFlush(deployServiceEntity);
-        testChangeLockConfigThrowsAccessDenied(serviceId);
-        testDestroyThrowsAccessDenied(serviceId);
-        testPurgeThrowsAccessDenied(serviceId);
+        String errorMsg = String.format("Service %s with the state %s is not allowed to %s.",
+                serviceId, state, action);
+        return objectMapper.writeValueAsString(
+                Response.errorResponse(ResultType.SERVICE_STATE_INVALID,
+                        Collections.singletonList(errorMsg)));
     }
 
-    @Test
-    @WithJwt(file = "jwt_all_roles.json")
-    void testDeployApiFailedWithDeployerOpenTofuLocal() throws Exception {
-        Ocl ocl = new OclLoader().getOcl(
-                URI.create("file:src/test/resources/ocl_terraform_test.yml").toURL());
-        ocl.setName("serviceDeployApiTest-6");
-        ocl.getDeployment().setKind(DeployerKind.OPEN_TOFU);
-        ServiceTemplateDetailVo serviceTemplate = registerServiceTemplate(ocl);
-        testDeployThrowsPolicyEvaluationFailedException(serviceTemplate);
+
+    void testApisThrowsAccessDeniedException(UUID serviceId) throws Exception {
+        // SetUp
+        DeployServiceEntity deployServiceEntity =
+                deployServiceStorage.findDeployServiceById(serviceId);
+        deployServiceEntity.setUserId("invalid-user-id");
+        deployServiceStorage.storeAndFlush(deployServiceEntity);
+
+        // SetUp changeLockConfig
+        String changeLockResult = getAccessDeniedExceptedResult("change lock config of");
+        ServiceLockConfig lockConfig = new ServiceLockConfig();
+        lockConfig.setDestroyLocked(true);
+        lockConfig.setModifyLocked(true);
+        // Run the test
+        final MockHttpServletResponse changeLockResponse = changeLockConfig(serviceId, lockConfig);
+        // Verify the results
+        assertEquals(HttpStatus.FORBIDDEN.value(), changeLockResponse.getStatus());
+        assertEquals(changeLockResult, changeLockResponse.getContentAsString());
+
+        // SetUp modify
+        String modifyResult = getAccessDeniedExceptedResult("modify");
+        ModifyRequest modifyRequest = new ModifyRequest();
+        modifyRequest.setFlavor("flavor-error");
+        // Run the test
+        final MockHttpServletResponse modifyResponse = modifyService(serviceId, modifyRequest);
+        assertEquals(HttpStatus.FORBIDDEN.value(), modifyResponse.getStatus());
+        assertEquals(modifyResult, modifyResponse.getContentAsString());
+
+        // SetUp redeploy
+        String redeployResult = getAccessDeniedExceptedResult("redeploy");
+        // Run the test
+        final MockHttpServletResponse redeployResponse = redeployService(serviceId);
+        assertEquals(HttpStatus.FORBIDDEN.value(), redeployResponse.getStatus());
+        assertEquals(redeployResult, redeployResponse.getContentAsString());
+
+        // SetUp destroy
+        String destroyResult = getAccessDeniedExceptedResult("destroy");
+        // Run the test
+        final MockHttpServletResponse destroyResponse = destroyService(serviceId);
+        assertEquals(HttpStatus.FORBIDDEN.value(), destroyResponse.getStatus());
+        assertEquals(destroyResult, destroyResponse.getContentAsString());
+
+        // SetUp purge
+        String purgeResult = getAccessDeniedExceptedResult("purge");
+        // Run the test
+        final MockHttpServletResponse purgeResponse = purgeService(serviceId);
+        assertEquals(HttpStatus.FORBIDDEN.value(), purgeResponse.getStatus());
+        assertEquals(purgeResult, purgeResponse.getContentAsString());
     }
 
-    @Test
-    @WithJwt(file = "jwt_all_roles.json")
-    void testDeployApiFailedWithDeployerTerraformLocal() throws Exception {
-        Ocl ocl = new OclLoader().getOcl(
-                URI.create("file:src/test/resources/ocl_terraform_test.yml").toURL());
-        ocl.setName("serviceDeployApiTest-7");
-        ServiceTemplateDetailVo serviceTemplate = registerServiceTemplate(ocl);
-        testDeployThrowsPolicyEvaluationFailedException(serviceTemplate);
+    String getAccessDeniedExceptedResult(String action) throws Exception {
+        String errorMsg = String.format("No permissions to %s services belonging to other users.",
+                action);
+        Response expectedResponse = Response.errorResponse(ResultType.ACCESS_DENIED,
+                Collections.singletonList(errorMsg));
+        return objectMapper.writeValueAsString(expectedResponse);
     }
 
-    @Test
-    @WithJwt(file = "jwt_all_roles.json")
     void testDeployApiFailedWithVariableInvalidException() throws Exception {
         // Setup
         Ocl ocl = new OclLoader().getOcl(
                 URI.create("file:src/test/resources/ocl_terraform_test.yml").toURL());
-        ocl.setName("serviceDeployApiTest-8");
+        ocl.setName("error-test-" + UUID.randomUUID());
         ocl.getDeployment().getVariables().getLast().setMandatory(true);
         AvailabilityZoneConfig zoneConfig = new AvailabilityZoneConfig();
         zoneConfig.setDisplayName("Primary AZ");
@@ -500,12 +622,7 @@ class ServiceDeployerApiTest extends ApisTestCommon {
                 Collections.singletonList(refuseMsg1));
         String result1 = objectMapper.writeValueAsString(response1);
 
-        final MockHttpServletResponse deployResponse1 = mockMvc.perform(
-                        post("/xpanse/services").contentType(MediaType.APPLICATION_JSON)
-                                .accept(MediaType.APPLICATION_JSON)
-                                .content(objectMapper.writeValueAsString(deployRequest1))).andReturn()
-                .getResponse();
-
+        final MockHttpServletResponse deployResponse1 = deployService(deployRequest1);
         // Verify the results
         assertEquals(HttpStatus.BAD_REQUEST.value(), deployResponse1.getStatus());
         assertEquals(result1, deployResponse1.getContentAsString());
@@ -526,121 +643,46 @@ class ServiceDeployerApiTest extends ApisTestCommon {
                 Response.errorResponse(ResultType.VARIABLE_VALIDATION_FAILED, List.of(refuseMsg2));
         String result2 = objectMapper.writeValueAsString(response2);
 
-        final MockHttpServletResponse deployResponse2 = mockMvc.perform(
-                        post("/xpanse/services").contentType(MediaType.APPLICATION_JSON)
-                                .accept(MediaType.APPLICATION_JSON)
-                                .content(objectMapper.writeValueAsString(deployRequest2))).andReturn()
-                .getResponse();
-
+        final MockHttpServletResponse deployResponse2 = deployService(deployRequest2);
         // Verify the results
         assertEquals(HttpStatus.BAD_REQUEST.value(), deployResponse2.getStatus());
         assertEquals(result2, deployResponse2.getContentAsString());
-        unregisterServiceTemplate(serviceTemplate.getServiceTemplateId());
+        serviceTemplateStorage.removeById(serviceTemplate.getServiceTemplateId());
+    }
+
+    void testRedeploy(UUID serviceId)
+            throws Exception {
+        String successMsg = String.format("Task for redeploying managed service %s has started.",
+                serviceId);
+        Response response = Response.successResponse(Collections.singletonList(successMsg));
+        String result = objectMapper.writeValueAsString(response);
+        // Run the test
+        final MockHttpServletResponse redeployResponse = redeployService(serviceId);
+        assertEquals(HttpStatus.ACCEPTED.value(), redeployResponse.getStatus());
+        assertEquals(result, redeployResponse.getContentAsString());
     }
 
     void testChangeLockConfig(UUID serviceId, ServiceLockConfig lockConfig)
             throws Exception {
         // Run the test
-        final MockHttpServletResponse changeLockConfigResponse = mockMvc.perform(
-                        put("/xpanse/services/changelock/{id}", serviceId)
-                                .content(objectMapper.writeValueAsString(lockConfig))
-                                .contentType(MediaType.APPLICATION_JSON)
-                                .accept(MediaType.APPLICATION_JSON))
-                .andReturn().getResponse();
-        assertEquals(HttpStatus.NO_CONTENT.value(), changeLockConfigResponse.getStatus());
+        final MockHttpServletResponse changeLockResponse = changeLockConfig(serviceId, lockConfig);
+        assertEquals(HttpStatus.NO_CONTENT.value(), changeLockResponse.getStatus());
     }
 
-    void testChangeLockConfigThrowsServiceNotDeployedException() throws Exception {
-        // SetUp
-        UUID serviceId = UUID.randomUUID();
-        Response expectedResponse = Response.errorResponse(ResultType.SERVICE_DEPLOYMENT_NOT_FOUND,
-                Collections.singletonList(
-                        String.format("Service with id %s not found.", serviceId)));
-        String result = objectMapper.writeValueAsString(expectedResponse);
-        ServiceLockConfig lockConfig = new ServiceLockConfig();
-        lockConfig.setDestroyLocked(true);
-        lockConfig.setModifyLocked(true);
-        // Run the test
-        final MockHttpServletResponse changeLockConfigResponse = mockMvc.perform(
-                        put("/xpanse/services/changelock/{id}", serviceId)
-                                .content(objectMapper.writeValueAsString(lockConfig))
-                                .contentType(MediaType.APPLICATION_JSON)
-                                .accept(MediaType.APPLICATION_JSON))
-                .andReturn().getResponse();
 
-        // Verify the results
-        assertEquals(HttpStatus.BAD_REQUEST.value(), changeLockConfigResponse.getStatus());
-        assertEquals(result, changeLockConfigResponse.getContentAsString());
-    }
-
-    void testChangeLockConfigThrowsAccessDenied(UUID serviceId) throws Exception {
-        // SetUp
-        Response expectedResponse = Response.errorResponse(ResultType.ACCESS_DENIED,
-                Collections.singletonList(
-                        "No permissions to change lock config of services belonging to other users."));
-        String result = objectMapper.writeValueAsString(expectedResponse);
-        ServiceLockConfig lockConfig = new ServiceLockConfig();
-        lockConfig.setDestroyLocked(true);
-        lockConfig.setModifyLocked(true);
-        // Run the test
-        final MockHttpServletResponse changeLockConfigResponse = mockMvc.perform(
-                        put("/xpanse/services/changelock/{id}", serviceId)
-                                .content(objectMapper.writeValueAsString(lockConfig))
-                                .contentType(MediaType.APPLICATION_JSON)
-                                .accept(MediaType.APPLICATION_JSON))
-                .andReturn().getResponse();
-
-        // Verify the results
-        assertEquals(HttpStatus.FORBIDDEN.value(), changeLockConfigResponse.getStatus());
-        assertEquals(result, changeLockConfigResponse.getContentAsString());
-    }
-
-    void testDestroy(UUID taskId) throws Exception {
+    void testDestroy(UUID serviceId) throws Exception {
         // SetUp
         String successMsg =
-                String.format("Task for destroying managed service %s has started.", taskId);
+                String.format("Task for destroying managed service %s has started.", serviceId);
         Response response = Response.successResponse(Collections.singletonList(successMsg));
-
         String result = objectMapper.writeValueAsString(response);
-
         // Run the test
-        final MockHttpServletResponse destroyResponse =
-                mockMvc.perform(delete("/xpanse/services/{id}", taskId)).andReturn().getResponse();
-
+        final MockHttpServletResponse destroyResponse = destroyService(serviceId);
         // Verify the results
         assertEquals(HttpStatus.ACCEPTED.value(), destroyResponse.getStatus());
         assertEquals(result, destroyResponse.getContentAsString());
     }
 
-    void testDestroyThrowsServiceNotDeployedException() throws Exception {
-        UUID uuid = UUID.randomUUID();
-        Response expectedResponse = Response.errorResponse(ResultType.SERVICE_DEPLOYMENT_NOT_FOUND,
-                Collections.singletonList(String.format("Service with id %s not found.", uuid)));
-        String result = objectMapper.writeValueAsString(expectedResponse);
-
-        // Run the test
-        final MockHttpServletResponse destroyResponse = mockMvc.perform(
-                delete("/xpanse/services/{id}", uuid).contentType(MediaType.APPLICATION_JSON)
-                        .accept(MediaType.APPLICATION_JSON)).andReturn().getResponse();
-
-        // Verify the results
-        assertEquals(HttpStatus.BAD_REQUEST.value(), destroyResponse.getStatus());
-        assertEquals(result, destroyResponse.getContentAsString());
-    }
-
-    void testDestroyThrowsAccessDenied(UUID serviceId) throws Exception {
-        // SetUp
-        Response expectedResponse = Response.errorResponse(ResultType.ACCESS_DENIED,
-                Collections.singletonList("No permissions to destroy services belonging to other "
-                        + "users."));
-        String result = objectMapper.writeValueAsString(expectedResponse);
-        // Run the test
-        final MockHttpServletResponse destroyResponse =
-                mockMvc.perform(delete("/xpanse/services/{id}", serviceId)).andReturn()
-                        .getResponse();
-        assertEquals(HttpStatus.FORBIDDEN.value(), destroyResponse.getStatus());
-        assertEquals(result, destroyResponse.getContentAsString());
-    }
 
     void testDestroyThrowsServiceLockedException(UUID serviceId) throws Exception {
         // SetUp
@@ -649,9 +691,23 @@ class ServiceDeployerApiTest extends ApisTestCommon {
                 Collections.singletonList(message));
         String result = objectMapper.writeValueAsString(expectedResponse);
         // Run the test
+        final MockHttpServletResponse destroyResponse = destroyService(serviceId);
+        assertEquals(HttpStatus.BAD_REQUEST.value(), destroyResponse.getStatus());
+        assertEquals(result, destroyResponse.getContentAsString());
+    }
+
+    void testModifyThrowsServiceLockedException(UUID serviceId) throws Exception {
+        // SetUp
+        String message = String.format("Service with id %s is locked from modification.",
+                serviceId);
+        Response expectedResponse = Response.errorResponse(ResultType.SERVICE_LOCKED,
+                Collections.singletonList(message));
+        String result = objectMapper.writeValueAsString(expectedResponse);
+        ModifyRequest modifyRequest = new ModifyRequest();
+        modifyRequest.setFlavor("flavor-error");
+        // Run the test
         final MockHttpServletResponse destroyResponse =
-                mockMvc.perform(delete("/xpanse/services/{id}", serviceId)).andReturn()
-                        .getResponse();
+                modifyService(serviceId, modifyRequest);
         assertEquals(HttpStatus.BAD_REQUEST.value(), destroyResponse.getStatus());
         assertEquals(result, destroyResponse.getContentAsString());
     }
@@ -665,88 +721,37 @@ class ServiceDeployerApiTest extends ApisTestCommon {
 
         DeployRequest deployRequest = getDeployRequest(serviceTemplate);
         // Run the test
-        final MockHttpServletResponse deployResponse = mockMvc.perform(
-                        post("/xpanse/services").contentType(MediaType.APPLICATION_JSON)
-                                .accept(MediaType.APPLICATION_JSON)
-                                .content(objectMapper.writeValueAsString(deployRequest))).andReturn()
-                .getResponse();
-
+        final MockHttpServletResponse deployResponse = deployService(deployRequest);
         // Verify the results
         assertEquals(HttpStatus.BAD_REQUEST.value(), deployResponse.getStatus());
         assertEquals(result, deployResponse.getContentAsString());
     }
 
-    void testDeployThrowsPolicyEvaluationFailedException(ServiceTemplateDetailVo serviceTemplate)
-            throws Exception {
-        approveServiceTemplateRegistration(serviceTemplate.getServiceTemplateId());
-        setMockPoliciesValidateApi();
-        UserPolicyCreateRequest userPolicyCreateRequest = new UserPolicyCreateRequest();
-        userPolicyCreateRequest.setCsp(serviceTemplate.getCsp());
-        userPolicyCreateRequest.setPolicy("userPolicy-3");
-        UserPolicy userPolicy = addUserPolicy(userPolicyCreateRequest);
-        addServicePolicies(serviceTemplate);
-        addCredentialForHuaweiCloud();
-        mockPolicyEvaluationResult(false);
-        deployService(serviceTemplate);
-        deleteUserPolicy(userPolicy.getUserPolicyId());
-        unregisterServiceTemplate(serviceTemplate.getServiceTemplateId());
-    }
 
-
-    void testPurge(UUID taskId) throws Exception {
+    void testPurge(UUID serviceId) throws Exception {
         // SetUp
         String successMsg =
-                String.format("Purging task for service with ID %s has started.", taskId);
+                String.format("Task for purging managed service %s has started.", serviceId);
         Response response = Response.successResponse(Collections.singletonList(successMsg));
         String result = objectMapper.writeValueAsString(response);
         // Run the test
-        final MockHttpServletResponse purgeResponse =
-                mockMvc.perform(delete("/xpanse/services/purge/{id}", taskId)).andReturn()
-                        .getResponse();
+        final MockHttpServletResponse purgeResponse = purgeService(serviceId);
         assertEquals(HttpStatus.ACCEPTED.value(), purgeResponse.getStatus());
         assertEquals(result, purgeResponse.getContentAsString());
 
         Thread.sleep(waitTime);
         // SetUp
-        String refuseMsg = String.format("Service with id %s not found.", taskId);
+        String refuseMsg = String.format("Service with id %s not found.", serviceId);
         Response detailsErrorResponse =
                 Response.errorResponse(ResultType.SERVICE_DEPLOYMENT_NOT_FOUND,
                         Collections.singletonList(refuseMsg));
         String detailsResult = objectMapper.writeValueAsString(detailsErrorResponse);
         final MockHttpServletResponse detailsResponse =
-                mockMvc.perform(get("/xpanse/services/details/self_hosted/{id}", taskId))
+                mockMvc.perform(get("/xpanse/services/details/self_hosted/{id}", serviceId))
                         .andReturn().getResponse();
 
         assertEquals(HttpStatus.BAD_REQUEST.value(), detailsResponse.getStatus());
         assertEquals(detailsResult, detailsResponse.getContentAsString());
-    }
-
-    void testPurgeThrowsServiceNotDeployedException() throws Exception {
-        UUID serviceId = UUID.randomUUID();
-        // SetUp
-        String refuseMsg = String.format("Service with id %s not found.", serviceId);
-        Response response = Response.errorResponse(ResultType.SERVICE_DEPLOYMENT_NOT_FOUND,
-                Collections.singletonList(refuseMsg));
-        String result = objectMapper.writeValueAsString(response);
-        // Run the test
-        final MockHttpServletResponse purgeResponse =
-                mockMvc.perform(delete("/xpanse/services/purge/{id}", serviceId)).andReturn()
-                        .getResponse();
-        assertEquals(HttpStatus.BAD_REQUEST.value(), purgeResponse.getStatus());
-        assertEquals(result, purgeResponse.getContentAsString());
-    }
-
-    void testPurgeThrowsAccessDenied(UUID serviceId) throws Exception {
-        Response expectedResponse = Response.errorResponse(ResultType.ACCESS_DENIED,
-                Collections.singletonList("No permissions to purge services belonging to other "
-                        + "users."));
-        String result = objectMapper.writeValueAsString(expectedResponse);
-        // Run the test
-        final MockHttpServletResponse purgeResponse =
-                mockMvc.perform(delete("/xpanse/services/purge/{id}", serviceId)).andReturn()
-                        .getResponse();
-        assertEquals(HttpStatus.FORBIDDEN.value(), purgeResponse.getStatus());
-        assertEquals(result, purgeResponse.getContentAsString());
     }
 
 
@@ -784,9 +789,7 @@ class ServiceDeployerApiTest extends ApisTestCommon {
                 Response.errorResponse(ResultType.SERVICE_TEMPLATE_NOT_REGISTERED,
                         Collections.singletonList("No available service templates found."));
         String result = objectMapper.writeValueAsString(expectedResponse);
-
         DeployRequest deployRequest = new DeployRequest();
-
         deployRequest.setServiceName("redis");
         deployRequest.setVersion("1.0.0");
         deployRequest.setCsp(Csp.HUAWEI);
@@ -798,14 +801,8 @@ class ServiceDeployerApiTest extends ApisTestCommon {
         deployRequest.setRegion(region);
         deployRequest.setServiceHostingType(ServiceHostingType.SELF);
         deployRequest.setBillingMode(BillingMode.FIXED);
-        String requestBody = objectMapper.writeValueAsString(deployRequest);
-
         // Run the test
-        final MockHttpServletResponse deployResponse = mockMvc.perform(
-                        post("/xpanse/services").contentType(MediaType.APPLICATION_JSON)
-                                .accept(MediaType.APPLICATION_JSON).content(requestBody)).andReturn()
-                .getResponse();
-
+        final MockHttpServletResponse deployResponse = deployService(deployRequest);
         // Verify the results
         assertEquals(HttpStatus.BAD_REQUEST.value(), deployResponse.getStatus());
         assertEquals(result, deployResponse.getContentAsString());
@@ -813,20 +810,54 @@ class ServiceDeployerApiTest extends ApisTestCommon {
     }
 
 
-    void testGetServiceDetailsThrowsServiceNotDeployedException() throws Exception {
-        String uuid = UUID.randomUUID().toString();
-        Response expectedResponse = Response.errorResponse(ResultType.SERVICE_DEPLOYMENT_NOT_FOUND,
-                Collections.singletonList(String.format("Service with id %s not found.", uuid)));
-        String result = objectMapper.writeValueAsString(expectedResponse);
-
-        // Run the test
-        final MockHttpServletResponse detailResponse =
-                mockMvc.perform(get("/xpanse/services/details/self_hosted/{id}", uuid)).andReturn()
-                        .getResponse();
+    MockHttpServletResponse getServiceDetails(UUID serviceId) throws Exception {
+        return mockMvc.perform(get("/xpanse/services/details/self_hosted/{id}", serviceId)
+                .contentType(MediaType.APPLICATION_JSON).accept(MediaType.APPLICATION_JSON)
+        ).andReturn().getResponse();
+    }
 
 
-        // Verify the results
-        assertEquals(HttpStatus.BAD_REQUEST.value(), detailResponse.getStatus());
-        assertEquals(result, detailResponse.getContentAsString());
+    MockHttpServletResponse deployService(DeployRequest deployRequest) throws Exception {
+        return mockMvc.perform(post("/xpanse/services")
+                        .contentType(MediaType.APPLICATION_JSON).accept(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(deployRequest))).andReturn()
+                .getResponse();
+    }
+
+
+    MockHttpServletResponse changeLockConfig(UUID serviceId, ServiceLockConfig lockConfig)
+            throws Exception {
+        return mockMvc.perform(put("/xpanse/services/changelock/{id}", serviceId)
+                        .content(objectMapper.writeValueAsString(lockConfig))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andReturn().getResponse();
+    }
+
+    MockHttpServletResponse modifyService(UUID serviceId, ModifyRequest modifyRequest)
+            throws Exception {
+        return mockMvc.perform(put("/xpanse/services/modify/{id}", serviceId)
+                        .content(objectMapper.writeValueAsString(modifyRequest))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andReturn().getResponse();
+    }
+
+    MockHttpServletResponse destroyService(UUID serviceId) throws Exception {
+        return mockMvc.perform(delete("/xpanse/services/{id}", serviceId)
+                .contentType(MediaType.APPLICATION_JSON).accept(MediaType.APPLICATION_JSON)
+        ).andReturn().getResponse();
+    }
+
+    MockHttpServletResponse purgeService(UUID serviceId) throws Exception {
+        return mockMvc.perform(delete("/xpanse/services/purge/{id}", serviceId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON)).andReturn().getResponse();
+    }
+
+    MockHttpServletResponse redeployService(UUID serviceId) throws Exception {
+        return mockMvc.perform(put("/xpanse/services/deploy/retry/{id}", serviceId)
+                .contentType(MediaType.APPLICATION_JSON).accept(MediaType.APPLICATION_JSON)
+        ).andReturn().getResponse();
     }
 }

--- a/runtime/src/test/java/org/eclipse/xpanse/runtime/util/ApisTestCommon.java
+++ b/runtime/src/test/java/org/eclipse/xpanse/runtime/util/ApisTestCommon.java
@@ -32,6 +32,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 import org.eclipse.xpanse.modules.models.common.enums.Csp;
 import org.eclipse.xpanse.modules.models.credential.CreateCredential;
 import org.eclipse.xpanse.modules.models.credential.CredentialVariable;
@@ -174,22 +175,18 @@ public class ApisTestCommon {
 
     protected boolean waitUntilExceptedState(UUID id, ServiceDeploymentState targetState)
             throws Exception {
-        boolean isDone = false;
-        long startTime = System.currentTimeMillis();
-        while (!isDone) {
+        final long endTime = System.nanoTime() + TimeUnit.MINUTES.toNanos(1);
+        while (true) {
             DeployedService deployedService = getDeployedServiceDetails(id);
             if (Objects.nonNull(deployedService)
                     && deployedService.getServiceDeploymentState() == targetState) {
-                isDone = true;
-            } else {
-                if (System.currentTimeMillis() - startTime > 60 * 1000) {
-                    break;
-                }
-                Thread.sleep(5 * 1000);
+                return true;
             }
-
+            if (System.nanoTime() > endTime) {
+                return false;
+            }
+            Thread.sleep(TimeUnit.SECONDS.toMillis(5));
         }
-        return isDone;
     }
 
     protected UUID deployService(ServiceTemplateDetailVo serviceTemplateDetailVo) throws Exception {


### PR DESCRIPTION
fixes #1687 
New API to redeploy service with id:
![image](https://github.com/eclipse-xpanse/xpanse/assets/121531362/02ae7f84-3a6c-42c8-aad6-fcaea1e82a2a)

Redeploy the service not with failed state return 400:
![msedge_tw2HVQ8JKy](https://github.com/eclipse-xpanse/xpanse/assets/121531362/33813765-0d65-497d-b7b1-7551462a51f0)
Redeploy the service with failed state return 202:
![msedge_6lDGUsKGKP](https://github.com/eclipse-xpanse/xpanse/assets/121531362/6dbc6928-4274-4b50-9d51-81cc0a5886ef)


