### PR TITLE
Delete controller cache to prevent return errors

### DIFF
--- a/modules/api/src/main/java/org/eclipse/xpanse/api/controllers/ServiceDeployerApi.java
+++ b/modules/api/src/main/java/org/eclipse/xpanse/api/controllers/ServiceDeployerApi.java
@@ -350,13 +350,18 @@ public class ServiceDeployerApi {
             @RequestParam(name = "regionName") String regionName,
             @Parameter(name = "serviceId", description = "id of the deployed service")
             @RequestParam(name = "serviceId", required = false) String serviceId) {
-
-        UUID uuid = StringUtils.isBlank(serviceId) ? null : UUID.fromString(serviceId);
-        String currentUserId = this.userServiceHelper.getCurrentUserId();
-        OrchestratorPlugin orchestratorPlugin = pluginManager.getOrchestratorPlugin(csp);
-        List<String> availabilityZones = orchestratorPlugin.getAvailabilityZonesOfRegion(
-                currentUserId, regionName, uuid);
-        return ResponseEntity.ok().cacheControl(getCacheControl()).body(availabilityZones);
+        try {
+            UUID uuid = StringUtils.isBlank(serviceId) ? null : UUID.fromString(serviceId);
+            String currentUserId = this.userServiceHelper.getCurrentUserId();
+            OrchestratorPlugin orchestratorPlugin = pluginManager.getOrchestratorPlugin(csp);
+            List<String> availabilityZones = orchestratorPlugin.getAvailabilityZonesOfRegion(
+                    currentUserId, regionName, uuid);
+            return ResponseEntity.ok().cacheControl(getCacheControl()).body(availabilityZones);
+        } catch (Exception ex) {
+            log.error("Error fetching availability zones", ex);
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .cacheControl(CacheControl.noCache()).body(Collections.emptyList());
+        }
     }
 
     private CacheControl getCacheControl() {

--- a/runtime/src/test/java/org/eclipse/xpanse/runtime/ServiceDeployerApiTest.java
+++ b/runtime/src/test/java/org/eclipse/xpanse/runtime/ServiceDeployerApiTest.java
@@ -271,10 +271,9 @@ class ServiceDeployerApiTest extends ApisTestCommon {
     void getAvailabilityZonesThrowsClientApiCallFailedException(Csp csp, String regionName)
             throws Exception {
         final MockHttpServletResponse listAzResponse = getAvailabilityZones(csp, regionName);
-        Response response =
-                objectMapper.readValue(listAzResponse.getContentAsString(), Response.class);
-        Assertions.assertEquals(HttpStatus.BAD_GATEWAY.value(), listAzResponse.getStatus());
-        Assertions.assertEquals(response.getResultType(), ResultType.BACKEND_FAILURE);
+        Assertions.assertEquals(HttpStatus.BAD_REQUEST.value(), listAzResponse.getStatus());
+        Assertions.assertEquals(listAzResponse.getContentAsString(), "[]");
+        Assertions.assertEquals(listAzResponse.getHeader("Cache-Control"),"no-cache");
     }
 
     MockHttpServletResponse getAvailabilityZones(Csp csp, String regionName) throws Exception {


### PR DESCRIPTION
fixes #1760 

Return errors with error credential:
![msedge_GPRrEjmMMU](https://github.com/eclipse-xpanse/xpanse/assets/121531362/ea942c6d-e6a4-4908-9ce1-9aa29a94f251)
Return correct data with correct credential not cached errors:
![msedge_7QvafA4eiK](https://github.com/eclipse-xpanse/xpanse/assets/121531362/ea74e470-ebcd-40cc-9d65-6692b9112701)
