### PR TITLE
make all fixed prices region specific

### DIFF
--- a/modules/api/src/test/resources/ocl_terraform_test.yml
+++ b/modules/api/src/test/resources/ocl_terraform_test.yml
@@ -20,6 +20,10 @@ cloudServiceProvider:
       area: Asia China
     - name: cn-north-4
       area: Asia China
+    - name: eu-west-0
+      area: Europe Pairs
+    - name: eu-west-101
+      area: Europe Dublin
 billing:
   # The supported mode of billing (`Fixed`, `Pay per Use`)
   billingModes:
@@ -48,27 +52,50 @@ flavors:
                 cloud_service_type: hws.service.type.ebs
                 resource_type: hws.resource.type.volume
                 resource_spec: SSD
-                resourceSize: 40
+                resource_size: 40
+                size_measure_id: 17
             - deployResourceKind: publicIP
               count: 1
               properties:
                 cloud_service_type: hws.service.type.vpc
                 resource_type: hws.resource.type.bandwidth
                 resource_spec: 19_bgp
-                resourceSize: 5
-          licensePrice:
-            cost: 0.80
-            currency: CNY
-            period: hourly
-          markUpPrice:
-            cost: 0.72
-            currency: CNY
-            period: hourly
+                resource_size: 5
+                size_measure_id: 15
+          licensePrices:
+            - region: any
+              price:
+                cost: 0.50
+                currency: CNY
+                period: hourly
+            - region: eu-west-101
+              price:
+                cost: 0.0015
+                currency: USD
+                period: hourly
+          markUpPrices:
+            - region: any
+              price:
+                cost: 0.50
+                currency: CNY
+                period: hourly
+            - region: eu-west-101
+              price:
+                cost: 0.0015
+                currency: USD
+                period: hourly
         # Used to calculate charges when users do not select 'pay_per_use' as the billing mode.
-        fixedPrice:
-          cost: 300
-          currency: CNY
-          period: monthly
+        fixedPrices:
+          - region: any
+            price:
+              cost: 172
+              currency: CNY
+              period: monthly
+          - region: eu-west-101
+            price:
+              cost: 20.00
+              currency: USD
+              period: monthly
         isPriceOnlyForManagementLayer: false
       # Properties for the service, which can be used by the deployment.
       properties:
@@ -95,27 +122,50 @@ flavors:
                 cloud_service_type: hws.service.type.ebs
                 resource_type: hws.resource.type.volume
                 resource_spec: SSD
-                resourceSize: 40
+                resource_size: 40
+                size_measure_id: 17
             - deployResourceKind: publicIP
               count: 1
               properties:
                 cloud_service_type: hws.service.type.vpc
                 resource_type: hws.resource.type.bandwidth
                 resource_spec: 19_bgp
-                resourceSize: 5
-          licensePrice:
-            cost: 1.21
-            currency: CNY
-            period: hourly
-          markUpPrice:
-            cost: 1.10
-            currency: CNY
-            period: hourly
+                resource_size: 5
+                size_measure_id: 15
+          licensePrices:
+            - region: any
+              price:
+                cost: 0.50
+                currency: CNY
+                period: hourly
+            - region: eu-west-101
+              price:
+                cost: 0.0015
+                currency: USD
+                period: hourly
+          markUpPrices:
+            - region: any
+              price:
+                cost: 0.50
+                currency: CNY
+                period: hourly
+            - region: eu-west-101
+              price:
+                cost: 0.0015
+                currency: USD
+                period: hourly
         # Used to calculate charges when users do not select 'pay_per_use' as the billing mode.
-        fixedPrice:
-          cost: 360
-          currency: CNY
-          period: monthly
+        fixedPrices:
+          - region: any
+            price:
+              cost: 360
+              currency: CNY
+              period: monthly
+          - region: eu-west-101
+            price:
+              cost: 35.00
+              currency: USD
+              period: monthly
         isPriceOnlyForManagementLayer: false
       # Properties for the service, which can be used by the deployment.
       properties:
@@ -128,7 +178,10 @@ flavors:
     isServiceInterrupted: true
   isDowngradeAllowed: true
 serviceProviderContactDetails:
-  emails: [ "test@test.com" ]
+  emails: [ "test30@test.com","test31@test.com" ]
+  phones: [ "011-13422222222","022-13344444444" ]
+  chats: [ "test1234","test1235" ]
+  websites: [ "https://hw.com","https://hwcloud.com" ]
 deployment:
   # kind, Supported values are terraform, opentofu.
   kind: terraform

--- a/modules/database/src/test/resources/ocl_terraform_test.yml
+++ b/modules/database/src/test/resources/ocl_terraform_test.yml
@@ -20,6 +20,10 @@ cloudServiceProvider:
       area: Asia China
     - name: cn-north-4
       area: Asia China
+    - name: eu-west-0
+      area: Europe Pairs
+    - name: eu-west-101
+      area: Europe Dublin
 billing:
   # The supported mode of billing (`Fixed`, `Pay per Use`)
   billingModes:
@@ -58,19 +62,40 @@ flavors:
                 resource_spec: 19_bgp
                 resource_size: 5
                 size_measure_id: 15
-          licensePrice:
-            cost: 0.80
-            currency: CNY
-            period: hourly
-          markUpPrice:
-            cost: 0.72
-            currency: CNY
-            period: hourly
+          licensePrices:
+            - region: any
+              price:
+                cost: 0.50
+                currency: CNY
+                period: hourly
+            - region: eu-west-101
+              price:
+                cost: 0.0015
+                currency: USD
+                period: hourly
+          markUpPrices:
+            - region: any
+              price:
+                cost: 0.50
+                currency: CNY
+                period: hourly
+            - region: eu-west-101
+              price:
+                cost: 0.0015
+                currency: USD
+                period: hourly
         # Used to calculate charges when users do not select 'pay_per_use' as the billing mode.
-        fixedPrice:
-          cost: 300
-          currency: CNY
-          period: monthly
+        fixedPrices:
+          - region: any
+            price:
+              cost: 172
+              currency: CNY
+              period: monthly
+          - region: eu-west-101
+            price:
+              cost: 20.00
+              currency: USD
+              period: monthly
         isPriceOnlyForManagementLayer: false
       # Properties for the service, which can be used by the deployment.
       properties:
@@ -107,19 +132,40 @@ flavors:
                 resource_spec: 19_bgp
                 resource_size: 5
                 size_measure_id: 15
-          licensePrice:
-            cost: 1.21
-            currency: CNY
-            period: hourly
-          markUpPrice:
-            cost: 1.10
-            currency: CNY
-            period: hourly
+          licensePrices:
+            - region: any
+              price:
+                cost: 0.50
+                currency: CNY
+                period: hourly
+            - region: eu-west-101
+              price:
+                cost: 0.0015
+                currency: USD
+                period: hourly
+          markUpPrices:
+            - region: any
+              price:
+                cost: 0.50
+                currency: CNY
+                period: hourly
+            - region: eu-west-101
+              price:
+                cost: 0.0015
+                currency: USD
+                period: hourly
         # Used to calculate charges when users do not select 'pay_per_use' as the billing mode.
-        fixedPrice:
-          cost: 360
-          currency: CNY
-          period: monthly
+        fixedPrices:
+          - region: any
+            price:
+              cost: 360
+              currency: CNY
+              period: monthly
+          - region: eu-west-101
+            price:
+              cost: 35.00
+              currency: USD
+              period: monthly
         isPriceOnlyForManagementLayer: false
       # Properties for the service, which can be used by the deployment.
       properties:
@@ -132,7 +178,10 @@ flavors:
     isServiceInterrupted: true
   isDowngradeAllowed: true
 serviceProviderContactDetails:
-  emails: [ "test@test.com" ]
+  emails: [ "test30@test.com","test31@test.com" ]
+  phones: [ "011-13422222222","022-13344444444" ]
+  chats: [ "test1234","test1235" ]
+  websites: [ "https://hw.com","https://hwcloud.com" ]
 deployment:
   # kind, Supported values are terraform, opentofu.
   kind: terraform

--- a/modules/deployment/src/test/resources/ocl_terraform_from_git_test.yml
+++ b/modules/deployment/src/test/resources/ocl_terraform_from_git_test.yml
@@ -20,6 +20,10 @@ cloudServiceProvider:
       area: Asia China
     - name: cn-north-4
       area: Asia China
+    - name: eu-west-0
+      area: Europe Pairs
+    - name: eu-west-101
+      area: Europe Dublin
 billing:
   # The supported mode of billing (`Fixed`, `Pay per Use`)
   billingModes:
@@ -58,19 +62,40 @@ flavors:
                 resource_spec: 19_bgp
                 resource_size: 5
                 size_measure_id: 15
-          licensePrice:
-            cost: 0.80
-            currency: CNY
-            period: hourly
-          markUpPrice:
-            cost: 0.72
-            currency: CNY
-            period: hourly
+          licensePrices:
+            - region: any
+              price:
+                cost: 0.50
+                currency: CNY
+                period: hourly
+            - region: eu-west-101
+              price:
+                cost: 0.0015
+                currency: USD
+                period: hourly
+          markUpPrices:
+            - region: any
+              price:
+                cost: 0.50
+                currency: CNY
+                period: hourly
+            - region: eu-west-101
+              price:
+                cost: 0.0015
+                currency: USD
+                period: hourly
         # Used to calculate charges when users do not select 'pay_per_use' as the billing mode.
-        fixedPrice:
-          cost: 300
-          currency: CNY
-          period: monthly
+        fixedPrices:
+          - region: any
+            price:
+              cost: 172
+              currency: CNY
+              period: monthly
+          - region: eu-west-101
+            price:
+              cost: 20.00
+              currency: USD
+              period: monthly
         isPriceOnlyForManagementLayer: false
       # Properties for the service, which can be used by the deployment.
       properties:
@@ -107,19 +132,40 @@ flavors:
                 resource_spec: 19_bgp
                 resource_size: 5
                 size_measure_id: 15
-          licensePrice:
-            cost: 1.21
-            currency: CNY
-            period: hourly
-          markUpPrice:
-            cost: 1.10
-            currency: CNY
-            period: hourly
+          licensePrices:
+            - region: any
+              price:
+                cost: 0.50
+                currency: CNY
+                period: hourly
+            - region: eu-west-101
+              price:
+                cost: 0.0015
+                currency: USD
+                period: hourly
+          markUpPrices:
+            - region: any
+              price:
+                cost: 0.50
+                currency: CNY
+                period: hourly
+            - region: eu-west-101
+              price:
+                cost: 0.0015
+                currency: USD
+                period: hourly
         # Used to calculate charges when users do not select 'pay_per_use' as the billing mode.
-        fixedPrice:
-          cost: 360
-          currency: CNY
-          period: monthly
+        fixedPrices:
+          - region: any
+            price:
+              cost: 360
+              currency: CNY
+              period: monthly
+          - region: eu-west-101
+            price:
+              cost: 35.00
+              currency: USD
+              period: monthly
         isPriceOnlyForManagementLayer: false
       # Properties for the service, which can be used by the deployment.
       properties:
@@ -132,7 +178,10 @@ flavors:
     isServiceInterrupted: true
   isDowngradeAllowed: true
 serviceProviderContactDetails:
-  emails: [ "test@test.com" ]
+  emails: [ "test30@test.com","test31@test.com" ]
+  phones: [ "011-13422222222","022-13344444444" ]
+  chats: [ "test1234","test1235" ]
+  websites: [ "https://hw.com","https://hwcloud.com" ]
 deployment:
   # kind, Supported values are terraform, opentofu.
   kind: terraform

--- a/modules/deployment/src/test/resources/ocl_terraform_test.yml
+++ b/modules/deployment/src/test/resources/ocl_terraform_test.yml
@@ -20,6 +20,10 @@ cloudServiceProvider:
       area: Asia China
     - name: cn-north-4
       area: Asia China
+    - name: eu-west-0
+      area: Europe Pairs
+    - name: eu-west-101
+      area: Europe Dublin
 billing:
   # The supported mode of billing (`Fixed`, `Pay per Use`)
   billingModes:
@@ -58,19 +62,40 @@ flavors:
                 resource_spec: 19_bgp
                 resource_size: 5
                 size_measure_id: 15
-          licensePrice:
-            cost: 0.80
-            currency: CNY
-            period: hourly
-          markUpPrice:
-            cost: 0.72
-            currency: CNY
-            period: hourly
+          licensePrices:
+            - region: any
+              price:
+                cost: 0.50
+                currency: CNY
+                period: hourly
+            - region: eu-west-101
+              price:
+                cost: 0.0015
+                currency: USD
+                period: hourly
+          markUpPrices:
+            - region: any
+              price:
+                cost: 0.50
+                currency: CNY
+                period: hourly
+            - region: eu-west-101
+              price:
+                cost: 0.0015
+                currency: USD
+                period: hourly
         # Used to calculate charges when users do not select 'pay_per_use' as the billing mode.
-        fixedPrice:
-          cost: 300
-          currency: CNY
-          period: monthly
+        fixedPrices:
+          - region: any
+            price:
+              cost: 172
+              currency: CNY
+              period: monthly
+          - region: eu-west-101
+            price:
+              cost: 20.00
+              currency: USD
+              period: monthly
         isPriceOnlyForManagementLayer: false
       # Properties for the service, which can be used by the deployment.
       properties:
@@ -107,19 +132,40 @@ flavors:
                 resource_spec: 19_bgp
                 resource_size: 5
                 size_measure_id: 15
-          licensePrice:
-            cost: 1.21
-            currency: CNY
-            period: hourly
-          markUpPrice:
-            cost: 1.10
-            currency: CNY
-            period: hourly
+          licensePrices:
+            - region: any
+              price:
+                cost: 0.50
+                currency: CNY
+                period: hourly
+            - region: eu-west-101
+              price:
+                cost: 0.0015
+                currency: USD
+                period: hourly
+          markUpPrices:
+            - region: any
+              price:
+                cost: 0.50
+                currency: CNY
+                period: hourly
+            - region: eu-west-101
+              price:
+                cost: 0.0015
+                currency: USD
+                period: hourly
         # Used to calculate charges when users do not select 'pay_per_use' as the billing mode.
-        fixedPrice:
-          cost: 360
-          currency: CNY
-          period: monthly
+        fixedPrices:
+          - region: any
+            price:
+              cost: 360
+              currency: CNY
+              period: monthly
+          - region: eu-west-101
+            price:
+              cost: 35.00
+              currency: USD
+              period: monthly
         isPriceOnlyForManagementLayer: false
       # Properties for the service, which can be used by the deployment.
       properties:
@@ -132,7 +178,10 @@ flavors:
     isServiceInterrupted: true
   isDowngradeAllowed: true
 serviceProviderContactDetails:
-  emails: [ "test@test.com" ]
+  emails: [ "test30@test.com","test31@test.com" ]
+  phones: [ "011-13422222222","022-13344444444" ]
+  chats: [ "test1234","test1235" ]
+  websites: [ "https://hw.com","https://hwcloud.com" ]
 deployment:
   # kind, Supported values are terraform, opentofu.
   kind: terraform

--- a/modules/models/src/main/java/org/eclipse/xpanse/modules/models/billing/PriceWithRegion.java
+++ b/modules/models/src/main/java/org/eclipse/xpanse/modules/models/billing/PriceWithRegion.java
@@ -1,0 +1,37 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * SPDX-FileCopyrightText: Huawei Inc.
+ */
+
+package org.eclipse.xpanse.modules.models.billing;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import java.io.Serial;
+import java.io.Serializable;
+import lombok.Data;
+
+/**
+ * Defines the price data model with specific region.
+ */
+@Data
+public class PriceWithRegion implements Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 4470758346696951771L;
+
+    @NotNull
+    @NotEmpty
+    @NotBlank
+    @Schema(description = "The defined region. If the special name 'any' provided, "
+            + "this price for all unknown regions.")
+    private String region;
+
+    @NotNull
+    @Schema(description = "The price for the defined region.")
+    private Price price;
+
+
+}

