### PR TITLE
support manage service state after modification

### DIFF
--- a/modules/deployment/src/main/java/org/eclipse/xpanse/modules/deployment/ServiceStateManager.java
+++ b/modules/deployment/src/main/java/org/eclipse/xpanse/modules/deployment/ServiceStateManager.java
@@ -329,10 +329,13 @@ public class ServiceStateManager {
         }
         ServiceDeploymentState serviceDeploymentState = service.getServiceDeploymentState();
         if (!(serviceDeploymentState == ServiceDeploymentState.DEPLOY_SUCCESS
-                || serviceDeploymentState == ServiceDeploymentState.DESTROY_FAILED)) {
-            throw new InvalidServiceStateException(
-                    String.format("Service with id %s is %s.", service.getId(),
-                            serviceDeploymentState));
+                || serviceDeploymentState == ServiceDeploymentState.DESTROY_FAILED
+                || serviceDeploymentState == ServiceDeploymentState.MODIFICATION_SUCCESSFUL
+                || serviceDeploymentState == ServiceDeploymentState.MODIFICATION_FAILED)) {
+            String errorMsg = String.format("Service %s with deployment state %s is not supported"
+                    + " to manage status.", service.getId(), serviceDeploymentState);
+            log.error(errorMsg);
+            throw new InvalidServiceStateException(errorMsg);
         }
     }
 

--- a/runtime/src/test/java/org/eclipse/xpanse/runtime/ServiceStateManageApiTest.java
+++ b/runtime/src/test/java/org/eclipse/xpanse/runtime/ServiceStateManageApiTest.java
@@ -175,10 +175,10 @@ class ServiceStateManageApiTest extends ApisTestCommon {
         // Setup
         DeployServiceEntity service4 = setUpWellDeployServiceEntity(Csp.HUAWEI_CLOUD, region);
         service4.setServiceDeploymentState(ServiceDeploymentState.DEPLOYING);
+        String errorMsg4 = String.format("Service %s with deployment state %s is not supported"
+                + " to manage status.", service4.getId(), service4.getServiceDeploymentState());
         Response result4 = Response.errorResponse(ResultType.SERVICE_STATE_INVALID,
-                Collections.singletonList(
-                        String.format("Service with id %s is %s.", service4.getId(),
-                                service4.getServiceDeploymentState())));
+                Collections.singletonList(errorMsg4));
         when(mockDeployServiceStorage.findDeployServiceById(service4.getId())).thenReturn(service4);
         // run the test
         final MockHttpServletResponse response4 = startService(service4.getId());
@@ -484,7 +484,7 @@ class ServiceStateManageApiTest extends ApisTestCommon {
         when(flexibleEngineClient.getEcsClient(any(), any())).thenReturn(mockEcsClient);
         addCredentialForFlexibleEngine();
         testServiceStateManageApisWithHuaweiCloudSdk(service);
-        deleteCredential(Csp.FLEXIBLE_ENGINE,"default", CredentialType.VARIABLES, "AK_SK");
+        deleteCredential(Csp.FLEXIBLE_ENGINE, "default", CredentialType.VARIABLES, "AK_SK");
     }
 
     void testServiceStateManageApisForOpenstack() throws Exception {
@@ -495,7 +495,7 @@ class ServiceStateManageApiTest extends ApisTestCommon {
         DeployServiceEntity service = setUpWellDeployServiceEntity(Csp.OPENSTACK_TESTLAB, region);
         when(mockDeployServiceStorage.findDeployServiceById(service.getId())).thenReturn(service);
         testServiceStateManageApisWithOpenstackSdk(service);
-        deleteCredential(Csp.OPENSTACK_TESTLAB,"default", CredentialType.VARIABLES,
+        deleteCredential(Csp.OPENSTACK_TESTLAB, "default", CredentialType.VARIABLES,
                 "USERNAME_PASSWORD");
     }
 

--- a/samples/compute/FlexibleEngine-Compute-terraform-dev.yml
+++ b/samples/compute/FlexibleEngine-Compute-terraform-dev.yml
@@ -28,7 +28,7 @@ serviceHostingType: self
 # The flavor of the service, the @category/@name/@version/@flavor can locate the specific service to be deployed.
 flavors:
   serviceFlavors:
-    - name: flavor-error-test
+    - name: 1vCPUs-1GB-normal
       priority: 3
       # The pricing of the flavor.
       pricing:

--- a/samples/compute/HuaweiCloud-Compute-opentofu-dev.yml
+++ b/samples/compute/HuaweiCloud-Compute-opentofu-dev.yml
@@ -38,7 +38,7 @@ serviceHostingType: self
 # The flavor of the service, the @category/@name/@version/@flavor can locate the specific service to be deployed.
 flavors:
   serviceFlavors:
-    - name: flavor-error-test
+    - name: 1vCPUs-1GB-normal
       priority: 3
       # The pricing of the flavor.
       pricing:

--- a/samples/compute/HuaweiCloud-Compute-terraform-dev-autofill.yml
+++ b/samples/compute/HuaweiCloud-Compute-terraform-dev-autofill.yml
@@ -38,7 +38,7 @@ serviceHostingType: self
 # The flavor of the service, the @category/@name/@version/@flavor can locate the specific service to be deployed.
 flavors:
   serviceFlavors:
-    - name: flavor-error-test
+    - name: 1vCPUs-1GB-normal
       priority: 3
       # The pricing of the flavor.
       pricing:

--- a/samples/compute/HuaweiCloud-Compute-terraform-dev-git-repo.yml
+++ b/samples/compute/HuaweiCloud-Compute-terraform-dev-git-repo.yml
@@ -38,7 +38,7 @@ serviceHostingType: self
 # The flavor of the service, the @category/@name/@version/@flavor can locate the specific service to be deployed.
 flavors:
   serviceFlavors:
-    - name: flavor-error-test
+    - name: 1vCPUs-1GB-normal
       priority: 3
       # The pricing of the flavor.
       pricing:

--- a/samples/compute/HuaweiCloud-Compute-terraform-dev.yml
+++ b/samples/compute/HuaweiCloud-Compute-terraform-dev.yml
@@ -38,7 +38,7 @@ serviceHostingType: self
 # The flavor of the service, the @category/@name/@version/@flavor can locate the specific service to be deployed.
 flavors:
   serviceFlavors:
-    - name: flavor-error-test
+    - name: 1vCPUs-1GB-normal
       priority: 3
       # The pricing of the flavor.
       pricing:


### PR DESCRIPTION
Fixed https://github.com/eclipse-xpanse/xpanse/issues/1922

Restart service with state `MODIFICATION SUCCESSFUL` successfully:
![image](https://github.com/user-attachments/assets/09078783-6c5f-4fa8-9bf3-b84375f8d804)

Stop service with state `MODIFICATION SUCCESSFUL` successfully:
![image](https://github.com/user-attachments/assets/ee78642d-61e8-4d40-92b8-37a5aaf75d28)

Start service with state `MODIFICATION SUCCESSFUL` successfully:
![image](https://github.com/user-attachments/assets/ac84dcc2-d1fa-4af3-a57b-60708f8785d4)