--- a/modules/models/src/main/java/org/eclipse/xpanse/modules/models/billing/RatingMode.java
+++ b/modules/models/src/main/java/org/eclipse/xpanse/modules/models/billing/RatingMode.java
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import java.io.Serial;
 import java.io.Serializable;
+import java.util.List;
 import lombok.Data;
 
 /**
@@ -20,9 +21,9 @@ public class RatingMode implements Serializable {
     @Serial
     private static final long serialVersionUID = 240913796673011260L;
 
-    @Schema(description = "The fixed price of the flavor in the managed service. This price "
-            + "includes all prices and this is the price shown to the customer..")
-    private Price fixedPrice;
+    @Schema(description = "The fixed prices of the flavor in the managed service for regions. "
+            + "The fixed price of the region includes all prices and shown to the customer.")
+    private List<PriceWithRegion> fixedPrices;
 
     @Schema(description = "The resource usage of the flavor in the managed service.")
     private ResourceUsage resourceUsage;

--- a/modules/models/src/main/java/org/eclipse/xpanse/modules/models/billing/ResourceUsage.java
+++ b/modules/models/src/main/java/org/eclipse/xpanse/modules/models/billing/ResourceUsage.java
@@ -27,9 +27,9 @@ public class ResourceUsage implements Serializable {
     @Schema(description = "The resources of the flavor of the manged service.")
     private List<Resource> resources;
 
-    @Schema(description = "The license price of the flavor of the manged service.")
-    private Price licensePrice;
+    @Schema(description = "The license prices of the flavor of the manged service.")
+    private List<PriceWithRegion> licensePrices;
 
-    @Schema(description = "The listed price of the flavor of the manged service.")
-    private Price markUpPrice;
+    @Schema(description = "The listed price list of the flavor of the manged service.")
+    private List<PriceWithRegion> markUpPrices;
 }

--- a/modules/models/src/main/java/org/eclipse/xpanse/modules/models/billing/utils/BillingCommonUtils.java
+++ b/modules/models/src/main/java/org/eclipse/xpanse/modules/models/billing/utils/BillingCommonUtils.java
@@ -1,0 +1,47 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * SPDX-FileCopyrightText: Huawei Inc.
+ */
+
+package org.eclipse.xpanse.modules.models.billing.utils;
+
+import java.util.List;
+import java.util.Optional;
+import org.apache.commons.lang3.StringUtils;
+import org.eclipse.xpanse.modules.models.billing.Price;
+import org.eclipse.xpanse.modules.models.billing.PriceWithRegion;
+import org.springframework.util.CollectionUtils;
+
+/**
+ * Defines common methods for service billing.
+ */
+public class BillingCommonUtils {
+
+    public static final String REGION_ANY = "any";
+
+
+    /**
+     * Get the specific price by region.
+     *
+     * @param prices price list
+     * @param region region
+     * @return the specific price.
+     */
+    public static Price getSpecificPriceByRegion(List<PriceWithRegion> prices, String region) {
+        if (CollectionUtils.isEmpty(prices) || StringUtils.isBlank(region)) {
+            return null;
+        }
+        // Find the specific price by region
+        Optional<PriceWithRegion> specificPrice = prices.stream()
+                .filter(price -> price.getRegion().equalsIgnoreCase(region))
+                .findFirst();
+        if (specificPrice.isPresent()) {
+            return specificPrice.get().getPrice();
+        }
+        // When the specific price is not found, return the price for the 'any' region or null.
+        Optional<PriceWithRegion> anyPrice = prices.stream()
+                .filter(price -> price.getRegion().equalsIgnoreCase(REGION_ANY))
+                .findFirst();
+        return anyPrice.map(PriceWithRegion::getPrice).orElse(null);
+    }
+}

--- a/modules/models/src/main/java/org/eclipse/xpanse/modules/models/servicetemplate/validators/BillingConfigValidator.java
+++ b/modules/models/src/main/java/org/eclipse/xpanse/modules/models/servicetemplate/validators/BillingConfigValidator.java
@@ -6,12 +6,15 @@
 package org.eclipse.xpanse.modules.models.servicetemplate.validators;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
+import org.eclipse.xpanse.modules.models.billing.PriceWithRegion;
+import org.eclipse.xpanse.modules.models.billing.ResourceUsage;
 import org.eclipse.xpanse.modules.models.billing.enums.BillingMode;
 import org.eclipse.xpanse.modules.models.servicetemplate.Ocl;
 import org.eclipse.xpanse.modules.models.servicetemplate.ServiceFlavor;
@@ -27,7 +30,6 @@ import org.springframework.util.CollectionUtils;
 @Component
 public class BillingConfigValidator {
 
-
     /**
      * Validate service flavors.
      *
@@ -35,25 +37,78 @@ public class BillingConfigValidator {
      */
     public void validateServiceFlavors(Ocl ocl) {
         List<String> errors = new ArrayList<>();
-        List<ServiceFlavorWithPrice> serviceFlavors = ocl.getFlavors().getServiceFlavors();
-        Map<String, Long> nameCountMap = serviceFlavors.stream()
-                .collect(Collectors.groupingBy(ServiceFlavor::getName, Collectors.counting()));
-        nameCountMap.entrySet().stream().filter(entry -> entry.getValue() > 1).forEach(entry -> {
-            String message =
-                    String.format("Service flavor with name %s is duplicated.", entry.getKey());
-            log.error(message);
-            errors.add(message);
-        });
-        List<BillingMode> billingModes = ocl.getBilling().getBillingModes();
 
+        // Check if service flavor names are unique
+        Map<String, Long> nameCountMap = ocl.getFlavors().getServiceFlavors().stream()
+                .collect(Collectors.groupingBy(ServiceFlavor::getName, Collectors.counting()));
+        nameCountMap.entrySet().stream().filter(entry -> entry.getValue() > 1)
+                .forEach(entry -> {
+                    String message = String.format("Service flavor with name %s is duplicated.",
+                            entry.getKey());
+                    log.error(message);
+                    errors.add(message);
+                });
+
+        List<String> billingErrors = validateServiceBillingErrors(ocl);
+        if (!CollectionUtils.isEmpty(billingErrors)) {
+            errors.addAll(billingErrors);
+        }
+
+        if (!CollectionUtils.isEmpty(errors)) {
+            throw new InvalidServiceFlavorsException(errors);
+        }
+    }
+
+
+    private List<String> validateServiceBillingErrors(Ocl ocl) {
+        List<String> errors = new ArrayList<>();
+        List<ServiceFlavorWithPrice> serviceFlavors = ocl.getFlavors().getServiceFlavors();
+        List<BillingMode> billingModes = ocl.getBilling().getBillingModes();
         boolean isSupportedPayPerUse = billingModes.contains(BillingMode.PAY_PER_USE);
         boolean isSupportedFixed = billingModes.contains(BillingMode.FIXED);
         if (isSupportedPayPerUse) {
-            Set<String> missingResourceUsageFlavorNames =
-                    serviceFlavors.stream().filter(serviceFlavor ->
-                                    Objects.isNull(serviceFlavor.getPricing().getResourceUsage()))
-                            .map(ServiceFlavorWithPrice::getName).collect(Collectors.toSet());
-            missingResourceUsageFlavorNames.forEach(flavorName -> {
+            // Check if resourceUsage is defined for each flavor supporting pay-per-use
+            Set<String> flavorNamesUnsupportedPayPerUse = new HashSet<>();
+            for (ServiceFlavorWithPrice serviceFlavor : serviceFlavors) {
+                String flavorName = serviceFlavor.getName();
+                ResourceUsage resourceUsage = serviceFlavor.getPricing().getResourceUsage();
+                if (Objects.isNull(resourceUsage)) {
+                    flavorNamesUnsupportedPayPerUse.add(flavorName);
+                } else {
+                    if (!CollectionUtils.isEmpty(resourceUsage.getMarkUpPrices())) {
+                        // Check if there are duplicated regions in markUpPrices
+                        Map<String, Long> regionPricesCountMap = resourceUsage.getMarkUpPrices()
+                                .stream().collect(Collectors.groupingBy(
+                                        PriceWithRegion::getRegion, Collectors.counting()));
+                        regionPricesCountMap.entrySet().stream()
+                                .filter(entry -> entry.getValue() > 1)
+                                .forEach(entry -> {
+                                    String message = String.format(
+                                            "Duplicated region %s in markUpPrices for flavor %s.",
+                                            entry.getKey(), flavorName);
+                                    log.error(message);
+                                    errors.add(message);
+                                });
+                    }
+
+                    if (!CollectionUtils.isEmpty(resourceUsage.getLicensePrices())) {
+                        // Check if there are duplicated regions in licensePrices
+                        Map<String, Long> regionPricesCountMap = resourceUsage.getLicensePrices()
+                                .stream().collect(Collectors.groupingBy(
+                                        PriceWithRegion::getRegion, Collectors.counting()));
+                        regionPricesCountMap.entrySet().stream()
+                                .filter(entry -> entry.getValue() > 1)
+                                .forEach(entry -> {
+                                    String message = String.format(
+                                            "Duplicated region %s in licensePrices for flavor %s.",
+                                            entry.getKey(), flavorName);
+                                    log.error(message);
+                                    errors.add(message);
+                                });
+                    }
+                }
+            }
+            flavorNamesUnsupportedPayPerUse.forEach(flavorName -> {
                 String message = String.format("Service flavor %s has no 'resourceUsage' "
                                 + "defined in 'pricing' for the billing mode 'pay-per-use'.",
                         flavorName);
@@ -62,20 +117,37 @@ public class BillingConfigValidator {
             });
         }
         if (isSupportedFixed) {
-            Set<String> missingFixedPriceFlavorNames =
-                    serviceFlavors.stream().filter(serviceFlavor ->
-                                    Objects.isNull(serviceFlavor.getPricing().getFixedPrice()))
-                            .map(ServiceFlavorWithPrice::getName).collect(Collectors.toSet());
-            missingFixedPriceFlavorNames.forEach(flavorName -> {
-                String message = String.format("Service flavor %s has no 'fixedPrice' "
+            // Check if fixedPrices is defined for each flavor supporting fixed
+            Set<String> flavorNamesUnsupportedFixed = new HashSet<>();
+            for (ServiceFlavorWithPrice serviceFlavor : serviceFlavors) {
+                String flavorName = serviceFlavor.getName();
+                List<PriceWithRegion> fixedPrices = serviceFlavor.getPricing().getFixedPrices();
+                if (CollectionUtils.isEmpty(fixedPrices)) {
+                    flavorNamesUnsupportedFixed.add(flavorName);
+                } else {
+                    // Check if there are duplicated regions in fixedPrices
+                    Map<String, Long> regionPricesCountMap =
+                            fixedPrices.stream().collect(Collectors.groupingBy(
+                                    PriceWithRegion::getRegion, Collectors.counting()));
+                    regionPricesCountMap.entrySet().stream()
+                            .filter(entry -> entry.getValue() > 1)
+                            .forEach(entry -> {
+                                String message = String.format(
+                                        "Duplicated region %s in fixedPrices for flavor %s.",
+                                        entry.getKey(), flavorName);
+                                log.error(message);
+                                errors.add(message);
+                            });
+                }
+            }
+            flavorNamesUnsupportedFixed.forEach(flavorName -> {
+                String message = String.format("Service flavor %s has no 'fixedPrices' "
                                 + "defined in 'pricing' for the billing mode 'fixed'.",
                         flavorName);
                 log.error(message);
                 errors.add(message);
             });
         }
-        if (!CollectionUtils.isEmpty(errors)) {
-            throw new InvalidServiceFlavorsException(errors);
-        }
+        return errors;
     }
 }

--- a/modules/models/src/test/java/org/eclipse/xpanse/modules/models/billing/PriceWithRegionTest.java
+++ b/modules/models/src/test/java/org/eclipse/xpanse/modules/models/billing/PriceWithRegionTest.java
@@ -1,0 +1,57 @@
+package org.eclipse.xpanse.modules.models.billing;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.springframework.beans.BeanUtils;
+
+class PriceWithRegionTest {
+
+    private final String region = "any";
+
+    @Mock
+    private Price mockPrice;
+
+    private PriceWithRegion test;
+
+    @BeforeEach
+    void setUp() {
+        test = new PriceWithRegion();
+        test.setPrice(mockPrice);
+        test.setRegion(region);
+    }
+
+    @Test
+    void testGetters() {
+        assertThat(test.getPrice()).isEqualTo(mockPrice);
+        assertThat(test.getRegion()).isEqualTo(region);
+    }
+
+
+    @Test
+    void testEqualsAndHashCode() {
+        Object o = new Object();
+        assertThat(test.equals(o)).isFalse();
+        assertThat(test.canEqual(o)).isFalse();
+        assertThat(test.hashCode()).isNotEqualTo(o.hashCode());
+
+        PriceWithRegion test1 = new PriceWithRegion();
+        assertThat(test.equals(test1)).isFalse();
+        assertThat(test.canEqual(test1)).isTrue();
+        assertThat(test.hashCode()).isNotEqualTo(test1.hashCode());
+
+        BeanUtils.copyProperties(test, test1);
+        assertThat(test.equals(test1)).isTrue();
+        assertThat(test.canEqual(test1)).isTrue();
+        assertThat(test.hashCode()).isEqualTo(test1.hashCode());
+    }
+
+
+    @Test
+    void testToString() {
+        String result = "PriceWithRegion(region=" + region + ", price=" + mockPrice + ")";
+        assertThat(test.toString()).isEqualTo(result);
+    }
+}

--- a/modules/models/src/test/java/org/eclipse/xpanse/modules/models/billing/RatingModeTest.java
+++ b/modules/models/src/test/java/org/eclipse/xpanse/modules/models/billing/RatingModeTest.java
@@ -2,6 +2,7 @@ package org.eclipse.xpanse.modules.models.billing;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -16,21 +17,21 @@ class RatingModeTest {
     @Mock
     private ResourceUsage mockResourceUsage;
     @Mock
-    private Price mockFixedPrice;
+    private List<PriceWithRegion> mockFixedPrices;
     private RatingMode ratingModeUnderTest;
 
     @BeforeEach
     void setUp() {
         ratingModeUnderTest = new RatingMode();
         ratingModeUnderTest.setResourceUsage(mockResourceUsage);
-        ratingModeUnderTest.setFixedPrice(mockFixedPrice);
+        ratingModeUnderTest.setFixedPrices(mockFixedPrices);
         ratingModeUnderTest.setIsPriceOnlyForManagementLayer(isPriceOnlyForManagementLayer);
     }
 
     @Test
     void testGetters() {
         assertThat(ratingModeUnderTest.getResourceUsage()).isEqualTo(mockResourceUsage);
-        assertThat(ratingModeUnderTest.getFixedPrice()).isEqualTo(mockFixedPrice);
+        assertThat(ratingModeUnderTest.getFixedPrices()).isEqualTo(mockFixedPrices);
         assertThat(ratingModeUnderTest.getIsPriceOnlyForManagementLayer()).isTrue();
     }
 
@@ -57,7 +58,7 @@ class RatingModeTest {
     @Test
     void testToString() {
         String result =
-                "RatingMode(fixedPrice=" + mockFixedPrice + ", resourceUsage=" + mockResourceUsage
+                "RatingMode(fixedPrices=" + mockFixedPrices + ", resourceUsage=" + mockResourceUsage
                         + ", isPriceOnlyForManagementLayer=" + isPriceOnlyForManagementLayer + ")";
         assertThat(ratingModeUnderTest.toString()).isEqualTo(result);
     }

--- a/modules/models/src/test/java/org/eclipse/xpanse/modules/models/billing/ResourceUsageTest.java
+++ b/modules/models/src/test/java/org/eclipse/xpanse/modules/models/billing/ResourceUsageTest.java
@@ -14,9 +14,9 @@ import org.springframework.beans.BeanUtils;
 class ResourceUsageTest {
 
     @Mock
-    private Price mockLicensePrice;
+    private List<PriceWithRegion> mockLicensePrices;
     @Mock
-    private Price mockMarkUpPrice;
+    private List<PriceWithRegion> mockMarkUpPrices;
     @Mock
     private List<Resource> mockResources;
 
@@ -25,15 +25,15 @@ class ResourceUsageTest {
     @BeforeEach
     void setUp() {
         resourceUsageUnderTest = new ResourceUsage();
-        resourceUsageUnderTest.setLicensePrice(mockLicensePrice);
-        resourceUsageUnderTest.setMarkUpPrice(mockMarkUpPrice);
+        resourceUsageUnderTest.setLicensePrices(mockLicensePrices);
+        resourceUsageUnderTest.setMarkUpPrices(mockMarkUpPrices);
         resourceUsageUnderTest.setResources(mockResources);
     }
 
     @Test
-    void testGetLicensePrice() {
-        assertThat(resourceUsageUnderTest.getLicensePrice()).isEqualTo(mockLicensePrice);
-        assertThat(resourceUsageUnderTest.getMarkUpPrice()).isEqualTo(mockMarkUpPrice);
+    void testGetters() {
+        assertThat(resourceUsageUnderTest.getLicensePrices()).isEqualTo(mockLicensePrices);
+        assertThat(resourceUsageUnderTest.getMarkUpPrices()).isEqualTo(mockMarkUpPrices);
         assertThat(resourceUsageUnderTest.getResources()).isEqualTo(mockResources);
     }
 
@@ -58,8 +58,8 @@ class ResourceUsageTest {
     void testToString() {
         String result = "ResourceUsage("
                 + "resources=" + mockResources
-                + ", licensePrice=" + mockLicensePrice
-                + ", markUpPrice=" + mockMarkUpPrice
+                + ", licensePrices=" + mockLicensePrices
+                + ", markUpPrices=" + mockMarkUpPrices
                 + ")";
         assertThat(resourceUsageUnderTest.toString()).isEqualTo(result);
     }

--- a/modules/models/src/test/resources/ocl_terraform_test.yml
+++ b/modules/models/src/test/resources/ocl_terraform_test.yml
@@ -20,6 +20,10 @@ cloudServiceProvider:
       area: Asia China
     - name: cn-north-4
       area: Asia China
+    - name: eu-west-0
+      area: Europe Pairs
+    - name: eu-west-101
+      area: Europe Dublin
 billing:
   # The supported mode of billing (`Fixed`, `Pay per Use`)
   billingModes:
@@ -58,19 +62,40 @@ flavors:
                 resource_spec: 19_bgp
                 resource_size: 5
                 size_measure_id: 15
-          licensePrice:
-            cost: 0.80
-            currency: CNY
-            period: hourly
-          markUpPrice:
-            cost: 0.72
-            currency: CNY
-            period: hourly
+          licensePrices:
+            - region: any
+              price:
+                cost: 0.50
+                currency: CNY
+                period: hourly
+            - region: eu-west-101
+              price:
+                cost: 0.0015
+                currency: USD
+                period: hourly
+          markUpPrices:
+            - region: any
+              price:
+                cost: 0.50
+                currency: CNY
+                period: hourly
+            - region: eu-west-101
+              price:
+                cost: 0.0015
+                currency: USD
+                period: hourly
         # Used to calculate charges when users do not select 'pay_per_use' as the billing mode.
-        fixedPrice:
-          cost: 300
-          currency: CNY
-          period: monthly
+        fixedPrices:
+          - region: any
+            price:
+              cost: 172
+              currency: CNY
+              period: monthly
+          - region: eu-west-101
+            price:
+              cost: 20.00
+              currency: USD
+              period: monthly
         isPriceOnlyForManagementLayer: false
       # Properties for the service, which can be used by the deployment.
       properties:
@@ -107,19 +132,40 @@ flavors:
                 resource_spec: 19_bgp
                 resource_size: 5
                 size_measure_id: 15
-          licensePrice:
-            cost: 1.21
-            currency: CNY
-            period: hourly
-          markUpPrice:
-            cost: 1.10
-            currency: CNY
-            period: hourly
+          licensePrices:
+            - region: any
+              price:
+                cost: 0.50
+                currency: CNY
+                period: hourly
+            - region: eu-west-101
+              price:
+                cost: 0.0015
+                currency: USD
+                period: hourly
+          markUpPrices:
+            - region: any
+              price:
+                cost: 0.50
+                currency: CNY
+                period: hourly
+            - region: eu-west-101
+              price:
+                cost: 0.0015
+                currency: USD
+                period: hourly
         # Used to calculate charges when users do not select 'pay_per_use' as the billing mode.
-        fixedPrice:
-          cost: 360
-          currency: CNY
-          period: monthly
+        fixedPrices:
+          - region: any
+            price:
+              cost: 360
+              currency: CNY
+              period: monthly
+          - region: eu-west-101
+            price:
+              cost: 35.00
+              currency: USD
+              period: monthly
         isPriceOnlyForManagementLayer: false
       # Properties for the service, which can be used by the deployment.
       properties:
@@ -132,7 +178,10 @@ flavors:
     isServiceInterrupted: true
   isDowngradeAllowed: true
 serviceProviderContactDetails:
-  emails: [ "test@test.com" ]
+  emails: [ "test30@test.com","test31@test.com" ]
+  phones: [ "011-13422222222","022-13344444444" ]
+  chats: [ "test1234","test1235" ]
+  websites: [ "https://hw.com","https://hwcloud.com" ]
 deployment:
   # kind, Supported values are terraform, opentofu.
   kind: terraform

--- a/modules/servicetemplate/src/main/java/org/eclipse/xpanse/modules/servicetemplate/price/ServicePricesManager.java
+++ b/modules/servicetemplate/src/main/java/org/eclipse/xpanse/modules/servicetemplate/price/ServicePricesManager.java
@@ -16,7 +16,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.eclipse.xpanse.modules.database.servicetemplate.DatabaseServiceTemplateStorage;
 import org.eclipse.xpanse.modules.database.servicetemplate.ServiceTemplateEntity;
 import org.eclipse.xpanse.modules.models.billing.FlavorPriceResult;
-import org.eclipse.xpanse.modules.models.billing.Price;
+import org.eclipse.xpanse.modules.models.billing.PriceWithRegion;
 import org.eclipse.xpanse.modules.models.billing.RatingMode;
 import org.eclipse.xpanse.modules.models.billing.ResourceUsage;
 import org.eclipse.xpanse.modules.models.billing.enums.BillingMode;
@@ -29,6 +29,7 @@ import org.eclipse.xpanse.modules.orchestrator.PluginManager;
 import org.eclipse.xpanse.modules.orchestrator.price.ServiceFlavorPriceRequest;
 import org.eclipse.xpanse.modules.security.UserServiceHelper;
 import org.springframework.stereotype.Service;
+import org.springframework.util.CollectionUtils;
 
 /**
  * Implement Interface to manage service prices.
@@ -173,11 +174,11 @@ public class ServicePricesManager {
                     + "the 'ResourceUsage' is null.";
             throw new ServicePriceCalculationFailed(errorMsg);
         }
-        Price fixedPrice = flavorPriceMode.getFixedPrice();
-        if (BillingMode.FIXED.equals(billingMode) && Objects.isNull(fixedPrice)) {
+        List<PriceWithRegion> fixedPrices = flavorPriceMode.getFixedPrices();
+        if (BillingMode.FIXED.equals(billingMode) && CollectionUtils.isEmpty(fixedPrices)) {
 
             String errorMsg = "BillingMode 'Fixed' can not be supported due to "
-                    + "the 'FixedPrice' is null.";
+                    + "the 'FixedPrices' is null.";
             throw new ServicePriceCalculationFailed(errorMsg);
         }
     }

--- a/modules/servicetemplate/src/test/resources/ocl_terraform_test.yml
+++ b/modules/servicetemplate/src/test/resources/ocl_terraform_test.yml
@@ -20,6 +20,10 @@ cloudServiceProvider:
       area: Asia China
     - name: cn-north-4
       area: Asia China
+    - name: eu-west-0
+      area: Europe Pairs
+    - name: eu-west-101
+      area: Europe Dublin
 billing:
   # The supported mode of billing (`Fixed`, `Pay per Use`)
   billingModes:
@@ -58,19 +62,40 @@ flavors:
                 resource_spec: 19_bgp
                 resource_size: 5
                 size_measure_id: 15
-          licensePrice:
-            cost: 0.80
-            currency: CNY
-            period: hourly
-          markUpPrice:
-            cost: 0.72
-            currency: CNY
-            period: hourly
+          licensePrices:
+            - region: any
+              price:
+                cost: 0.50
+                currency: CNY
+                period: hourly
+            - region: eu-west-101
+              price:
+                cost: 0.0015
+                currency: USD
+                period: hourly
+          markUpPrices:
+            - region: any
+              price:
+                cost: 0.50
+                currency: CNY
+                period: hourly
+            - region: eu-west-101
+              price:
+                cost: 0.0015
+                currency: USD
+                period: hourly
         # Used to calculate charges when users do not select 'pay_per_use' as the billing mode.
-        fixedPrice:
-          cost: 300
-          currency: CNY
-          period: monthly
+        fixedPrices:
+          - region: any
+            price:
+              cost: 172
+              currency: CNY
+              period: monthly
+          - region: eu-west-101
+            price:
+              cost: 20.00
+              currency: USD
+              period: monthly
         isPriceOnlyForManagementLayer: false
       # Properties for the service, which can be used by the deployment.
       properties:
@@ -107,19 +132,40 @@ flavors:
                 resource_spec: 19_bgp
                 resource_size: 5
                 size_measure_id: 15
-          licensePrice:
-            cost: 1.21
-            currency: CNY
-            period: hourly
-          markUpPrice:
-            cost: 1.10
-            currency: CNY
-            period: hourly
+          licensePrices:
+            - region: any
+              price:
+                cost: 0.50
+                currency: CNY
+                period: hourly
+            - region: eu-west-101
+              price:
+                cost: 0.0015
+                currency: USD
+                period: hourly
+          markUpPrices:
+            - region: any
+              price:
+                cost: 0.50
+                currency: CNY
+                period: hourly
+            - region: eu-west-101
+              price:
+                cost: 0.0015
+                currency: USD
+                period: hourly
         # Used to calculate charges when users do not select 'pay_per_use' as the billing mode.
-        fixedPrice:
-          cost: 360
-          currency: CNY
-          period: monthly
+        fixedPrices:
+          - region: any
+            price:
+              cost: 360
+              currency: CNY
+              period: monthly
+          - region: eu-west-101
+            price:
+              cost: 35.00
+              currency: USD
+              period: monthly
         isPriceOnlyForManagementLayer: false
       # Properties for the service, which can be used by the deployment.
       properties:
@@ -132,7 +178,10 @@ flavors:
     isServiceInterrupted: true
   isDowngradeAllowed: true
 serviceProviderContactDetails:
-  emails: [ "test@test.com" ]
+  emails: [ "test30@test.com","test31@test.com" ]
+  phones: [ "011-13422222222","022-13344444444" ]
+  chats: [ "test1234","test1235" ]
+  websites: [ "https://hw.com","https://hwcloud.com" ]
 deployment:
   # kind, Supported values are terraform, opentofu.
   kind: terraform

--- a/plugins/flexibleengine/src/main/java/org/eclipse/xpanse/plugins/flexibleengine/price/FlexibleEnginePriceCalculator.java
+++ b/plugins/flexibleengine/src/main/java/org/eclipse/xpanse/plugins/flexibleengine/price/FlexibleEnginePriceCalculator.java
@@ -15,6 +15,7 @@ import org.eclipse.xpanse.modules.models.billing.Price;
 import org.eclipse.xpanse.modules.models.billing.ResourceUsage;
 import org.eclipse.xpanse.modules.models.billing.enums.BillingMode;
 import org.eclipse.xpanse.modules.models.billing.enums.PricingPeriod;
+import org.eclipse.xpanse.modules.models.billing.utils.BillingCommonUtils;
 import org.eclipse.xpanse.modules.orchestrator.price.ServiceFlavorPriceRequest;
 import org.springframework.stereotype.Component;
 
@@ -52,10 +53,12 @@ public class FlexibleEnginePriceCalculator {
         // TODO Get recurring price with resource usage in future.
 
         // Add markup price if not null
-        Price markUpPrice = resourceUsage.getMarkUpPrice();
+        Price markUpPrice = BillingCommonUtils.getSpecificPriceByRegion(
+                resourceUsage.getMarkUpPrices(), request.getRegionName());
         addExtraPaymentPrice(flavorPriceResult, markUpPrice);
         // Add license price if not null
-        Price licensePrice = resourceUsage.getLicensePrice();
+        Price licensePrice = BillingCommonUtils.getSpecificPriceByRegion(
+                resourceUsage.getLicensePrices(), request.getRegionName());
         addExtraPaymentPrice(flavorPriceResult, licensePrice);
         return flavorPriceResult;
     }
@@ -105,7 +108,8 @@ public class FlexibleEnginePriceCalculator {
     }
 
     private FlavorPriceResult getServiceFlavorPriceWithFixed(ServiceFlavorPriceRequest request) {
-        Price fixedPrice = request.getFlavorRatingMode().getFixedPrice();
+        Price fixedPrice = BillingCommonUtils.getSpecificPriceByRegion(
+                request.getFlavorRatingMode().getFixedPrices(), request.getRegionName());
         FlavorPriceResult flavorPriceResult = new FlavorPriceResult();
         flavorPriceResult.setRecurringPrice(fixedPrice);
         return flavorPriceResult;

--- a/plugins/huaweicloud/src/main/java/org/eclipse/xpanse/plugins/huaweicloud/price/HuaweiCloudPriceCalculator.java
+++ b/plugins/huaweicloud/src/main/java/org/eclipse/xpanse/plugins/huaweicloud/price/HuaweiCloudPriceCalculator.java
@@ -21,6 +21,7 @@ import org.eclipse.xpanse.modules.models.billing.Price;
 import org.eclipse.xpanse.modules.models.billing.ResourceUsage;
 import org.eclipse.xpanse.modules.models.billing.enums.BillingMode;
 import org.eclipse.xpanse.modules.models.billing.enums.PricingPeriod;
+import org.eclipse.xpanse.modules.models.billing.utils.BillingCommonUtils;
 import org.eclipse.xpanse.modules.models.common.enums.Csp;
 import org.eclipse.xpanse.modules.models.common.exceptions.ClientApiCallFailedException;
 import org.eclipse.xpanse.modules.models.credential.AbstractCredentialInfo;
@@ -98,10 +99,12 @@ public class HuaweiCloudPriceCalculator {
         FlavorPriceResult flavorPriceResult = new FlavorPriceResult();
         flavorPriceResult.setRecurringPrice(recurringPrice);
         // Add markup price if not null
-        Price markUpPrice = resourceUsage.getMarkUpPrice();
+        Price markUpPrice = BillingCommonUtils.getSpecificPriceByRegion(
+                resourceUsage.getMarkUpPrices(), request.getRegionName());
         addExtraPaymentPrice(flavorPriceResult, markUpPrice);
         // Add license price if not null
-        Price licensePrice = resourceUsage.getLicensePrice();
+        Price licensePrice = BillingCommonUtils.getSpecificPriceByRegion(
+                resourceUsage.getLicensePrices(), request.getRegionName());
         addExtraPaymentPrice(flavorPriceResult, licensePrice);
         return flavorPriceResult;
     }
@@ -192,7 +195,8 @@ public class HuaweiCloudPriceCalculator {
     }
 
     private FlavorPriceResult getServiceFlavorPriceWithFixed(ServiceFlavorPriceRequest request) {
-        Price fixedPrice = request.getFlavorRatingMode().getFixedPrice();
+        Price fixedPrice = BillingCommonUtils.getSpecificPriceByRegion(
+                request.getFlavorRatingMode().getFixedPrices(), request.getRegionName());
         FlavorPriceResult flavorPriceResult = new FlavorPriceResult();
         flavorPriceResult.setRecurringPrice(fixedPrice);
         return flavorPriceResult;

--- a/plugins/openstack-common/src/main/java/org/eclipse/xpanse/plugins/openstack/common/price/OpenstackServicePriceCalculator.java
+++ b/plugins/openstack-common/src/main/java/org/eclipse/xpanse/plugins/openstack/common/price/OpenstackServicePriceCalculator.java
@@ -15,6 +15,7 @@ import org.eclipse.xpanse.modules.models.billing.Price;
 import org.eclipse.xpanse.modules.models.billing.ResourceUsage;
 import org.eclipse.xpanse.modules.models.billing.enums.BillingMode;
 import org.eclipse.xpanse.modules.models.billing.enums.PricingPeriod;
+import org.eclipse.xpanse.modules.models.billing.utils.BillingCommonUtils;
 import org.eclipse.xpanse.modules.orchestrator.price.ServiceFlavorPriceRequest;
 import org.springframework.stereotype.Component;
 
@@ -51,10 +52,12 @@ public class OpenstackServicePriceCalculator {
         FlavorPriceResult flavorPriceResult = new FlavorPriceResult();
         // TODO Get recurring price with resource usage in future.
         // Add markup price if not null
-        Price markUpPrice = resourceUsage.getMarkUpPrice();
+        Price markUpPrice = BillingCommonUtils.getSpecificPriceByRegion(
+                resourceUsage.getMarkUpPrices(), request.getRegionName());
         addExtraPaymentPrice(flavorPriceResult, markUpPrice);
         // Add license price if not null
-        Price licensePrice = resourceUsage.getLicensePrice();
+        Price licensePrice = BillingCommonUtils.getSpecificPriceByRegion(
+                resourceUsage.getLicensePrices(), request.getRegionName());
         addExtraPaymentPrice(flavorPriceResult, licensePrice);
         return flavorPriceResult;
     }
@@ -104,7 +107,8 @@ public class OpenstackServicePriceCalculator {
     }
 
     private FlavorPriceResult getServiceFlavorPriceWithFixed(ServiceFlavorPriceRequest request) {
-        Price fixedPrice = request.getFlavorRatingMode().getFixedPrice();
+        Price fixedPrice = BillingCommonUtils.getSpecificPriceByRegion(
+                request.getFlavorRatingMode().getFixedPrices(), request.getRegionName());
         FlavorPriceResult flavorPriceResult = new FlavorPriceResult();
         flavorPriceResult.setRecurringPrice(fixedPrice);
         return flavorPriceResult;

--- a/runtime/src/test/resources/ocl_terraform_from_git_test.yml
+++ b/runtime/src/test/resources/ocl_terraform_from_git_test.yml
@@ -20,6 +20,10 @@ cloudServiceProvider:
       area: Asia China
     - name: cn-north-4
       area: Asia China
+    - name: eu-west-0
+      area: Europe Pairs
+    - name: eu-west-101
+      area: Europe Dublin
 billing:
   # The supported mode of billing (`Fixed`, `Pay per Use`)
   billingModes:
@@ -58,19 +62,40 @@ flavors:
                 resource_spec: 19_bgp
                 resource_size: 5
                 size_measure_id: 15
-          licensePrice:
-            cost: 0.80
-            currency: CNY
-            period: hourly
-          markUpPrice:
-            cost: 0.72
-            currency: CNY
-            period: hourly
+          licensePrices:
+            - region: any
+              price:
+                cost: 0.50
+                currency: CNY
+                period: hourly
+            - region: eu-west-101
+              price:
+                cost: 0.0015
+                currency: USD
+                period: hourly
+          markUpPrices:
+            - region: any
+              price:
+                cost: 0.50
+                currency: CNY
+                period: hourly
+            - region: eu-west-101
+              price:
+                cost: 0.0015
+                currency: USD
+                period: hourly
         # Used to calculate charges when users do not select 'pay_per_use' as the billing mode.
-        fixedPrice:
-          cost: 300
-          currency: CNY
-          period: monthly
+        fixedPrices:
+          - region: any
+            price:
+              cost: 172
+              currency: CNY
+              period: monthly
+          - region: eu-west-101
+            price:
+              cost: 20.00
+              currency: USD
+              period: monthly
         isPriceOnlyForManagementLayer: false
       # Properties for the service, which can be used by the deployment.
       properties:
@@ -107,19 +132,40 @@ flavors:
                 resource_spec: 19_bgp
                 resource_size: 5
                 size_measure_id: 15
-          licensePrice:
-            cost: 1.21
-            currency: CNY
-            period: hourly
-          markUpPrice:
-            cost: 1.10
-            currency: CNY
-            period: hourly
+          licensePrices:
+            - region: any
+              price:
+                cost: 0.50
+                currency: CNY
+                period: hourly
+            - region: eu-west-101
+              price:
+                cost: 0.0015
+                currency: USD
+                period: hourly
+          markUpPrices:
+            - region: any
+              price:
+                cost: 0.50
+                currency: CNY
+                period: hourly
+            - region: eu-west-101
+              price:
+                cost: 0.0015
+                currency: USD
+                period: hourly
         # Used to calculate charges when users do not select 'pay_per_use' as the billing mode.
-        fixedPrice:
-          cost: 360
-          currency: CNY
-          period: monthly
+        fixedPrices:
+          - region: any
+            price:
+              cost: 360
+              currency: CNY
+              period: monthly
+          - region: eu-west-101
+            price:
+              cost: 35.00
+              currency: USD
+              period: monthly
         isPriceOnlyForManagementLayer: false
       # Properties for the service, which can be used by the deployment.
       properties:
@@ -132,7 +178,10 @@ flavors:
     isServiceInterrupted: true
   isDowngradeAllowed: true
 serviceProviderContactDetails:
-  emails: [ "test@test.com" ]
+  emails: [ "test30@test.com","test31@test.com" ]
+  phones: [ "011-13422222222","022-13344444444" ]
+  chats: [ "test1234","test1235" ]
+  websites: [ "https://hw.com","https://hwcloud.com" ]
 deployment:
   # kind, Supported values are terraform, opentofu.
   kind: terraform

--- a/runtime/src/test/resources/ocl_terraform_test.yml
+++ b/runtime/src/test/resources/ocl_terraform_test.yml
@@ -20,6 +20,10 @@ cloudServiceProvider:
       area: Asia China
     - name: cn-north-4
       area: Asia China
+    - name: eu-west-0
+      area: Europe Pairs
+    - name: eu-west-101
+      area: Europe Dublin
 billing:
   # The supported mode of billing (`Fixed`, `Pay per Use`)
   billingModes:
@@ -58,19 +62,40 @@ flavors:
                 resource_spec: 19_bgp
                 resource_size: 5
                 size_measure_id: 15
-          licensePrice:
-            cost: 100
-            currency: CNY
-            period: oneTime
-          markUpPrice:
-            cost: 100
-            currency: CNY
-            period: oneTime
+          licensePrices:
+            - region: any
+              price:
+                cost: 0.50
+                currency: CNY
+                period: hourly
+            - region: eu-west-101
+              price:
+                cost: 0.0015
+                currency: USD
+                period: hourly
+          markUpPrices:
+            - region: any
+              price:
+                cost: 0.50
+                currency: CNY
+                period: hourly
+            - region: eu-west-101
+              price:
+                cost: 0.0015
+                currency: USD
+                period: hourly
         # Used to calculate charges when users do not select 'pay_per_use' as the billing mode.
-        fixedPrice:
-          cost: 300
-          currency: CNY
-          period: monthly
+        fixedPrices:
+          - region: any
+            price:
+              cost: 172
+              currency: CNY
+              period: monthly
+          - region: eu-west-101
+            price:
+              cost: 20.00
+              currency: USD
+              period: monthly
         isPriceOnlyForManagementLayer: false
       # Properties for the service, which can be used by the deployment.
       properties:
@@ -107,19 +132,40 @@ flavors:
                 resource_spec: 19_bgp
                 resource_size: 5
                 size_measure_id: 15
-          licensePrice:
-            cost: 1.21
-            currency: CNY
-            period: daily
-          markUpPrice:
-            cost: 1.10
-            currency: CNY
-            period: daily
+          licensePrices:
+            - region: any
+              price:
+                cost: 0.50
+                currency: CNY
+                period: hourly
+            - region: eu-west-101
+              price:
+                cost: 0.0015
+                currency: USD
+                period: hourly
+          markUpPrices:
+            - region: any
+              price:
+                cost: 0.50
+                currency: CNY
+                period: hourly
+            - region: eu-west-101
+              price:
+                cost: 0.0015
+                currency: USD
+                period: hourly
         # Used to calculate charges when users do not select 'pay_per_use' as the billing mode.
-        fixedPrice:
-          cost: 360
-          currency: CNY
-          period: monthly
+        fixedPrices:
+          - region: any
+            price:
+              cost: 360
+              currency: CNY
+              period: monthly
+          - region: eu-west-101
+            price:
+              cost: 35.00
+              currency: USD
+              period: monthly
         isPriceOnlyForManagementLayer: false
       # Properties for the service, which can be used by the deployment.
       properties:

--- a/samples/HuaweiCloud-K8S-autofill.yml
+++ b/samples/HuaweiCloud-K8S-autofill.yml
@@ -3,7 +3,7 @@ version: 1.0
 # The category of the service.
 category: container
 # The Service provided by the ISV, the name will be shown on the console as a service.
-name: K8S-cluster
+name: K8S-cluster-autofill
 # The version of the service, the end-user can select the version they want to deploy.
 serviceVersion: 1.0.0
 # For the users may have more than one service, the @namespace can be used to separate the clusters.
@@ -50,19 +50,25 @@ flavors:
                 resource_spec: SSD
                 resource_size: 40
                 size_measure_id: 17
-          licensePrice:
-            cost: 1.90
-            currency: CNY
-            period: hourly
-          markUpPrice:
-            cost: 1.60
-            currency: CNY
-            period: hourly
+          licensePrices:
+            - region: any
+              price:
+                cost: 1.90
+                currency: CNY
+                period: hourly
+          markUpPrices:
+            - region: any
+              price:
+                cost: 1.90
+                currency: CNY
+                period: hourly
         # Used to calculate charges when users do not select 'pay_per_use' as the billing mode.
-        fixedPrice:
-          cost: 730
-          currency: CNY
-          period: monthly
+        fixedPrices:
+          - region: any
+            price:
+              cost: 730
+              currency: CNY
+              period: monthly
       # Properties for the service, which can be used by the deployment.
       properties:
         worker_nodes_count: 3
@@ -90,20 +96,26 @@ flavors:
                 resource_type: hws.resource.type.volume
                 resource_spec: SSD
                 resource_size: 40
-                size_measure_id: 15
-          licensePrice:
-            cost: 3.20
-            currency: CNY
-            period: hourly
-          markUpPrice:
-            cost: 2.88
-            currency: CNY
-            period: hourly
+                size_measure_id: 17
+          licensePrices:
+            - region: any
+              price:
+                cost: 1.90
+                currency: CNY
+                period: hourly
+          markUpPrices:
+            - region: any
+              price:
+                cost: 1.90
+                currency: CNY
+                period: hourly
         # Used to calculate charges when users do not select 'pay_per_use' as the billing mode.
-        fixedPrice:
-          cost: 980
-          currency: CNY
-          period: monthly
+        fixedPrices:
+          - region: any
+            price:
+              cost: 980
+              currency: CNY
+              period: monthly
       # Properties for the service, which can be used by the deployment.
       properties:
         worker_nodes_count: 3

--- a/samples/HuaweiCloud-K8S.yml
+++ b/samples/HuaweiCloud-K8S.yml
@@ -50,19 +50,25 @@ flavors:
                 resource_spec: SSD
                 resource_size: 40
                 size_measure_id: 17
-          licensePrice:
-            cost: 1.90
-            currency: CNY
-            period: hourly
-          markUpPrice:
-            cost: 1.60
-            currency: CNY
-            period: hourly
+          licensePrices:
+            - region: any
+              price:
+                cost: 1.90
+                currency: CNY
+                period: hourly
+          markUpPrices:
+            - region: any
+              price:
+                cost: 1.90
+                currency: CNY
+                period: hourly
         # Used to calculate charges when users do not select 'pay_per_use' as the billing mode.
-        fixedPrice:
-          cost: 730
-          currency: CNY
-          period: monthly
+        fixedPrices:
+          - region: any
+            price:
+              cost: 730
+              currency: CNY
+              period: monthly
       # Properties for the service, which can be used by the deployment.
       properties:
         worker_nodes_count: 3
@@ -91,19 +97,25 @@ flavors:
                 resource_spec: SSD
                 resource_size: 40
                 size_measure_id: 17
-          licensePrice:
-            cost: 3.20
-            currency: CNY
-            period: hourly
-          markUpPrice:
-            cost: 2.88
-            currency: CNY
-            period: hourly
+          licensePrices:
+            - region: any
+              price:
+                cost: 1.90
+                currency: CNY
+                period: hourly
+          markUpPrices:
+            - region: any
+              price:
+                cost: 1.90
+                currency: CNY
+                period: hourly
         # Used to calculate charges when users do not select 'pay_per_use' as the billing mode.
-        fixedPrice:
-          cost: 980
-          currency: CNY
-          period: monthly
+        fixedPrices:
+          - region: any
+            price:
+              cost: 980
+              currency: CNY
+              period: monthly
       # Properties for the service, which can be used by the deployment.
       properties:
         worker_nodes_count: 3

--- a/samples/HuaweiCloud-Kafka-autofill.yml
+++ b/samples/HuaweiCloud-Kafka-autofill.yml
@@ -3,7 +3,7 @@ version: 1.0
 # The category of the service.
 category: middleware
 # The Service provided by the ISV, the name will be shown on the console as a service.
-name: Kafka-cluster
+name: Kafka-cluster-autofill
 # The version of the service, the end-user can select the version they want to deploy.
 serviceVersion: 1.0.0
 # For the users may have more than one service, the @namespace can be used to separate the clusters.
@@ -30,7 +30,7 @@ serviceHostingType: self
 flavors:
   serviceFlavors:
     - name: 1-zookeeper-with-3-worker-nodes-normal
-      priority: 2
+      priority: 1
       # The pricing of the flavor.
       pricing:
         # Used to calculate charges when users select 'pay_per_use' as the billing mode.
@@ -50,19 +50,25 @@ flavors:
                 resource_spec: SSD
                 resource_size: 40
                 size_measure_id: 17
-          licensePrice:
-            cost: 1.90
-            currency: CNY
-            period: hourly
-          markUpPrice:
-            cost: 1.60
-            currency: CNY
-            period: hourly
+          licensePrices:
+            - region: any
+              price:
+                cost: 1.90
+                currency: CNY
+                period: hourly
+          markUpPrices:
+            - region: any
+              price:
+                cost: 1.90
+                currency: CNY
+                period: hourly
         # Used to calculate charges when users do not select 'pay_per_use' as the billing mode.
-        fixedPrice:
-          cost: 730
-          currency: CNY
-          period: monthly
+        fixedPrices:
+          - region: any
+            price:
+              cost: 730
+              currency: CNY
+              period: monthly
       # Properties for the service, which can be used by the deployment.
       properties:
         worker_nodes_count: 3
@@ -71,7 +77,7 @@ flavors:
         - High Availability
         - Maximum performance
     - name: 1-zookeeper-with-3-worker-nodes-performance
-      priority: 1
+      priority: 2
       # The pricing of the flavor.
       pricing:
         # Used to calculate charges when users select 'pay_per_use' as the billing mode.
@@ -90,20 +96,26 @@ flavors:
                 resource_type: hws.resource.type.volume
                 resource_spec: SSD
                 resource_size: 40
-                size_measure_id: 17
-          licensePrice:
-            cost: 3.20
-            currency: CNY
-            period: hourly
-          markUpPrice:
-            cost: 2.88
-            currency: CNY
-            period: hourly
+                size_measure_id: 15
+          licensePrices:
+            - region: any
+              price:
+                cost: 1.90
+                currency: CNY
+                period: hourly
+          markUpPrices:
+            - region: any
+              price:
+                cost: 1.90
+                currency: CNY
+                period: hourly
         # Used to calculate charges when users do not select 'pay_per_use' as the billing mode.
-        fixedPrice:
-          cost: 980
-          currency: CNY
-          period: monthly
+        fixedPrices:
+          - region: any
+            price:
+              cost: 980
+              currency: CNY
+              period: monthly
       properties:
         worker_nodes_count: 3
         flavor_id: s6.large.4

--- a/samples/HuaweiCloud-Kafka-terraform_module.yml
+++ b/samples/HuaweiCloud-Kafka-terraform_module.yml
@@ -3,7 +3,7 @@ version: 1.0
 # The category of the service.
 category: middleware
 # The Service provided by the ISV, the name will be shown on the console as a service.
-name: Kafka-cluster
+name: Kafka-cluster-tf-module
 # The version of the service, the end-user can select the version they want to deploy.
 serviceVersion: 1.0.0
 # For the users may have more than one service, the @namespace can be used to separate the clusters.
@@ -30,7 +30,7 @@ serviceHostingType: self
 flavors:
   serviceFlavors:
     - name: 1-zookeeper-with-3-worker-nodes-normal
-      priority: 2
+      priority: 1
       # The pricing of the flavor.
       pricing:
         # Used to calculate charges when users select 'pay_per_use' as the billing mode.
@@ -50,19 +50,25 @@ flavors:
                 resource_spec: SSD
                 resource_size: 40
                 size_measure_id: 17
-          licensePrice:
-            cost: 1.90
-            currency: CNY
-            period: hourly
-          markUpPrice:
-            cost: 1.60
-            currency: CNY
-            period: hourly
+          licensePrices:
+            - region: any
+              price:
+                cost: 1.90
+                currency: CNY
+                period: hourly
+          markUpPrices:
+            - region: any
+              price:
+                cost: 1.90
+                currency: CNY
+                period: hourly
         # Used to calculate charges when users do not select 'pay_per_use' as the billing mode.
-        fixedPrice:
-          cost: 730
-          currency: CNY
-          period: monthly
+        fixedPrices:
+          - region: any
+            price:
+              cost: 730
+              currency: CNY
+              period: monthly
       # Properties for the service, which can be used by the deployment.
       properties:
         worker_nodes_count: 3
@@ -71,7 +77,7 @@ flavors:
         - High Availability
         - Maximum performance
     - name: 1-zookeeper-with-3-worker-nodes-performance
-      priority: 1
+      priority: 2
       # The pricing of the flavor.
       pricing:
         # Used to calculate charges when users select 'pay_per_use' as the billing mode.
@@ -90,20 +96,26 @@ flavors:
                 resource_type: hws.resource.type.volume
                 resource_spec: SSD
                 resource_size: 40
-                size_measure_id: 17
-          licensePrice:
-            cost: 3.20
-            currency: CNY
-            period: hourly
-          markUpPrice:
-            cost: 2.88
-            currency: CNY
-            period: hourly
+                size_measure_id: 15
+          licensePrices:
+            - region: any
+              price:
+                cost: 1.90
+                currency: CNY
+                period: hourly
+          markUpPrices:
+            - region: any
+              price:
+                cost: 1.90
+                currency: CNY
+                period: hourly
         # Used to calculate charges when users do not select 'pay_per_use' as the billing mode.
-        fixedPrice:
-          cost: 980
-          currency: CNY
-          period: monthly
+        fixedPrices:
+          - region: any
+            price:
+              cost: 980
+              currency: CNY
+              period: monthly
       properties:
         worker_nodes_count: 3
         flavor_id: s6.large.4

--- a/samples/HuaweiCloud-Kafka.yml
+++ b/samples/HuaweiCloud-Kafka.yml
@@ -50,19 +50,25 @@ flavors:
                 resource_spec: SSD
                 resource_size: 40
                 size_measure_id: 17
-          licensePrice:
-            cost: 1.90
-            currency: CNY
-            period: hourly
-          markUpPrice:
-            cost: 1.60
-            currency: CNY
-            period: hourly
+          licensePrices:
+            - region: any
+              price:
+                cost: 1.90
+                currency: CNY
+                period: hourly
+          markUpPrices:
+            - region: any
+              price:
+                cost: 1.90
+                currency: CNY
+                period: hourly
         # Used to calculate charges when users do not select 'pay_per_use' as the billing mode.
-        fixedPrice:
-          cost: 730
-          currency: CNY
-          period: monthly
+        fixedPrices:
+          - region: any
+            price:
+              cost: 730
+              currency: CNY
+              period: monthly
       # Properties for the service, which can be used by the deployment.
       properties:
         worker_nodes_count: 3
@@ -91,19 +97,25 @@ flavors:
                 resource_spec: SSD
                 resource_size: 40
                 size_measure_id: 15
-          licensePrice:
-            cost: 3.20
-            currency: CNY
-            period: hourly
-          markUpPrice:
-            cost: 2.88
-            currency: CNY
-            period: hourly
+          licensePrices:
+            - region: any
+              price:
+                cost: 1.90
+                currency: CNY
+                period: hourly
+          markUpPrices:
+            - region: any
+              price:
+                cost: 1.90
+                currency: CNY
+                period: hourly
         # Used to calculate charges when users do not select 'pay_per_use' as the billing mode.
-        fixedPrice:
-          cost: 980
-          currency: CNY
-          period: monthly
+        fixedPrices:
+          - region: any
+            price:
+              cost: 980
+              currency: CNY
+              period: monthly
       properties:
         worker_nodes_count: 3
         flavor_id: s6.large.4

--- a/samples/HuaweiCloud-MySql.yml
+++ b/samples/HuaweiCloud-MySql.yml
@@ -58,19 +58,25 @@ flavors:
                 resource_spec: 19_bgp
                 resource_size: 5
                 size_measure_id: 15
-          licensePrice:
-            cost: 1.50
-            currency: CNY
-            period: hourly
-          markUpPrice:
-            cost: 1.45
-            currency: CNY
-            period: hourly
+          licensePrices:
+            - region: any
+              price:
+                cost: 1.90
+                currency: CNY
+                period: hourly
+          markUpPrices:
+            - region: any
+              price:
+                cost: 1.90
+                currency: CNY
+                period: hourly
         # Used to calculate charges when users do not select 'pay_per_use' as the billing mode.
-        fixedPrice:
-          cost: 590
-          currency: CNY
-          period: monthly
+        fixedPrices:
+          - region: any
+            price:
+              cost: 570
+              currency: CNY
+              period: monthly
         isPriceOnlyForManagementLayer: false
       # Properties for the service, which can be used by the deployment.
       properties:
@@ -107,19 +113,25 @@ flavors:
                 resource_spec: 19_bgp
                 resource_size: 5
                 size_measure_id: 15
-          licensePrice:
-            cost: 1.60
-            currency: CNY
-            period: hourly
-          markUpPrice:
-            cost: 1.50
-            currency: CNY
-            period: hourly
+          licensePrices:
+            - region: any
+              price:
+                cost: 1.90
+                currency: CNY
+                period: hourly
+          markUpPrices:
+            - region: any
+              price:
+                cost: 1.90
+                currency: CNY
+                period: hourly
         # Used to calculate charges when users do not select 'pay_per_use' as the billing mode.
-        fixedPrice:
-          cost: 740
-          currency: CNY
-          period: monthly
+        fixedPrices:
+          - region: any
+            price:
+              cost: 740
+              currency: CNY
+              period: monthly
         isPriceOnlyForManagementLayer: false
       # Properties for the service, which can be used by the deployment.
       properties:

--- a/samples/OpenstackTestLab-Kafka.yml
+++ b/samples/OpenstackTestLab-Kafka.yml
@@ -33,10 +33,12 @@ flavors:
       # The pricing of the flavor.
       pricing:
         # Used to calculate charges when users do not select 'pay_per_use' as the billing mode.
-        fixedPrice:
-          cost: 95.00
-          currency: USD
-          period: monthly
+        fixedPrices:
+          - region: any
+            price:
+              cost: 95.00
+              currency: USD
+              period: monthly
       # Properties for the service, which can be used by the deployment.
       properties:
         worker_nodes_count: 3
@@ -49,10 +51,12 @@ flavors:
       # The pricing of the flavor.
       pricing:
         # Used to calculate charges when users do not select 'pay_per_use' as the billing mode.
-        fixedPrice:
-          cost: 122.0
-          currency: USD
-          period: monthly
+        fixedPrices:
+          - region: any
+            price:
+              cost: 130.00
+              currency: USD
+              period: monthly
       # Properties for the service, which can be used by the deployment.
       properties:
         worker_nodes_count: 3

--- a/samples/PlusServer-Kafka.yml
+++ b/samples/PlusServer-Kafka.yml
@@ -33,10 +33,12 @@ flavors:
       # The pricing of the flavor.
       pricing:
         # Used to calculate charges when users do not select 'pay_per_use' as the billing mode.
-        fixedPrice:
-          cost: 95.00
-          currency: USD
-          period: monthly
+        fixedPrices:
+          - region: any
+            price:
+              cost: 95.00
+              currency: USD
+              period: monthly
       # Properties for the service, which can be used by the deployment.
       properties:
         worker_nodes_count: 3
@@ -50,10 +52,12 @@ flavors:
       # The pricing of the flavor.
       pricing:
         # Used to calculate charges when users do not select 'pay_per_use' as the billing mode.
-        fixedPrice:
-          cost: 95.00
-          currency: USD
-          period: monthly
+        fixedPrices:
+          - region: any
+            price:
+              cost: 95.00
+              currency: USD
+              period: monthly
       # Properties for the service, which can be used by the deployment.
       properties:
         worker_nodes_count: 3

--- a/samples/RegioCloud-Kafka.yml
+++ b/samples/RegioCloud-Kafka.yml
@@ -33,10 +33,12 @@ flavors:
       # The pricing of the flavor.
       pricing:
         # Used to calculate charges when users do not select 'pay_per_use' as the billing mode.
-        fixedPrice:
-          cost: 95.00
-          currency: USD
-          period: monthly
+        fixedPrices:
+          - region: any
+            price:
+              cost: 95.00
+              currency: USD
+              period: monthly
       # Properties for the service, which can be used by the deployment.
       properties:
         worker_nodes_count: 3
@@ -50,10 +52,12 @@ flavors:
       # The pricing of the flavor.
       pricing:
         # Used to calculate charges when users do not select 'pay_per_use' as the billing mode.
-        fixedPrice:
-          cost: 95.00
-          currency: USD
-          period: monthly
+        fixedPrices:
+          - region: any
+            price:
+              cost: 95.00
+              currency: USD
+              period: monthly
       # Properties for the service, which can be used by the deployment.
       properties:
         worker_nodes_count: 3

--- a/samples/develop/HuaweiCloud-Compute-opentofu-dev-autofill.yml
+++ b/samples/develop/HuaweiCloud-Compute-opentofu-dev-autofill.yml
@@ -3,7 +3,7 @@ version: 1.0
 # The category of the service.
 category: compute
 # The Service provided by the ISV, the name will be shown on the console as a service.
-name: opentofu-ecs
+name: opentofu-ecs-autofill
 # The version of the service, the end-user can select the version they want to deploy.
 serviceVersion: 1.0.0
 # For the users may have more than one service, the @namespace can be used to separate the clusters.
@@ -20,6 +20,10 @@ cloudServiceProvider:
       area: Asia China
     - name: cn-north-4
       area: Asia China
+    - name: eu-west-0
+      area: Europe Pairs
+    - name: eu-west-101
+      area: Europe Dublin
 billing:
   # The supported mode of billing (`Fixed`, `Pay per Use`)
   billingModes:
@@ -42,7 +46,7 @@ flavors:
               properties:
                 cloud_service_type: hws.service.type.ec2
                 resource_type: hws.resource.type.vm
-                resource_spec: s7.small.1.linux
+                resource_spec: s6.small.1.linux
             - deployResourceKind: volume
               count: 1
               properties:
@@ -59,23 +63,44 @@ flavors:
                 resource_spec: 19_bgp
                 resource_size: 5
                 size_measure_id: 15
-          licensePrice:
-            cost: 0.50
-            currency: CNY
-            period: hourly
-          markUpPrice:
-            cost: 0.43
-            currency: CNY
-            period: hourly
+          licensePrices:
+            - region: any
+              price:
+                cost: 0.50
+                currency: CNY
+                period: hourly
+            - region: eu-west-101
+              price:
+                cost: 0.0015
+                currency: USD
+                period: hourly
+          markUpPrices:
+            - region: any
+              price:
+                cost: 0.50
+                currency: CNY
+                period: hourly
+            - region: eu-west-101
+              price:
+                cost: 0.0015
+                currency: USD
+                period: hourly
         # Used to calculate charges when users do not select 'pay_per_use' as the billing mode.
-        fixedPrice:
-          cost: 172
-          currency: CNY
-          period: monthly
+        fixedPrices:
+          - region: any
+            price:
+              cost: 172
+              currency: CNY
+              period: monthly
+          - region: eu-west-101
+            price:
+              cost: 20.00
+              currency: USD
+              period: monthly
         isPriceOnlyForManagementLayer: false
       # Properties for the service, which can be used by the deployment.
       properties:
-        flavor_id: s7.small.1
+        flavor_id: s6.small.1
       features:
         - High Availability
         - Maximum performance
@@ -108,19 +133,40 @@ flavors:
                 resource_spec: 19_bgp
                 resource_size: 5
                 size_measure_id: 15
-          licensePrice:
-            cost: 0.80
-            currency: CNY
-            period: hourly
-          markUpPrice:
-            cost: 0.72
-            currency: CNY
-            period: hourly
+          licensePrices:
+            - region: any
+              price:
+                cost: 0.50
+                currency: CNY
+                period: hourly
+            - region: eu-west-101
+              price:
+                cost: 0.0015
+                currency: USD
+                period: hourly
+          markUpPrices:
+            - region: any
+              price:
+                cost: 0.50
+                currency: CNY
+                period: hourly
+            - region: eu-west-101
+              price:
+                cost: 0.0015
+                currency: USD
+                period: hourly
         # Used to calculate charges when users do not select 'pay_per_use' as the billing mode.
-        fixedPrice:
-          cost: 300
-          currency: CNY
-          period: monthly
+        fixedPrices:
+          - region: any
+            price:
+              cost: 280
+              currency: CNY
+              period: monthly
+          - region: eu-west-101
+            price:
+              cost: 28.50
+              currency: USD
+              period: monthly
         isPriceOnlyForManagementLayer: false
       # Properties for the service, which can be used by the deployment.
       properties:
@@ -157,19 +203,40 @@ flavors:
                 resource_spec: 19_bgp
                 resource_size: 5
                 size_measure_id: 15
-          licensePrice:
-            cost: 1.21
-            currency: CNY
-            period: hourly
-          markUpPrice:
-            cost: 1.10
-            currency: CNY
-            period: hourly
+          licensePrices:
+            - region: any
+              price:
+                cost: 0.50
+                currency: CNY
+                period: hourly
+            - region: eu-west-101
+              price:
+                cost: 0.0015
+                currency: USD
+                period: hourly
+          markUpPrices:
+            - region: any
+              price:
+                cost: 0.50
+                currency: CNY
+                period: hourly
+            - region: eu-west-101
+              price:
+                cost: 0.0015
+                currency: USD
+                period: hourly
         # Used to calculate charges when users do not select 'pay_per_use' as the billing mode.
-        fixedPrice:
-          cost: 360
-          currency: CNY
-          period: monthly
+        fixedPrices:
+          - region: any
+            price:
+              cost: 360
+              currency: CNY
+              period: monthly
+          - region: eu-west-101
+            price:
+              cost: 35.00
+              currency: USD
+              period: monthly
         isPriceOnlyForManagementLayer: false
       # Properties for the service, which can be used by the deployment.
       properties:

--- a/samples/develop/HuaweiCloud-Compute-opentofu-dev-git-repo.yml
+++ b/samples/develop/HuaweiCloud-Compute-opentofu-dev-git-repo.yml
@@ -20,6 +20,10 @@ cloudServiceProvider:
       area: Asia China
     - name: cn-north-4
       area: Asia China
+    - name: eu-west-0
+      area: Europe Pairs
+    - name: eu-west-101
+      area: Europe Dublin
 billing:
   # The supported mode of billing (`Fixed`, `Pay per Use`)
   billingModes:
@@ -42,7 +46,7 @@ flavors:
               properties:
                 cloud_service_type: hws.service.type.ec2
                 resource_type: hws.resource.type.vm
-                resource_spec: s7.small.1.linux
+                resource_spec: s6.small.1.linux
             - deployResourceKind: volume
               count: 1
               properties:
@@ -59,23 +63,44 @@ flavors:
                 resource_spec: 19_bgp
                 resource_size: 5
                 size_measure_id: 15
-          licensePrice:
-            cost: 0.50
-            currency: CNY
-            period: hourly
-          markUpPrice:
-            cost: 0.43
-            currency: CNY
-            period: hourly
+          licensePrices:
+            - region: any
+              price:
+                cost: 0.50
+                currency: CNY
+                period: hourly
+            - region: eu-west-101
+              price:
+                cost: 0.0015
+                currency: USD
+                period: hourly
+          markUpPrices:
+            - region: any
+              price:
+                cost: 0.50
+                currency: CNY
+                period: hourly
+            - region: eu-west-101
+              price:
+                cost: 0.0015
+                currency: USD
+                period: hourly
         # Used to calculate charges when users do not select 'pay_per_use' as the billing mode.
-        fixedPrice:
-          cost: 172
-          currency: CNY
-          period: monthly
+        fixedPrices:
+          - region: any
+            price:
+              cost: 172
+              currency: CNY
+              period: monthly
+          - region: eu-west-101
+            price:
+              cost: 20.00
+              currency: USD
+              period: monthly
         isPriceOnlyForManagementLayer: false
       # Properties for the service, which can be used by the deployment.
       properties:
-        flavor_id: s7.small.1
+        flavor_id: s6.small.1
       features:
         - High Availability
         - Maximum performance
@@ -108,19 +133,40 @@ flavors:
                 resource_spec: 19_bgp
                 resource_size: 5
                 size_measure_id: 15
-          licensePrice:
-            cost: 0.80
-            currency: CNY
-            period: hourly
-          markUpPrice:
-            cost: 0.72
-            currency: CNY
-            period: hourly
+          licensePrices:
+            - region: any
+              price:
+                cost: 0.50
+                currency: CNY
+                period: hourly
+            - region: eu-west-101
+              price:
+                cost: 0.0015
+                currency: USD
+                period: hourly
+          markUpPrices:
+            - region: any
+              price:
+                cost: 0.50
+                currency: CNY
+                period: hourly
+            - region: eu-west-101
+              price:
+                cost: 0.0015
+                currency: USD
+                period: hourly
         # Used to calculate charges when users do not select 'pay_per_use' as the billing mode.
-        fixedPrice:
-          cost: 300
-          currency: CNY
-          period: monthly
+        fixedPrices:
+          - region: any
+            price:
+              cost: 280
+              currency: CNY
+              period: monthly
+          - region: eu-west-101
+            price:
+              cost: 28.50
+              currency: USD
+              period: monthly
         isPriceOnlyForManagementLayer: false
       # Properties for the service, which can be used by the deployment.
       properties:
@@ -157,19 +203,40 @@ flavors:
                 resource_spec: 19_bgp
                 resource_size: 5
                 size_measure_id: 15
-          licensePrice:
-            cost: 1.21
-            currency: CNY
-            period: hourly
-          markUpPrice:
-            cost: 1.10
-            currency: CNY
-            period: hourly
+          licensePrices:
+            - region: any
+              price:
+                cost: 0.50
+                currency: CNY
+                period: hourly
+            - region: eu-west-101
+              price:
+                cost: 0.0015
+                currency: USD
+                period: hourly
+          markUpPrices:
+            - region: any
+              price:
+                cost: 0.50
+                currency: CNY
+                period: hourly
+            - region: eu-west-101
+              price:
+                cost: 0.0015
+                currency: USD
+                period: hourly
         # Used to calculate charges when users do not select 'pay_per_use' as the billing mode.
-        fixedPrice:
-          cost: 360
-          currency: CNY
-          period: monthly
+        fixedPrices:
+          - region: any
+            price:
+              cost: 360
+              currency: CNY
+              period: monthly
+          - region: eu-west-101
+            price:
+              cost: 35.00
+              currency: USD
+              period: monthly
         isPriceOnlyForManagementLayer: false
       # Properties for the service, which can be used by the deployment.
       properties:

--- a/samples/develop/HuaweiCloud-Compute-opentofu-dev.yml
+++ b/samples/develop/HuaweiCloud-Compute-opentofu-dev.yml
@@ -20,6 +20,10 @@ cloudServiceProvider:
       area: Asia China
     - name: cn-north-4
       area: Asia China
+    - name: eu-west-0
+      area: Europe Pairs
+    - name: eu-west-101
+      area: Europe Dublin
 billing:
   # The supported mode of billing (`Fixed`, `Pay per Use`)
   billingModes:
@@ -42,7 +46,7 @@ flavors:
               properties:
                 cloud_service_type: hws.service.type.ec2
                 resource_type: hws.resource.type.vm
-                resource_spec: s7.small.1.linux
+                resource_spec: s6.small.1.linux
             - deployResourceKind: volume
               count: 1
               properties:
@@ -59,23 +63,44 @@ flavors:
                 resource_spec: 19_bgp
                 resource_size: 5
                 size_measure_id: 15
-          licensePrice:
-            cost: 0.50
-            currency: CNY
-            period: hourly
-          markUpPrice:
-            cost: 0.43
-            currency: CNY
-            period: hourly
+          licensePrices:
+            - region: any
+              price:
+                cost: 0.50
+                currency: CNY
+                period: hourly
+            - region: eu-west-101
+              price:
+                cost: 0.0015
+                currency: USD
+                period: hourly
+          markUpPrices:
+            - region: any
+              price:
+                cost: 0.50
+                currency: CNY
+                period: hourly
+            - region: eu-west-101
+              price:
+                cost: 0.0015
+                currency: USD
+                period: hourly
         # Used to calculate charges when users do not select 'pay_per_use' as the billing mode.
-        fixedPrice:
-          cost: 172
-          currency: CNY
-          period: monthly
+        fixedPrices:
+          - region: any
+            price:
+              cost: 172
+              currency: CNY
+              period: monthly
+          - region: eu-west-101
+            price:
+              cost: 20.00
+              currency: USD
+              period: monthly
         isPriceOnlyForManagementLayer: false
       # Properties for the service, which can be used by the deployment.
       properties:
-        flavor_id: s7.small.1
+        flavor_id: s6.small.1
       features:
         - High Availability
         - Maximum performance
@@ -108,19 +133,40 @@ flavors:
                 resource_spec: 19_bgp
                 resource_size: 5
                 size_measure_id: 15
-          licensePrice:
-            cost: 0.80
-            currency: CNY
-            period: hourly
-          markUpPrice:
-            cost: 0.72
-            currency: CNY
-            period: hourly
+          licensePrices:
+            - region: any
+              price:
+                cost: 0.50
+                currency: CNY
+                period: hourly
+            - region: eu-west-101
+              price:
+                cost: 0.0015
+                currency: USD
+                period: hourly
+          markUpPrices:
+            - region: any
+              price:
+                cost: 0.50
+                currency: CNY
+                period: hourly
+            - region: eu-west-101
+              price:
+                cost: 0.0015
+                currency: USD
+                period: hourly
         # Used to calculate charges when users do not select 'pay_per_use' as the billing mode.
-        fixedPrice:
-          cost: 300
-          currency: CNY
-          period: monthly
+        fixedPrices:
+          - region: any
+            price:
+              cost: 280
+              currency: CNY
+              period: monthly
+          - region: eu-west-101
+            price:
+              cost: 28.50
+              currency: USD
+              period: monthly
         isPriceOnlyForManagementLayer: false
       # Properties for the service, which can be used by the deployment.
       properties:
@@ -157,19 +203,40 @@ flavors:
                 resource_spec: 19_bgp
                 resource_size: 5
                 size_measure_id: 15
-          licensePrice:
-            cost: 1.21
-            currency: CNY
-            period: hourly
-          markUpPrice:
-            cost: 1.10
-            currency: CNY
-            period: hourly
+          licensePrices:
+            - region: any
+              price:
+                cost: 0.50
+                currency: CNY
+                period: hourly
+            - region: eu-west-101
+              price:
+                cost: 0.0015
+                currency: USD
+                period: hourly
+          markUpPrices:
+            - region: any
+              price:
+                cost: 0.50
+                currency: CNY
+                period: hourly
+            - region: eu-west-101
+              price:
+                cost: 0.0015
+                currency: USD
+                period: hourly
         # Used to calculate charges when users do not select 'pay_per_use' as the billing mode.
-        fixedPrice:
-          cost: 360
-          currency: CNY
-          period: monthly
+        fixedPrices:
+          - region: any
+            price:
+              cost: 360
+              currency: CNY
+              period: monthly
+          - region: eu-west-101
+            price:
+              cost: 35.00
+              currency: USD
+              period: monthly
         isPriceOnlyForManagementLayer: false
       # Properties for the service, which can be used by the deployment.
       properties:

--- a/samples/develop/HuaweiCloud-Compute-terraform-dev-autofill.yml
+++ b/samples/develop/HuaweiCloud-Compute-terraform-dev-autofill.yml
@@ -3,7 +3,7 @@ version: 1.0
 # The category of the service.
 category: compute
 # The Service provided by the ISV, the name will be shown on the console as a service.
-name: terraform-ecs
+name: terraform-ecs-autofill
 # The version of the service, the end-user can select the version they want to deploy.
 serviceVersion: 1.0.0
 # For the users may have more than one service, the @namespace can be used to separate the clusters.
@@ -20,6 +20,10 @@ cloudServiceProvider:
       area: Asia China
     - name: cn-north-4
       area: Asia China
+    - name: eu-west-0
+      area: Europe Pairs
+    - name: eu-west-101
+      area: Europe Dublin
 billing:
   # The supported mode of billing (`Fixed`, `Pay per Use`)
   billingModes:
@@ -42,7 +46,7 @@ flavors:
               properties:
                 cloud_service_type: hws.service.type.ec2
                 resource_type: hws.resource.type.vm
-                resource_spec: s7.small.1.linux
+                resource_spec: s6.small.1.linux
             - deployResourceKind: volume
               count: 1
               properties:
@@ -59,23 +63,44 @@ flavors:
                 resource_spec: 19_bgp
                 resource_size: 5
                 size_measure_id: 15
-          licensePrice:
-            cost: 0.50
-            currency: CNY
-            period: hourly
-          markUpPrice:
-            cost: 0.43
-            currency: CNY
-            period: hourly
+          licensePrices:
+            - region: any
+              price:
+                cost: 0.50
+                currency: CNY
+                period: hourly
+            - region: eu-west-101
+              price:
+                cost: 0.0015
+                currency: USD
+                period: hourly
+          markUpPrices:
+            - region: any
+              price:
+                cost: 0.50
+                currency: CNY
+                period: hourly
+            - region: eu-west-101
+              price:
+                cost: 0.0015
+                currency: USD
+                period: hourly
         # Used to calculate charges when users do not select 'pay_per_use' as the billing mode.
-        fixedPrice:
-          cost: 172
-          currency: CNY
-          period: monthly
+        fixedPrices:
+          - region: any
+            price:
+              cost: 172
+              currency: CNY
+              period: monthly
+          - region: eu-west-101
+            price:
+              cost: 20.00
+              currency: USD
+              period: monthly
         isPriceOnlyForManagementLayer: false
       # Properties for the service, which can be used by the deployment.
       properties:
-        flavor_id: s7.small.1
+        flavor_id: s6.small.1
       features:
         - High Availability
         - Maximum performance
@@ -108,19 +133,40 @@ flavors:
                 resource_spec: 19_bgp
                 resource_size: 5
                 size_measure_id: 15
-          licensePrice:
-            cost: 0.80
-            currency: CNY
-            period: hourly
-          markUpPrice:
-            cost: 0.72
-            currency: CNY
-            period: hourly
+          licensePrices:
+            - region: any
+              price:
+                cost: 0.50
+                currency: CNY
+                period: hourly
+            - region: eu-west-101
+              price:
+                cost: 0.0015
+                currency: USD
+                period: hourly
+          markUpPrices:
+            - region: any
+              price:
+                cost: 0.50
+                currency: CNY
+                period: hourly
+            - region: eu-west-101
+              price:
+                cost: 0.0015
+                currency: USD
+                period: hourly
         # Used to calculate charges when users do not select 'pay_per_use' as the billing mode.
-        fixedPrice:
-          cost: 300
-          currency: CNY
-          period: monthly
+        fixedPrices:
+          - region: any
+            price:
+              cost: 280
+              currency: CNY
+              period: monthly
+          - region: eu-west-101
+            price:
+              cost: 28.50
+              currency: USD
+              period: monthly
         isPriceOnlyForManagementLayer: false
       # Properties for the service, which can be used by the deployment.
       properties:
@@ -157,19 +203,40 @@ flavors:
                 resource_spec: 19_bgp
                 resource_size: 5
                 size_measure_id: 15
-          licensePrice:
-            cost: 1.21
-            currency: CNY
-            period: hourly
-          markUpPrice:
-            cost: 1.10
-            currency: CNY
-            period: hourly
+          licensePrices:
+            - region: any
+              price:
+                cost: 0.50
+                currency: CNY
+                period: hourly
+            - region: eu-west-101
+              price:
+                cost: 0.0015
+                currency: USD
+                period: hourly
+          markUpPrices:
+            - region: any
+              price:
+                cost: 0.50
+                currency: CNY
+                period: hourly
+            - region: eu-west-101
+              price:
+                cost: 0.0015
+                currency: USD
+                period: hourly
         # Used to calculate charges when users do not select 'pay_per_use' as the billing mode.
-        fixedPrice:
-          cost: 360
-          currency: CNY
-          period: monthly
+        fixedPrices:
+          - region: any
+            price:
+              cost: 360
+              currency: CNY
+              period: monthly
+          - region: eu-west-101
+            price:
+              cost: 35.00
+              currency: USD
+              period: monthly
         isPriceOnlyForManagementLayer: false
       # Properties for the service, which can be used by the deployment.
       properties:

--- a/samples/develop/HuaweiCloud-Compute-terraform-dev-git-repo.yml
+++ b/samples/develop/HuaweiCloud-Compute-terraform-dev-git-repo.yml
@@ -20,6 +20,10 @@ cloudServiceProvider:
       area: Asia China
     - name: cn-north-4
       area: Asia China
+    - name: eu-west-0
+      area: Europe Pairs
+    - name: eu-west-101
+      area: Europe Dublin
 billing:
   # The supported mode of billing (`Fixed`, `Pay per Use`)
   billingModes:
@@ -42,7 +46,7 @@ flavors:
               properties:
                 cloud_service_type: hws.service.type.ec2
                 resource_type: hws.resource.type.vm
-                resource_spec: s7.small.1.linux
+                resource_spec: s6.small.1.linux
             - deployResourceKind: volume
               count: 1
               properties:
@@ -59,23 +63,44 @@ flavors:
                 resource_spec: 19_bgp
                 resource_size: 5
                 size_measure_id: 15
-          licensePrice:
-            cost: 0.50
-            currency: CNY
-            period: hourly
-          markUpPrice:
-            cost: 0.43
-            currency: CNY
-            period: hourly
+          licensePrices:
+            - region: any
+              price:
+                cost: 0.50
+                currency: CNY
+                period: hourly
+            - region: eu-west-101
+              price:
+                cost: 0.0015
+                currency: USD
+                period: hourly
+          markUpPrices:
+            - region: any
+              price:
+                cost: 0.50
+                currency: CNY
+                period: hourly
+            - region: eu-west-101
+              price:
+                cost: 0.0015
+                currency: USD
+                period: hourly
         # Used to calculate charges when users do not select 'pay_per_use' as the billing mode.
-        fixedPrice:
-          cost: 172
-          currency: CNY
-          period: monthly
+        fixedPrices:
+          - region: any
+            price:
+              cost: 172
+              currency: CNY
+              period: monthly
+          - region: eu-west-101
+            price:
+              cost: 20.00
+              currency: USD
+              period: monthly
         isPriceOnlyForManagementLayer: false
       # Properties for the service, which can be used by the deployment.
       properties:
-        flavor_id: s7.small.1
+        flavor_id: s6.small.1
       features:
         - High Availability
         - Maximum performance
@@ -108,19 +133,40 @@ flavors:
                 resource_spec: 19_bgp
                 resource_size: 5
                 size_measure_id: 15
-          licensePrice:
-            cost: 0.80
-            currency: CNY
-            period: hourly
-          markUpPrice:
-            cost: 0.72
-            currency: CNY
-            period: hourly
+          licensePrices:
+            - region: any
+              price:
+                cost: 0.50
+                currency: CNY
+                period: hourly
+            - region: eu-west-101
+              price:
+                cost: 0.0015
+                currency: USD
+                period: hourly
+          markUpPrices:
+            - region: any
+              price:
+                cost: 0.50
+                currency: CNY
+                period: hourly
+            - region: eu-west-101
+              price:
+                cost: 0.0015
+                currency: USD
+                period: hourly
         # Used to calculate charges when users do not select 'pay_per_use' as the billing mode.
-        fixedPrice:
-          cost: 300
-          currency: CNY
-          period: monthly
+        fixedPrices:
+          - region: any
+            price:
+              cost: 280
+              currency: CNY
+              period: monthly
+          - region: eu-west-101
+            price:
+              cost: 28.50
+              currency: USD
+              period: monthly
         isPriceOnlyForManagementLayer: false
       # Properties for the service, which can be used by the deployment.
       properties:
@@ -157,19 +203,40 @@ flavors:
                 resource_spec: 19_bgp
                 resource_size: 5
                 size_measure_id: 15
-          licensePrice:
-            cost: 1.21
-            currency: CNY
-            period: hourly
-          markUpPrice:
-            cost: 1.10
-            currency: CNY
-            period: hourly
+          licensePrices:
+            - region: any
+              price:
+                cost: 0.50
+                currency: CNY
+                period: hourly
+            - region: eu-west-101
+              price:
+                cost: 0.0015
+                currency: USD
+                period: hourly
+          markUpPrices:
+            - region: any
+              price:
+                cost: 0.50
+                currency: CNY
+                period: hourly
+            - region: eu-west-101
+              price:
+                cost: 0.0015
+                currency: USD
+                period: hourly
         # Used to calculate charges when users do not select 'pay_per_use' as the billing mode.
-        fixedPrice:
-          cost: 360
-          currency: CNY
-          period: monthly
+        fixedPrices:
+          - region: any
+            price:
+              cost: 360
+              currency: CNY
+              period: monthly
+          - region: eu-west-101
+            price:
+              cost: 35.00
+              currency: USD
+              period: monthly
         isPriceOnlyForManagementLayer: false
       # Properties for the service, which can be used by the deployment.
       properties:

--- a/samples/develop/HuaweiCloud-Compute-terraform-dev.yml
+++ b/samples/develop/HuaweiCloud-Compute-terraform-dev.yml
@@ -63,19 +63,40 @@ flavors:
                 resource_spec: 19_bgp
                 resource_size: 5
                 size_measure_id: 15
-          licensePrice:
-            cost: 1.01
-            currency: CNY
-            period: monthly
-          markUpPrice:
-            cost: 1.02
-            currency: CNY
-            period: monthly
+          licensePrices:
+            - region: any
+              price:
+                cost: 0.50
+                currency: CNY
+                period: hourly
+            - region: eu-west-101
+              price:
+                cost: 0.0015
+                currency: USD
+                period: hourly
+          markUpPrices:
+            - region: any
+              price:
+                cost: 0.50
+                currency: CNY
+                period: hourly
+            - region: eu-west-101
+              price:
+                cost: 0.0015
+                currency: USD
+                period: hourly
         # Used to calculate charges when users do not select 'pay_per_use' as the billing mode.
-        fixedPrice:
-          cost: 172
-          currency: CNY
-          period: monthly
+        fixedPrices:
+          - region: any
+            price:
+              cost: 172
+              currency: CNY
+              period: monthly
+          - region: eu-west-101
+            price:
+              cost: 20.00
+              currency: USD
+              period: monthly
         isPriceOnlyForManagementLayer: false
       # Properties for the service, which can be used by the deployment.
       properties:
@@ -112,19 +133,40 @@ flavors:
                 resource_spec: 19_bgp
                 resource_size: 5
                 size_measure_id: 15
-          licensePrice:
-            cost: 12.20
-            currency: CNY
-            period: yearly
-          markUpPrice:
-            cost: 12.10
-            currency: CNY
-            period: yearly
+          licensePrices:
+            - region: any
+              price:
+                cost: 0.50
+                currency: CNY
+                period: hourly
+            - region: eu-west-101
+              price:
+                cost: 0.0015
+                currency: USD
+                period: hourly
+          markUpPrices:
+            - region: any
+              price:
+                cost: 0.50
+                currency: CNY
+                period: hourly
+            - region: eu-west-101
+              price:
+                cost: 0.0015
+                currency: USD
+                period: hourly
         # Used to calculate charges when users do not select 'pay_per_use' as the billing mode.
-        fixedPrice:
-          cost: 300
-          currency: CNY
-          period: monthly
+        fixedPrices:
+          - region: any
+            price:
+              cost: 280
+              currency: CNY
+              period: monthly
+          - region: eu-west-101
+            price:
+              cost: 28.50
+              currency: USD
+              period: monthly
         isPriceOnlyForManagementLayer: false
       # Properties for the service, which can be used by the deployment.
       properties:
@@ -161,19 +203,40 @@ flavors:
                 resource_spec: 19_bgp
                 resource_size: 5
                 size_measure_id: 15
-          licensePrice:
-            cost: 30.21
-            currency: CNY
-            period: oneTime
-          markUpPrice:
-            cost: 30.10
-            currency: CNY
-            period: oneTime
+          licensePrices:
+            - region: any
+              price:
+                cost: 0.50
+                currency: CNY
+                period: hourly
+            - region: eu-west-101
+              price:
+                cost: 0.0015
+                currency: USD
+                period: hourly
+          markUpPrices:
+            - region: any
+              price:
+                cost: 0.50
+                currency: CNY
+                period: hourly
+            - region: eu-west-101
+              price:
+                cost: 0.0015
+                currency: USD
+                period: hourly
         # Used to calculate charges when users do not select 'pay_per_use' as the billing mode.
-        fixedPrice:
-          cost: 360
-          currency: CNY
-          period: monthly
+        fixedPrices:
+          - region: any
+            price:
+              cost: 360
+              currency: CNY
+              period: monthly
+          - region: eu-west-101
+            price:
+              cost: 35.00
+              currency: USD
+              period: monthly
         isPriceOnlyForManagementLayer: false
       # Properties for the service, which can be used by the deployment.
       properties:

--- a/samples/develop/OpenstackTestLab-Compute-terraform-dev.yml
+++ b/samples/develop/OpenstackTestLab-Compute-terraform-dev.yml
@@ -34,10 +34,12 @@ flavors:
       # The pricing of the flavor.
       pricing:
         # Used to calculate charges when users do not select 'pay_per_use' as the billing mode.
-        fixedPrice:
-          cost: 6.15
-          currency: USD
-          period: monthly
+        fixedPrices:
+          - region: any
+            price:
+              cost: 6.15
+              currency: USD
+              period: monthly
         isPriceOnlyForManagementLayer: false
       # Properties for the service, which can be used by the deployment.
       properties:
@@ -50,10 +52,12 @@ flavors:
       # The pricing of the flavor.
       pricing:
         # Used to calculate charges when users do not select 'pay_per_use' as the billing mode.
-        fixedPrice:
-          cost: 23.75
-          currency: USD
-          period: monthly
+        fixedPrices:
+          - region: any
+            price:
+              cost: 23.75
+              currency: USD
+              period: monthly
         isPriceOnlyForManagementLayer: false
       # Properties for the service, which can be used by the deployment.
       properties:
@@ -66,10 +70,12 @@ flavors:
       # The pricing of the flavor.
       pricing:
         # Used to calculate charges when users do not select 'pay_per_use' as the billing mode.
-        fixedPrice:
-          cost: 30.50
-          currency: USD
-          period: monthly
+        fixedPrices:
+          - region: any
+            price:
+              cost: 30.50
+              currency: USD
+              period: monthly
         isPriceOnlyForManagementLayer: false
       # Properties for the service, which can be used by the deployment.
       properties:

--- a/samples/develop/flexibleEngine-compute-terraform-dev.yml
+++ b/samples/develop/flexibleEngine-compute-terraform-dev.yml
@@ -32,14 +32,16 @@ flavors:
       # The pricing of the flavor.
       pricing:
         # Used to calculate charges when users do not select 'pay_per_use' as the billing mode.
-        fixedPrice:
-          cost: 172
-          currency: EUR
-          period: monthly
+        fixedPrices:
+          - region: any
+            price:
+              cost: 20.00
+              currency: EUR
+              period: monthly
         isPriceOnlyForManagementLayer: false
       # Properties for the service, which can be used by the deployment.
       properties:
-        flavor_id: s7.small.1
+        flavor_id: s6.small.1
       features:
         - High Availability
         - Maximum performance
@@ -48,10 +50,12 @@ flavors:
       # The pricing of the flavor.
       pricing:
         # Used to calculate charges when users do not select 'pay_per_use' as the billing mode.
-        fixedPrice:
-          cost: 39.00
-          currency: EUR
-          period: monthly
+        fixedPrices:
+          - region: any
+            price:
+              cost: 39.00
+              currency: EUR
+              period: monthly
         isPriceOnlyForManagementLayer: false
       # Properties for the service, which can be used by the deployment.
       properties:
@@ -63,44 +67,13 @@ flavors:
       priority: 1
       # The pricing of the flavor.
       pricing:
-        # Used to calculate charges when users select 'pay_per_use' as the billing mode.
-        resourceUsage:
-          resources:
-            - deployResourceKind: vm
-              count: 1
-              properties:
-                cloud_service_type: hws.service.type.ec2
-                resource_type: hws.resource.type.vm
-                resource_spec: s6.large.4.linux
-            - deployResourceKind: volume
-              count: 1
-              properties:
-                cloud_service_type: hws.service.type.ebs
-                resource_type: hws.resource.type.volume
-                resource_spec: SSD
-                resource_size: 40
-                size_measure_id: 17
-            - deployResourceKind: publicIP
-              count: 1
-              properties:
-                cloud_service_type: hws.service.type.vpc
-                resource_type: hws.resource.type.bandwidth
-                resource_spec: 19_bgp
-                resource_size: 5
-                size_measure_id: 15
-          licensePrice:
-            cost: 0.1562
-            currency: EUR
-            period: hourly
-          markUpPrice:
-            cost: 0.1420
-            currency: EUR
-            period: hourly
         # Used to calculate charges when users do not select 'pay_per_use' as the billing mode.
-        fixedPrice:
-          cost: 46.50
-          currency: EUR
-          period: monthly
+        fixedPrices:
+          - region: any
+            price:
+              cost: 46.50
+              currency: EUR
+              period: monthly
         isPriceOnlyForManagementLayer: false
       # Properties for the service, which can be used by the deployment.
       properties:
@@ -236,7 +209,7 @@ deployment:
       required_providers {
         flexibleengine = {
           source  = "FlexibleEngineCloud/flexibleengine"
-          version = "~> 1.45.0"
+          version = "~> 1.46.0"
         }
       }
     }
@@ -247,53 +220,44 @@ deployment:
 
     data "flexibleengine_availability_zones" "osc-az" {}
 
-    data "flexibleengine_vpc_v1" "existing" {
-      name  = var.vpc_name
-      count = length(data.flexibleengine_vpc_v1.existing)
-    }
-
-    data "flexibleengine_vpc_subnet_v1" "existing" {
-      name    = var.subnet_name
-      count = length(data.flexibleengine_vpc_subnet_v1.existing)
-    }
-
-    data "flexibleengine_networking_secgroup_v2" "existing" {
-      name  = var.secgroup_name
-      count = length(data.flexibleengine_networking_secgroup_v2.existing)
-    }
-
-    locals {
-      availability_zone = var.availability_zone == "" ? data.flexibleengine_availability_zones.osc-az.names[0] : var.availability_zone
-      admin_passwd      = var.admin_passwd == "" ? random_password.password.result : var.admin_passwd
-      vpc_id            = length(data.flexibleengine_vpc_v1.existing) > 0 ? data.flexibleengine_vpc_v1.existing[0].id : flexibleengine_vpc_v1.new[0].id
-      subnet_id         = length(data.flexibleengine_vpc_subnet_v1.existing) > 0 ? data.flexibleengine_vpc_subnet_v1.existing[0].id : flexibleengine_vpc_subnet_v1.new[0].id
-      secgroup_id       = length(data.flexibleengine_networking_secgroup_v2.existing) > 0 ? data.flexibleengine_networking_secgroup_v2.existing[0].id : flexibleengine_networking_secgroup_v2.new[0].id
-      secgroup_name     = length(data.flexibleengine_networking_secgroup_v2.existing) > 0 ? data.flexibleengine_networking_secgroup_v2.existing[0].name : flexibleengine_networking_secgroup_v2.new[0].name
+    data "flexibleengine_vpcs" "existing" {
+      name = var.vpc_name
     }
 
     resource "flexibleengine_vpc_v1" "new" {
-      count = length(data.flexibleengine_vpc_v1.existing) == 0 ? 1 : 0
+      count = length(data.flexibleengine_vpcs.existing.vpcs) == 0 ? 1 : 0
       name  = "${var.vpc_name}-${random_id.new.hex}"
       cidr  = "192.168.0.0/16"
     }
 
+    data "flexibleengine_vpc_subnets" "existing" {
+      name = var.subnet_name
+    }
+      
     resource "flexibleengine_vpc_subnet_v1" "new" {
-      count      = length(data.flexibleengine_vpc_subnet_v1.existing) == 0 ? 1 : 0
+      count      = length(data.flexibleengine_vpc_subnets.existing.subnets) == 0 ? 1 : 0
       vpc_id     = local.vpc_id
       name       = "${var.subnet_name}-${random_id.new.hex}"
       cidr       = "192.168.10.0/24"
       gateway_ip = "192.168.10.1"
-      dns_list   = ["100.125.0.41","100.125.12.161"]
+      dns_list   = ["100.125.0.41", "100.125.12.161"]
     }
 
     resource "flexibleengine_networking_secgroup_v2" "new" {
-      count       = length(data.flexibleengine_networking_secgroup_v2.existing) == 0 ? 1 : 0
       name        = "${var.secgroup_name}-${random_id.new.hex}"
       description = "Compute security group"
     }
+      
+    locals {
+      availability_zone = var.availability_zone == "" ? data.flexibleengine_availability_zones.osc-az.names[0] : var.availability_zone
+      admin_passwd      = var.admin_passwd == "" ? random_password.password.result : var.admin_passwd
+      vpc_id            = length(data.flexibleengine_vpcs.existing.vpcs) > 0 ? data.flexibleengine_vpcs.existing.vpcs[0].id : flexibleengine_vpc_v1.new[0].id
+      subnet_id         = length(data.flexibleengine_vpc_subnets.existing.subnets) > 0 ? data.flexibleengine_vpc_subnets.existing.subnets[0].id : flexibleengine_vpc_subnet_v1.new[0].id
+      secgroup_id       = flexibleengine_networking_secgroup_v2.new.id
+      secgroup_name     = flexibleengine_networking_secgroup_v2.new.name
+    }
 
     resource "flexibleengine_networking_secgroup_rule_v2" "secgroup_rule_0" {
-      count             = length(data.flexibleengine_networking_secgroup_v2.existing) == 0 ? 1 : 0
       direction         = "ingress"
       ethertype         = "IPv4"
       protocol          = "tcp"
@@ -304,7 +268,6 @@ deployment:
     }
 
     resource "flexibleengine_networking_secgroup_rule_v2" "secgroup_rule_1" {
-      count             = length(data.flexibleengine_networking_secgroup_v2.existing) == 0 ? 1 : 0
       direction         = "ingress"
       ethertype         = "IPv4"
       protocol          = "tcp"
@@ -315,7 +278,6 @@ deployment:
     }
 
     resource "flexibleengine_networking_secgroup_rule_v2" "secgroup_rule_2" {
-      count             = length(data.flexibleengine_networking_secgroup_v2.existing) == 0 ? 1 : 0
       direction         = "ingress"
       ethertype         = "IPv4"
       protocol          = "tcp"
@@ -356,10 +318,16 @@ deployment:
       security_groups    = [ local.secgroup_name ]
       image_id           = data.flexibleengine_images_image.image.id
       key_pair           = flexibleengine_compute_keypair_v2.keypair.name
-      admin_pass         = local.admin_passwd
       network {
         uuid = local.subnet_id
       }
+      user_data = <<EOF
+        #!/bin/bash
+        sudo sed -i 's/^#*PermitRootLogin.*$/PermitRootLogin yes/' /etc/ssh/sshd_config
+        sudo sed -i 's/^#*PasswordAuthentication.*$/PasswordAuthentication yes/' /etc/ssh/sshd_config
+        sudo systemctl restart ssh
+        echo "root:${local.admin_passwd}" | sudo chpasswd
+      EOF
     }
     
     resource "flexibleengine_blockstorage_volume_v2" "volume" {

--- a/samples/flexibleEngine-K8S.yml
+++ b/samples/flexibleEngine-K8S.yml
@@ -31,10 +31,12 @@ flavors:
       # The pricing of the flavor.
       pricing:
         # Used to calculate charges when users do not select 'pay_per_use' as the billing mode.
-        fixedPrice:
-          cost: 95.20
-          currency: EUR
-          period: monthly
+        fixedPrices:
+          - region: any
+            price:
+              cost: 95.20
+              currency: EUR
+              period: monthly
       # Properties for the service, which can be used by the deployment.
       properties:
         worker_nodes_count: 3
@@ -47,10 +49,12 @@ flavors:
       # The pricing of the flavor.
       pricing:
         # Used to calculate charges when users do not select 'pay_per_use' as the billing mode.
-        fixedPrice:
-          cost: 126.48
-          currency: EUR
-          period: monthly
+        fixedPrices:
+          - region: any
+            price:
+              cost: 126.48
+              currency: EUR
+              period: monthly
       # Properties for the service, which can be used by the deployment.
       properties:
         worker_nodes_count: 3
@@ -182,7 +186,7 @@ deployment:
       required_providers {
         flexibleengine = {
           source  = "FlexibleEngineCloud/flexibleengine"
-          version = "~> 1.45.0"
+          version = "~> 1.46.0"
         }
       }
     }
@@ -193,53 +197,45 @@ deployment:
 
     data "flexibleengine_availability_zones" "osc-az" {}
 
-    data "flexibleengine_vpc_v1" "existing" {
-      name  = var.vpc_name
-      count = length(data.flexibleengine_vpc_v1.existing)
-    }
-
-    data "flexibleengine_vpc_subnet_v1" "existing" {
-      name    = var.subnet_name
-      count = length(data.flexibleengine_vpc_subnet_v1.existing)
-    }
-
-    data "flexibleengine_networking_secgroup_v2" "existing" {
-      name  = var.secgroup_name
-      count = length(data.flexibleengine_networking_secgroup_v2.existing)
-    }
-
-    locals {
-      availability_zone = var.availability_zone == "" ? data.flexibleengine_availability_zones.osc-az.names[0] : var.availability_zone
-      admin_passwd      = var.admin_passwd == "" ? random_password.password.result : var.admin_passwd
-      vpc_id            = length(data.flexibleengine_vpc_v1.existing) > 0 ? data.flexibleengine_vpc_v1.existing[0].id : flexibleengine_vpc_v1.new[0].id
-      subnet_id         = length(data.flexibleengine_vpc_subnet_v1.existing) > 0 ? data.flexibleengine_vpc_subnet_v1.existing[0].id : flexibleengine_vpc_subnet_v1.new[0].id
-      secgroup_id       = length(data.flexibleengine_networking_secgroup_v2.existing) > 0 ? data.flexibleengine_networking_secgroup_v2.existing[0].id : flexibleengine_networking_secgroup_v2.new[0].id
-      secgroup_name     = length(data.flexibleengine_networking_secgroup_v2.existing) > 0 ? data.flexibleengine_networking_secgroup_v2.existing[0].name : flexibleengine_networking_secgroup_v2.new[0].name
+    data "flexibleengine_vpcs" "existing" {
+      name = var.vpc_name
     }
 
     resource "flexibleengine_vpc_v1" "new" {
-      count = length(data.flexibleengine_vpc_v1.existing) == 0 ? 1 : 0
+      count = length(data.flexibleengine_vpcs.existing.vpcs) == 0 ? 1 : 0
       name  = "${var.vpc_name}-${random_id.new.hex}"
       cidr  = "192.168.0.0/16"
     }
 
+    data "flexibleengine_vpc_subnets" "existing" {
+      name = var.subnet_name
+    }
+    
     resource "flexibleengine_vpc_subnet_v1" "new" {
-      count      = length(data.flexibleengine_vpc_subnet_v1.existing) == 0 ? 1 : 0
+      count      = length(data.flexibleengine_vpc_subnets.existing.subnets) == 0 ? 1 : 0
       vpc_id     = local.vpc_id
       name       = "${var.subnet_name}-${random_id.new.hex}"
       cidr       = "192.168.10.0/24"
       gateway_ip = "192.168.10.1"
-      dns_list   = ["100.125.0.41","100.125.12.161"]
+      dns_list   = ["100.125.0.41", "100.125.12.161"]
     }
 
     resource "flexibleengine_networking_secgroup_v2" "new" {
-      count       = length(data.flexibleengine_networking_secgroup_v2.existing) == 0 ? 1 : 0
       name        = "${var.secgroup_name}-${random_id.new.hex}"
       description = "K8S cluster security group"
     }
+    
+    locals {
+      availability_zone = var.availability_zone == "" ? data.flexibleengine_availability_zones.osc-az.names[0] : var.availability_zone
+      admin_passwd      = var.admin_passwd == "" ? random_password.password.result : var.admin_passwd
+      vpc_id            = length(data.flexibleengine_vpcs.existing.vpcs) > 0 ? data.flexibleengine_vpcs.existing.vpcs[0].id : flexibleengine_vpc_v1.new[0].id
+      subnet_id         = length(data.flexibleengine_vpc_subnets.existing.subnets) > 0 ? data.flexibleengine_vpc_subnets.existing.subnets[0].id : flexibleengine_vpc_subnet_v1.new[0].id
+      secgroup_id       = flexibleengine_networking_secgroup_v2.new.id
+      secgroup_name     = flexibleengine_networking_secgroup_v2.new.name
+    }
+
 
     resource "flexibleengine_networking_secgroup_rule_v2" "secgroup_rule_0" {
-      count             = length(data.flexibleengine_networking_secgroup_v2.existing) == 0 ? 1 : 0
       direction         = "ingress"
       ethertype         = "IPv4"
       protocol          = "tcp"
@@ -248,8 +244,6 @@ deployment:
       remote_ip_prefix  = "121.37.117.211/32"
       security_group_id = local.secgroup_id
     }
-
-
 
     resource "random_id" "new" {
       byte_length = 4
@@ -287,7 +281,10 @@ deployment:
       }
       user_data = <<EOF
             #!bin/bash
-            echo root:${local.admin_passwd} | sudo chpasswd
+            sudo sed -i 's/^#*PermitRootLogin.*$/PermitRootLogin yes/' /etc/ssh/sshd_config
+            sudo sed -i 's/^#*PasswordAuthentication.*$/PasswordAuthentication yes/' /etc/ssh/sshd_config
+            sudo systemctl restart ssh
+            echo "root:${local.admin_passwd}" | sudo chpasswd
             sudo sh /root/k8s-init.sh true ${local.admin_passwd} ${var.worker_nodes_count} > /root/init.log
           EOF
     }

--- a/samples/flexibleEngine-Kafka.yml
+++ b/samples/flexibleEngine-Kafka.yml
@@ -31,10 +31,12 @@ flavors:
       # The pricing of the flavor.
       pricing:
         # Used to calculate charges when users do not select 'pay_per_use' as the billing mode.
-        fixedPrice:
-          cost: 95.20
-          currency: EUR
-          period: monthly
+        fixedPrices:
+          - region: any
+            price:
+              cost: 95.20
+              currency: EUR
+              period: monthly
       # Properties for the service, which can be used by the deployment.
       properties:
         worker_nodes_count: 3
@@ -47,10 +49,12 @@ flavors:
       # The pricing of the flavor.
       pricing:
         # Used to calculate charges when users do not select 'pay_per_use' as the billing mode.
-        fixedPrice:
-          cost: 126.48
-          currency: EUR
-          period: monthly
+        fixedPrices:
+         - region: any
+           price:
+             cost: 126.48
+             currency: EUR
+             period: monthly
       properties:
         worker_nodes_count: 3
         flavor_id: s6.large.4
@@ -227,7 +231,7 @@ deployment:
       required_providers {
         flexibleengine = {
           source  = "FlexibleEngineCloud/flexibleengine"
-          version = "~> 1.45.0"
+          version = "~> 1.46.0"
         }
       }
     }
@@ -238,53 +242,44 @@ deployment:
 
     data "flexibleengine_availability_zones" "osc-az" {}
 
-    data "flexibleengine_vpc_v1" "existing" {
-      name  = var.vpc_name
-      count = length(data.flexibleengine_vpc_v1.existing)
-    }
-
-    data "flexibleengine_vpc_subnet_v1" "existing" {
-      name  = var.subnet_name
-      count = length(data.flexibleengine_vpc_subnet_v1.existing)
-    }
-
-    data "flexibleengine_networking_secgroup_v2" "existing" {
-      name  = var.secgroup_name
-      count = length(data.flexibleengine_networking_secgroup_v2.existing)
-    }
-
-    locals {
-      availability_zone = var.availability_zone == "" ? data.flexibleengine_availability_zones.osc-az.names[0] : var.availability_zone
-      admin_passwd      = var.admin_passwd == "" ? random_password.password.result : var.admin_passwd
-      vpc_id            = length(data.flexibleengine_vpc_v1.existing) > 0 ? data.flexibleengine_vpc_v1.existing[0].id : flexibleengine_vpc_v1.new[0].id
-      subnet_id         = length(data.flexibleengine_vpc_subnet_v1.existing) > 0 ? data.flexibleengine_vpc_subnet_v1.existing[0].id : flexibleengine_vpc_subnet_v1.new[0].id
-      secgroup_id       = length(data.flexibleengine_networking_secgroup_v2.existing) > 0 ? data.flexibleengine_networking_secgroup_v2.existing[0].id : flexibleengine_networking_secgroup_v2.new[0].id
-      secgroup_name     = length(data.flexibleengine_networking_secgroup_v2.existing) > 0 ? data.flexibleengine_networking_secgroup_v2.existing[0].name : flexibleengine_networking_secgroup_v2.new[0].name
+    data "flexibleengine_vpcs" "existing" {
+      name = var.vpc_name
     }
 
     resource "flexibleengine_vpc_v1" "new" {
-      count = length(data.flexibleengine_vpc_v1.existing) == 0 ? 1 : 0
+      count = length(data.flexibleengine_vpcs.existing.vpcs) == 0 ? 1 : 0
       name  = "${var.vpc_name}-${random_id.new.hex}"
       cidr  = "192.168.0.0/16"
     }
 
+    data "flexibleengine_vpc_subnets" "existing" {
+      name = var.subnet_name
+    }
+    
     resource "flexibleengine_vpc_subnet_v1" "new" {
-      count      = length(data.flexibleengine_vpc_subnet_v1.existing) == 0 ? 1 : 0
+      count      = length(data.flexibleengine_vpc_subnets.existing.subnets) == 0 ? 1 : 0
       vpc_id     = local.vpc_id
       name       = "${var.subnet_name}-${random_id.new.hex}"
       cidr       = "192.168.10.0/24"
       gateway_ip = "192.168.10.1"
-      dns_list   = ["100.125.0.41","100.125.12.161"]
+      dns_list   = ["100.125.0.41", "100.125.12.161"]
     }
 
     resource "flexibleengine_networking_secgroup_v2" "new" {
-      count       = length(data.flexibleengine_networking_secgroup_v2.existing) == 0 ? 1 : 0
       name        = "${var.secgroup_name}-${random_id.new.hex}"
       description = "Kafka cluster security group"
     }
+    
+    locals {
+      availability_zone = var.availability_zone == "" ? data.flexibleengine_availability_zones.osc-az.names[0] : var.availability_zone
+      admin_passwd      = var.admin_passwd == "" ? random_password.password.result : var.admin_passwd
+      vpc_id            = length(data.flexibleengine_vpcs.existing.vpcs) > 0 ? data.flexibleengine_vpcs.existing.vpcs[0].id : flexibleengine_vpc_v1.new[0].id
+      subnet_id         = length(data.flexibleengine_vpc_subnets.existing.subnets) > 0 ? data.flexibleengine_vpc_subnets.existing.subnets[0].id : flexibleengine_vpc_subnet_v1.new[0].id
+      secgroup_id       = flexibleengine_networking_secgroup_v2.new.id
+      secgroup_name     = flexibleengine_networking_secgroup_v2.new.name
+    }
 
     resource "flexibleengine_networking_secgroup_rule_v2" "secgroup_rule_0" {
-      count             = length(data.flexibleengine_networking_secgroup_v2.existing) == 0 ? 1 : 0
       direction         = "ingress"
       ethertype         = "IPv4"
       protocol          = "tcp"
@@ -295,7 +290,6 @@ deployment:
     }
 
     resource "flexibleengine_networking_secgroup_rule_v2" "secgroup_rule_1" {
-      count             = length(data.flexibleengine_networking_secgroup_v2.existing) == 0 ? 1 : 0
       direction         = "ingress"
       ethertype         = "IPv4"
       protocol          = "tcp"
@@ -306,7 +300,6 @@ deployment:
     }
 
     resource "flexibleengine_networking_secgroup_rule_v2" "secgroup_rule_2" {
-      count             = length(data.flexibleengine_networking_secgroup_v2.existing) == 0 ? 1 : 0
       direction         = "ingress"
       ethertype         = "IPv4"
       protocol          = "tcp"
@@ -352,7 +345,10 @@ deployment:
       }
       user_data = <<EOF
             #!bin/bash
-            echo root:${local.admin_passwd} | sudo chpasswd
+            sudo sed -i 's/^#*PermitRootLogin.*$/PermitRootLogin yes/' /etc/ssh/sshd_config
+            sudo sed -i 's/^#*PasswordAuthentication.*$/PasswordAuthentication yes/' /etc/ssh/sshd_config
+            sudo systemctl restart ssh
+            echo "root:${local.admin_passwd}" | sudo chpasswd
             sudo systemctl start docker
             sudo systemctl enable docker
             sudo docker run -d --name zookeeper-server --privileged=true -p 2181:2181 -e ALLOW_ANONYMOUS_LOGIN=yes bitnami/zookeeper:3.8.1


### PR DESCRIPTION
**Fixed https://github.com/eclipse-xpanse/xpanse/issues/1851**

**Service template with one specific price for region 'eu-west-101' and  one common price for 'any' region:**
![image](https://github.com/user-attachments/assets/8374d4a3-f9f8-4299-a086-ec511e321952)
**When select region 'eu-west-101', fixed prices of service as below:**
![chrome_9VDNJDqXUt](https://github.com/user-attachments/assets/0027ec3b-7624-41f2-b0ff-c6f136ce3519)
**When select other region except 'eu-west-101', fixed prices of service as below:**
     Fixed prices for region 'cn-southwest-2':
![chrome_JU2kE0JEh9](https://github.com/user-attachments/assets/29c5b848-774e-44cf-9fe1-2f87bf6a6dfa)
     Fixed prices for region 'eu-west-0':
![image](https://github.com/user-attachments/assets/d39e4e91-4031-45ef-82b8-1efca1bbc841)


