### PR TITLE
extend OCL with deployer tool version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,10 @@ jobs:
         with:
           java-version: 21
           distribution: 'temurin'
+      - name: Set up Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: 1.6.0
       - name: Set up OpenTofu
         uses: opentofu/setup-opentofu@v1
         with:

--- a/modules/api/src/test/resources/ocl_terraform_test.yml
+++ b/modules/api/src/test/resources/ocl_terraform_test.yml
@@ -235,8 +235,11 @@ serviceProviderContactDetails:
   chats: [ "test1234","test1235" ]
   websites: [ "https://hw.com","https://hwcloud.com" ]
 deployment:
-  # kind, Supported values are terraform, opentofu.
-  kind: terraform
+  deployerTool:
+    # kind, Supported values are terraform, opentofu.
+    kind: terraform
+    # version, the required version of the deployer tool for the deployer scripts.
+    version: "=1.6.0"
   serviceAvailabilityConfigs:
     - displayName: Availability Zone
       varName: availability_zone

--- a/modules/database/src/test/resources/ocl_terraform_test.yml
+++ b/modules/database/src/test/resources/ocl_terraform_test.yml
@@ -235,8 +235,11 @@ serviceProviderContactDetails:
   chats: [ "test1234","test1235" ]
   websites: [ "https://hw.com","https://hwcloud.com" ]
 deployment:
-  # kind, Supported values are terraform, opentofu.
-  kind: terraform
+  deployerTool:
+    # kind, Supported values are terraform, opentofu.
+    kind: terraform
+    # version, the required version of the deployer tool for the deployer scripts.
+    version: "=1.6.0"
   serviceAvailabilityConfigs:
     - displayName: Availability Zone
       varName: availability_zone

--- a/modules/deployment/src/main/java/org/eclipse/xpanse/modules/deployment/DeployService.java
+++ b/modules/deployment/src/main/java/org/eclipse/xpanse/modules/deployment/DeployService.java
@@ -392,8 +392,8 @@ public class DeployService {
     private void deployService(DeployTask deployTask) {
         DeployResult deployResult;
         RuntimeException exception = null;
-        Deployer deployer =
-                deployerKindManager.getDeployment(deployTask.getOcl().getDeployment().getKind());
+        Deployer deployer = deployerKindManager.getDeployment(
+                deployTask.getOcl().getDeployment().getDeployerTool().getKind());
         ServiceOrderEntity orderTaskEntity =
                 serviceOrderManager.createServiceOrderTask(deployTask, null);
         DeployServiceEntity serviceEntity = storeNewDeployServiceEntity(deployTask);
@@ -428,8 +428,8 @@ public class DeployService {
                                  DeployServiceEntity deployServiceEntity) {
         DeployResult redeployResult;
         RuntimeException exception = null;
-        Deployer deployer =
-                deployerKindManager.getDeployment(redeployTask.getOcl().getDeployment().getKind());
+        Deployer deployer = deployerKindManager.getDeployment(
+                redeployTask.getOcl().getDeployment().getDeployerTool().getKind());
         ServiceOrderEntity orderTaskEntity =
                 serviceOrderManager.createServiceOrderTask(redeployTask, deployServiceEntity);
         try {
@@ -478,8 +478,8 @@ public class DeployService {
         DeployResult rollbackResult;
         RuntimeException exception = null;
         deployTask.setDeploymentScenario(DeploymentScenario.ROLLBACK);
-        Deployer deployer =
-                deployerKindManager.getDeployment(deployTask.getOcl().getDeployment().getKind());
+        Deployer deployer = deployerKindManager.getDeployment(
+                deployTask.getOcl().getDeployment().getDeployerTool().getKind());
         try {
             rollbackResult = deployer.destroy(deployTask);
         } catch (RuntimeException e) {
@@ -600,8 +600,8 @@ public class DeployService {
         RuntimeException exception = null;
         DeployResult modifyResult;
         MDC.put(SERVICE_ID, modifyTask.getServiceId().toString());
-        Deployer deployer =
-                deployerKindManager.getDeployment(modifyTask.getOcl().getDeployment().getKind());
+        Deployer deployer = deployerKindManager.getDeployment(
+                modifyTask.getOcl().getDeployment().getDeployerTool().getKind());
         ServiceOrderEntity orderTaskEntity =
                 serviceOrderManager.createServiceOrderTask(modifyTask, deployServiceEntity);
         try {
@@ -640,8 +640,8 @@ public class DeployService {
         MDC.put(SERVICE_ID, destroyTask.getServiceId().toString());
         ServiceOrderEntity orderTaskEntity =
                 serviceOrderManager.createServiceOrderTask(destroyTask, deployServiceEntity);
-        Deployer deployer =
-                deployerKindManager.getDeployment(destroyTask.getOcl().getDeployment().getKind());
+        Deployer deployer = deployerKindManager.getDeployment(
+                destroyTask.getOcl().getDeployment().getDeployerTool().getKind());
         try {
             if (DeploymentScenario.ROLLBACK != destroyTask.getDeploymentScenario()) {
                 deployServiceEntityHandler.updateServiceDeploymentStatus(deployServiceEntity,
@@ -684,7 +684,7 @@ public class DeployService {
                         purgeTask.getServiceId(), purgeTask.getOrderId());
                 purgeTask.setDeploymentScenario(DeploymentScenario.PURGE);
                 Deployer deployer = deployerKindManager.getDeployment(
-                        purgeTask.getOcl().getDeployment().getKind());
+                        purgeTask.getOcl().getDeployment().getDeployerTool().getKind());
                 deployServiceEntityHandler.updateServiceDeploymentStatus(deployServiceEntity,
                         ServiceDeploymentState.DESTROYING);
                 serviceOrderManager.startOrderProgress(purgeTask.getOrderId());

--- a/modules/deployment/src/main/java/org/eclipse/xpanse/modules/deployment/PolicyValidator.java
+++ b/modules/deployment/src/main/java/org/eclipse/xpanse/modules/deployment/PolicyValidator.java
@@ -87,9 +87,9 @@ public class PolicyValidator {
         if (CollectionUtils.isEmpty(userPolicies) && CollectionUtils.isEmpty(servicePolicies)) {
             return;
         }
-        String planJson =
-                deployerKindManager.getDeployment(deployTask.getOcl().getDeployment().getKind())
-                        .getDeploymentPlanAsJson(deployTask);
+        String planJson = deployerKindManager.getDeployment(
+                        deployTask.getOcl().getDeployment().getDeployerTool().getKind())
+                .getDeploymentPlanAsJson(deployTask);
         if (StringUtils.isEmpty(planJson)) {
             return;
         }

--- a/modules/deployment/src/main/java/org/eclipse/xpanse/modules/deployment/deployers/opentofu/callbacks/OpenTofuDeploymentResultCallbackManager.java
+++ b/modules/deployment/src/main/java/org/eclipse/xpanse/modules/deployment/deployers/opentofu/callbacks/OpenTofuDeploymentResultCallbackManager.java
@@ -28,6 +28,7 @@ import org.eclipse.xpanse.modules.deployment.migration.MigrationService;
 import org.eclipse.xpanse.modules.deployment.migration.consts.MigrateConstants;
 import org.eclipse.xpanse.modules.models.service.enums.DeployerTaskStatus;
 import org.eclipse.xpanse.modules.models.service.enums.ServiceDeploymentState;
+import org.eclipse.xpanse.modules.models.servicetemplate.enums.DeployerKind;
 import org.eclipse.xpanse.modules.orchestrator.deployment.DeployResult;
 import org.eclipse.xpanse.modules.orchestrator.deployment.DeployTask;
 import org.eclipse.xpanse.modules.orchestrator.deployment.DeploymentScenario;
@@ -124,8 +125,10 @@ public class OpenTofuDeploymentResultCallbackManager {
             ServiceTemplateEntity serviceTemplateEntity =
                     serviceTemplateStorage.getServiceTemplateById(
                             deployServiceEntity.getServiceTemplateId());
-            resourceHandlerManager.getResourceHandler(deployServiceEntity.getCsp(),
-                    serviceTemplateEntity.getOcl().getDeployment().getKind()).handler(deployResult);
+            DeployerKind deployerKind = serviceTemplateEntity.getOcl().getDeployment()
+                    .getDeployerTool().getKind();
+            resourceHandlerManager.getResourceHandler(deployServiceEntity.getCsp(), deployerKind)
+                    .handler(deployResult);
         }
         return deployResultManager.updateDeployServiceEntityWithDeployResult(deployResult,
                 deployServiceEntity);

--- a/modules/deployment/src/main/java/org/eclipse/xpanse/modules/deployment/deployers/terraform/callbacks/TerraformDeploymentResultCallbackManager.java
+++ b/modules/deployment/src/main/java/org/eclipse/xpanse/modules/deployment/deployers/terraform/callbacks/TerraformDeploymentResultCallbackManager.java
@@ -27,6 +27,7 @@ import org.eclipse.xpanse.modules.deployment.migration.MigrationService;
 import org.eclipse.xpanse.modules.deployment.migration.consts.MigrateConstants;
 import org.eclipse.xpanse.modules.models.service.enums.DeployerTaskStatus;
 import org.eclipse.xpanse.modules.models.service.enums.ServiceDeploymentState;
+import org.eclipse.xpanse.modules.models.servicetemplate.enums.DeployerKind;
 import org.eclipse.xpanse.modules.orchestrator.deployment.DeployResult;
 import org.eclipse.xpanse.modules.orchestrator.deployment.DeployTask;
 import org.eclipse.xpanse.modules.orchestrator.deployment.DeploymentScenario;
@@ -124,8 +125,10 @@ public class TerraformDeploymentResultCallbackManager {
             ServiceTemplateEntity serviceTemplateEntity =
                     serviceTemplateStorage.getServiceTemplateById(
                             deployServiceEntity.getServiceTemplateId());
-            resourceHandlerManager.getResourceHandler(deployServiceEntity.getCsp(),
-                    serviceTemplateEntity.getOcl().getDeployment().getKind()).handler(deployResult);
+            DeployerKind deployerKind = serviceTemplateEntity.getOcl().getDeployment()
+                    .getDeployerTool().getKind();
+            resourceHandlerManager.getResourceHandler(deployServiceEntity.getCsp(), deployerKind)
+                    .handler(deployResult);
         }
         return deployResultManager.updateDeployServiceEntityWithDeployResult(deployResult,
                 deployServiceEntity);

--- a/modules/deployment/src/test/java/org/eclipse/xpanse/modules/deployment/deployers/opentofu/opentofulocal/OpenTofuLocalDeploymentTest.java
+++ b/modules/deployment/src/test/java/org/eclipse/xpanse/modules/deployment/deployers/opentofu/opentofulocal/OpenTofuLocalDeploymentTest.java
@@ -109,11 +109,11 @@ class OpenTofuLocalDeploymentTest {
         OclLoader oclLoader = new OclLoader();
         ocl = oclLoader.getOcl(
                 URI.create("file:src/test/resources/ocl_terraform_test.yml").toURL());
-        ocl.getDeployment().setKind(DeployerKind.OPEN_TOFU);
+        ocl.getDeployment().getDeployerTool().setKind(DeployerKind.OPEN_TOFU);
 
         oclWithGitScripts = oclLoader.getOcl(
                 URI.create("file:src/test/resources/ocl_terraform_from_git_test.yml").toURL());
-        oclWithGitScripts.getDeployment().setKind(DeployerKind.OPEN_TOFU);
+        oclWithGitScripts.getDeployment().getDeployerTool().setKind(DeployerKind.OPEN_TOFU);
         doReturn(new HashMap<>()).when(this.deployEnvironments).getCredentialVariables(any());
     }
 

--- a/modules/deployment/src/test/java/org/eclipse/xpanse/modules/deployment/deployers/opentofu/opentofulocal/OpenTofuLocalExecutorTest.java
+++ b/modules/deployment/src/test/java/org/eclipse/xpanse/modules/deployment/deployers/opentofu/opentofulocal/OpenTofuLocalExecutorTest.java
@@ -47,7 +47,7 @@ class OpenTofuLocalExecutorTest {
         OclLoader oclLoader = new OclLoader();
         Ocl ocl = oclLoader.getOcl(
                         URI.create("file:src/test/resources/ocl_terraform_test.yml").toURL());
-        ocl.getDeployment().setKind(DeployerKind.OPEN_TOFU);
+        ocl.getDeployment().getDeployerTool().setKind(DeployerKind.OPEN_TOFU);
         String script = ocl.getDeployment().getDeployer();
         File ws = new File(workspace + "/" + UUID.randomUUID());
         ws.mkdirs();

--- a/modules/deployment/src/test/java/org/eclipse/xpanse/modules/deployment/deployers/opentofu/tofumaker/TofuMakerDeploymentTest.java
+++ b/modules/deployment/src/test/java/org/eclipse/xpanse/modules/deployment/deployers/opentofu/tofumaker/TofuMakerDeploymentTest.java
@@ -108,7 +108,7 @@ class TofuMakerDeploymentTest {
         OclLoader oclLoader = new OclLoader();
         ocl = oclLoader.getOcl(
                 URI.create("file:src/test/resources/ocl_terraform_test.yml").toURL());
-        ocl.getDeployment().setKind(DeployerKind.OPEN_TOFU);
+        ocl.getDeployment().getDeployerTool().setKind(DeployerKind.OPEN_TOFU);
 
         DeployRequest deployRequest = new DeployRequest();
         deployRequest.setServiceId(serviceId);

--- a/modules/deployment/src/test/resources/ocl_terraform_from_git_test.yml
+++ b/modules/deployment/src/test/resources/ocl_terraform_from_git_test.yml
@@ -235,8 +235,11 @@ serviceProviderContactDetails:
   chats: [ "test1234","test1235" ]
   websites: [ "https://hw.com","https://hwcloud.com" ]
 deployment:
-  # kind, Supported values are terraform, opentofu.
-  kind: terraform
+  deployerTool:
+    # kind, Supported values are terraform, opentofu.
+    kind: terraform
+    # version, the required version of the deployer tool for the deployer scripts.
+    version: "=1.6.0"
   serviceAvailabilityConfigs:
     - displayName: Availability Zone
       varName: availability_zone

--- a/modules/deployment/src/test/resources/ocl_terraform_test.yml
+++ b/modules/deployment/src/test/resources/ocl_terraform_test.yml
@@ -235,8 +235,11 @@ serviceProviderContactDetails:
   chats: [ "test1234","test1235" ]
   websites: [ "https://hw.com","https://hwcloud.com" ]
 deployment:
-  # kind, Supported values are terraform, opentofu.
-  kind: terraform
+  deployerTool:
+    # kind, Supported values are terraform, opentofu.
+    kind: terraform
+    # version, the required version of the deployer tool for the deployer scripts.
+    version: "=1.6.0"
   serviceAvailabilityConfigs:
     - displayName: Availability Zone
       varName: availability_zone

--- a/modules/models/src/main/java/org/eclipse/xpanse/modules/models/servicetemplate/DeployerTool.java
+++ b/modules/models/src/main/java/org/eclipse/xpanse/modules/models/servicetemplate/DeployerTool.java
@@ -1,0 +1,32 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * SPDX-FileCopyrightText: Huawei Inc.
+ */
+
+package org.eclipse.xpanse.modules.models.servicetemplate;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+import org.eclipse.xpanse.modules.models.servicetemplate.enums.DeployerKind;
+import org.eclipse.xpanse.modules.models.servicetemplate.validators.DeployerVersionConstraint;
+import org.springframework.validation.annotation.Validated;
+
+/**
+ * Defines the Deployer Tool.
+ */
+@Data
+@Validated
+public class DeployerTool {
+
+    @NotNull
+    @Schema(description = "The type of the deployer which will handle the service deployment.")
+    private DeployerKind kind;
+
+    @NotNull
+    @NotBlank
+    @DeployerVersionConstraint
+    @Schema(description = "The version of the deployer which will handle the service deployment.")
+    private String version;
+}

--- a/modules/models/src/main/java/org/eclipse/xpanse/modules/models/servicetemplate/Deployment.java
+++ b/modules/models/src/main/java/org/eclipse/xpanse/modules/models/servicetemplate/Deployment.java
@@ -15,7 +15,6 @@ import java.io.Serializable;
 import java.util.List;
 import lombok.Data;
 import org.eclipse.xpanse.modules.models.credential.enums.CredentialType;
-import org.eclipse.xpanse.modules.models.servicetemplate.enums.DeployerKind;
 import org.hibernate.validator.constraints.UniqueElements;
 import org.springframework.validation.annotation.Validated;
 
@@ -29,9 +28,10 @@ public class Deployment implements Serializable {
     @Serial
     private static final long serialVersionUID = 2566478948717883360L;
 
+    @Valid
     @NotNull
-    @Schema(description = "The type of the Deployer which will handle the service deployment")
-    private DeployerKind kind;
+    @Schema(description = "The deployer tool which will handle the service deployment.")
+    private DeployerTool deployerTool;
 
     @Valid
     @NotNull

--- a/modules/models/src/main/java/org/eclipse/xpanse/modules/models/servicetemplate/validators/DeployerVersionConstraint.java
+++ b/modules/models/src/main/java/org/eclipse/xpanse/modules/models/servicetemplate/validators/DeployerVersionConstraint.java
@@ -1,0 +1,39 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * SPDX-FileCopyrightText: Huawei Inc.
+ */
+
+package org.eclipse.xpanse.modules.models.servicetemplate.validators;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Bean validation for deployer version.
+ */
+@Documented
+@Constraint(validatedBy = DeployerVersionValidator.class)
+@Target({ElementType.METHOD, ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface DeployerVersionConstraint {
+
+    /**
+     * Message for invalid deployer version.
+     */
+    String message() default "Invalid deployer version.";
+
+    /**
+     * Classes which the constraint applies to.
+     */
+    Class<?>[] groups() default {};
+
+    /**
+     * Payload for the constraint.
+     */
+    Class<? extends Payload>[] payload() default {};
+}

--- a/modules/models/src/main/java/org/eclipse/xpanse/modules/models/servicetemplate/validators/DeployerVersionValidator.java
+++ b/modules/models/src/main/java/org/eclipse/xpanse/modules/models/servicetemplate/validators/DeployerVersionValidator.java
@@ -1,0 +1,41 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * SPDX-FileCopyrightText: Huawei Inc.
+ */
+
+package org.eclipse.xpanse.modules.models.servicetemplate.validators;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import java.util.regex.Pattern;
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * Validator for Deployer version.
+ */
+public class DeployerVersionValidator
+        implements ConstraintValidator<DeployerVersionConstraint, String> {
+
+
+    /**
+     * Regular expression for matching deployer version.
+     * This Pattern object is used to validate strings against a specific version number format.
+     * The version number format includes: =, >=, <=, followed by optional space and v/V,
+     * and then three numeric parts separated by dots.
+     */
+    private static final Pattern VERSION_PATTERN =
+            Pattern.compile("^(=|>=|<=)\\s*([vV])?\\d+\\.\\d+\\.\\d+$");
+
+    @Override
+    public void initialize(DeployerVersionConstraint constraintAnnotation) {
+        // No initialization required
+    }
+
+    @Override
+    public boolean isValid(String version, ConstraintValidatorContext context) {
+        if (StringUtils.isBlank(version)) {
+            return false;
+        }
+        return VERSION_PATTERN.matcher(version).matches();
+    }
+}

--- a/modules/models/src/test/java/org/eclipse/xpanse/modules/models/servicetemplate/DeployerToolTest.java
+++ b/modules/models/src/test/java/org/eclipse/xpanse/modules/models/servicetemplate/DeployerToolTest.java
@@ -1,0 +1,51 @@
+package org.eclipse.xpanse.modules.models.servicetemplate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.eclipse.xpanse.modules.models.servicetemplate.enums.DeployerKind;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.BeanUtils;
+
+class DeployerToolTest {
+
+    private final DeployerKind kind = DeployerKind.TERRAFORM;
+
+    private final String version = "=1.6.0";
+
+    private DeployerTool test;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        test = new DeployerTool();
+        test.setKind(kind);
+        test.setVersion(version);
+    }
+
+    @Test
+    void testGetters() {
+        assertEquals(kind, test.getKind());
+        assertEquals(version, test.getVersion());
+    }
+
+    @Test
+    void testEqualsAndHashCode() {
+        Object obj = new Object();
+        assertThat(test).isNotEqualTo(obj);
+        assertThat(test.hashCode()).isNotEqualTo(obj.hashCode());
+        DeployerTool test1 = new DeployerTool();
+        assertThat(test).isNotEqualTo(test1);
+        assertThat(test.hashCode()).isNotEqualTo(test1.hashCode());
+        DeployerTool test2 = new DeployerTool();
+        BeanUtils.copyProperties(test, test2);
+        assertThat(test).isEqualTo(test2);
+        assertThat(test.hashCode()).isEqualTo(test2.hashCode());
+    }
+
+    @Test
+    void testToString() {
+        String expectedString = "DeployerTool(kind=" + kind + ", version=" + version + ")";
+        assertEquals(expectedString, test.toString());
+    }
+}

--- a/modules/models/src/test/java/org/eclipse/xpanse/modules/models/servicetemplate/DeploymentTest.java
+++ b/modules/models/src/test/java/org/eclipse/xpanse/modules/models/servicetemplate/DeploymentTest.java
@@ -19,13 +19,12 @@ import org.springframework.beans.BeanUtils;
  * Test of Deployment.
  */
 class DeploymentTest {
-
-    private final DeployerKind kind = DeployerKind.TERRAFORM;
     private final String deployer = "deployer";
+    private final CredentialType credentialType = CredentialType.API_KEY;
+    private DeployerTool deployerTool;
     private ScriptsRepo scriptsRepo;
     private List<DeployVariable> variables;
     private List<AvailabilityZoneConfig> availabilityZoneConfigs;
-    private final CredentialType credentialType = CredentialType.API_KEY;
     private Deployment test;
 
     @BeforeEach
@@ -46,9 +45,13 @@ class DeploymentTest {
         scriptsRepo.setBranch("branch");
         scriptsRepo.setScriptsPath("scriptsPath");
 
+        deployerTool = new DeployerTool();
+        deployerTool.setKind(DeployerKind.TERRAFORM);
+        deployerTool.setVersion("=1.6.1");
+
         test = new Deployment();
-        test.setKind(kind);
         test.setDeployer(deployer);
+        test.setDeployerTool(deployerTool);
         test.setVariables(variables);
         test.setCredentialType(credentialType);
         test.setServiceAvailabilityConfigs(availabilityZoneConfigs);
@@ -56,8 +59,8 @@ class DeploymentTest {
     }
 
     @Test
-    void testGetterAndSetter() {
-        assertEquals(kind, test.getKind());
+    void testGetters() {
+        assertEquals(deployerTool, test.getDeployerTool());
         assertEquals(deployer, test.getDeployer());
         assertEquals(variables, test.getVariables());
         assertEquals(credentialType, test.getCredentialType());
@@ -88,8 +91,7 @@ class DeploymentTest {
 
     @Test
     void testToString() {
-        String expectedString = "Deployment(" +
-                "kind=" + kind +
+        String expectedString = "Deployment(deployerTool=" + deployerTool +
                 ", variables=" + variables +
                 ", credentialType=" + credentialType +
                 ", serviceAvailabilityConfigs=" + availabilityZoneConfigs +

--- a/modules/models/src/test/java/org/eclipse/xpanse/modules/models/servicetemplate/utils/OclLoaderTest.java
+++ b/modules/models/src/test/java/org/eclipse/xpanse/modules/models/servicetemplate/utils/OclLoaderTest.java
@@ -28,12 +28,13 @@ public class OclLoaderTest {
     OclLoader oclLoader;
 
     @Test
-    public void loading() throws Exception {
+    public void testGetOcl() throws Exception {
         Ocl ocl = oclLoader.getOcl(
                 new File("src/test/resources/ocl_terraform_test.yml").toURI().toURL());
         Assertions.assertNotNull(ocl);
         Assertions.assertEquals(Category.OTHERS, ocl.getCategory());
         Assertions.assertEquals("terraform-test", ocl.getName());
-        Assertions.assertEquals(DeployerKind.TERRAFORM, ocl.getDeployment().getKind());
+        Assertions.assertEquals(DeployerKind.TERRAFORM,
+                ocl.getDeployment().getDeployerTool().getKind());
     }
 }

--- a/modules/models/src/test/resources/ocl_terraform_test.yml
+++ b/modules/models/src/test/resources/ocl_terraform_test.yml
@@ -235,8 +235,11 @@ serviceProviderContactDetails:
   chats: [ "test1234","test1235" ]
   websites: [ "https://hw.com","https://hwcloud.com" ]
 deployment:
-  # kind, Supported values are terraform, opentofu.
-  kind: terraform
+  deployerTool:
+    # kind, Supported values are terraform, opentofu.
+    kind: terraform
+    # version, the required version of the deployer tool for the deployer scripts.
+    version: "=1.6.0"
   serviceAvailabilityConfigs:
     - displayName: Availability Zone
       varName: availability_zone

--- a/modules/servicetemplate/src/main/java/org/eclipse/xpanse/modules/servicetemplate/ServiceTemplateManage.java
+++ b/modules/servicetemplate/src/main/java/org/eclipse/xpanse/modules/servicetemplate/ServiceTemplateManage.java
@@ -419,10 +419,10 @@ public class ServiceTemplateManage {
 
 
     private void validateTerraformScript(Deployment deployment) {
-        if (deployment.getKind() == DeployerKind.TERRAFORM) {
+        DeployerKind deployerKind = deployment.getDeployerTool().getKind();
+        if (deployerKind == DeployerKind.TERRAFORM) {
             DeploymentScriptValidationResult tfValidationResult =
-                    this.deployerKindManager.getDeployment(deployment.getKind())
-                            .validate(deployment);
+                    this.deployerKindManager.getDeployment(deployerKind).validate(deployment);
             if (!tfValidationResult.isValid()) {
                 throw new TerraformScriptFormatInvalidException(
                         tfValidationResult.getDiagnostics().stream()
@@ -431,10 +431,9 @@ public class ServiceTemplateManage {
             }
         }
 
-        if (deployment.getKind() == DeployerKind.OPEN_TOFU) {
+        if (deployerKind == DeployerKind.OPEN_TOFU) {
             DeploymentScriptValidationResult tfValidationResult =
-                    this.deployerKindManager.getDeployment(deployment.getKind())
-                            .validate(deployment);
+                    this.deployerKindManager.getDeployment(deployerKind).validate(deployment);
             if (!tfValidationResult.isValid()) {
                 throw new OpenTofuScriptFormatInvalidException(
                         tfValidationResult.getDiagnostics().stream()

--- a/modules/servicetemplate/src/test/resources/ocl_terraform_test.yml
+++ b/modules/servicetemplate/src/test/resources/ocl_terraform_test.yml
@@ -235,8 +235,11 @@ serviceProviderContactDetails:
   chats: [ "test1234","test1235" ]
   websites: [ "https://hw.com","https://hwcloud.com" ]
 deployment:
-  # kind, Supported values are terraform, opentofu.
-  kind: terraform
+  deployerTool:
+    # kind, Supported values are terraform, opentofu.
+    kind: terraform
+    # version, the required version of the deployer tool for the deployer scripts.
+    version: "=1.6.0"
   serviceAvailabilityConfigs:
     - displayName: Availability Zone
       varName: availability_zone

--- a/runtime/src/test/java/org/eclipse/xpanse/runtime/ServiceDeployerApiTest.java
+++ b/runtime/src/test/java/org/eclipse/xpanse/runtime/ServiceDeployerApiTest.java
@@ -363,12 +363,12 @@ class ServiceDeployerApiTest extends ApisTestCommon {
         // Setup
         Ocl ocl = new OclLoader().getOcl(
                 URI.create("file:src/test/resources/ocl_terraform_test.yml").toURL());
-        ocl.getDeployment().setKind(DeployerKind.OPEN_TOFU);
+        ocl.getDeployment().getDeployerTool().setKind(DeployerKind.OPEN_TOFU);
         testDeployerWithOclAndPolicy(ocl);
 
         Ocl oclFromGit = new OclLoader().getOcl(
                 URI.create("file:src/test/resources/ocl_terraform_from_git_test.yml").toURL());
-        oclFromGit.getDeployment().setKind(DeployerKind.OPEN_TOFU);
+        oclFromGit.getDeployment().getDeployerTool().setKind(DeployerKind.OPEN_TOFU);
         testDeployerWithOclAndPolicy(oclFromGit);
     }
 

--- a/runtime/src/test/java/org/eclipse/xpanse/runtime/ServiceTemplateApiTest.java
+++ b/runtime/src/test/java/org/eclipse/xpanse/runtime/ServiceTemplateApiTest.java
@@ -373,6 +373,26 @@ class ServiceTemplateApiTest extends ApisTestCommon {
         assertEquals(HttpStatus.UNPROCESSABLE_ENTITY.value(), response.getStatus());
         assertEquals(result.getResultType(), ResultType.UNPROCESSABLE_ENTITY);
         assertFalse(result.getDetails().isEmpty());
+
+        Ocl oclTest = oclLoader.getOcl(
+                URI.create("file:src/test/resources/ocl_terraform_test.yml").toURL());
+        oclTest.getDeployment().getDeployerTool().setVersion(null);
+        // Run the test
+        final MockHttpServletResponse response1 = register(oclTest);
+        Response result1 = objectMapper.readValue(response1.getContentAsString(), Response.class);
+        // Verify the results
+        assertEquals(HttpStatus.UNPROCESSABLE_ENTITY.value(), response1.getStatus());
+        assertEquals(result1.getResultType(), ResultType.UNPROCESSABLE_ENTITY);
+        assertFalse(result1.getDetails().isEmpty());
+
+        oclTest.getDeployment().getDeployerTool().setVersion("> v1.6.0");
+        // Run the test
+        final MockHttpServletResponse response2 = register(oclTest);
+        Response result2 = objectMapper.readValue(response2.getContentAsString(), Response.class);
+        // Verify the results
+        assertEquals(HttpStatus.UNPROCESSABLE_ENTITY.value(), response2.getStatus());
+        assertEquals(result2.getResultType(), ResultType.UNPROCESSABLE_ENTITY);
+        assertFalse(result2.getDetails().isEmpty());
     }
 
     void testRegisterThrowsPluginNotFoundException() throws Exception {

--- a/runtime/src/test/java/org/eclipse/xpanse/runtime/TerraformBootWebhookApiTest.java
+++ b/runtime/src/test/java/org/eclipse/xpanse/runtime/TerraformBootWebhookApiTest.java
@@ -19,6 +19,7 @@ import com.c4_soft.springaddons.security.oauth2.test.annotations.WithJwt;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.net.URI;
 import java.util.Collections;
+import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
@@ -86,10 +87,10 @@ public class TerraformBootWebhookApiTest extends ApisTestCommon {
     void testTerraformBootWebhookApisThrowsException() throws Exception {
         // Setup
         UUID uuid = UUID.randomUUID();
+        ResultType expectedResultType = ResultType.SERVICE_DEPLOYMENT_NOT_FOUND;
+        String errorMsg = String.format("Service with id %s not found.", uuid);
+        List<String> expectedDetails = Collections.singletonList(errorMsg);
         TerraformResult deployResult = getTerraformResultByFile("deploy_success_callback.json");
-        Response deployCallbackResult = Response.errorResponse(
-                ResultType.SERVICE_DEPLOYMENT_NOT_FOUND,
-                Collections.singletonList(String.format("Service with id %s not found.", uuid)));
         // Run the test
         final MockHttpServletResponse deployCallbackResponse = mockMvc.perform(
                         post("/webhook/terraform-boot/deploy/{serviceId}", uuid)
@@ -99,8 +100,10 @@ public class TerraformBootWebhookApiTest extends ApisTestCommon {
                 .andReturn().getResponse();
         // Verify the results
         assertEquals(HttpStatus.BAD_REQUEST.value(), deployCallbackResponse.getStatus());
-        assertEquals(objectMapper.writeValueAsString(deployCallbackResult),
-                deployCallbackResponse.getContentAsString());
+        Response deployCallbackResult =
+                objectMapper.readValue(deployCallbackResponse.getContentAsString(), Response.class);
+        assertEquals(deployCallbackResult.getResultType(), expectedResultType);
+        assertEquals(deployCallbackResult.getDetails(), expectedDetails);
 
         // Run the test
         final MockHttpServletResponse modifyCallbackResponse = mockMvc.perform(
@@ -111,14 +114,13 @@ public class TerraformBootWebhookApiTest extends ApisTestCommon {
                 .andReturn().getResponse();
         // Verify the results
         assertEquals(HttpStatus.BAD_REQUEST.value(), modifyCallbackResponse.getStatus());
-        assertEquals(objectMapper.writeValueAsString(deployCallbackResult),
-                modifyCallbackResponse.getContentAsString());
+        Response modifyCallbackResult =
+                objectMapper.readValue(modifyCallbackResponse.getContentAsString(), Response.class);
+        assertEquals(modifyCallbackResult.getResultType(), expectedResultType);
+        assertEquals(modifyCallbackResult.getDetails(), expectedDetails);
 
         // Setup
         TerraformResult destroyResult = getTerraformResultByFile("destroy_success_callback.json");
-        Response destroyCallbackResult = Response.errorResponse(
-                ResultType.SERVICE_DEPLOYMENT_NOT_FOUND,
-                Collections.singletonList(String.format("Service with id %s not found.", uuid)));
         // Run the test
         final MockHttpServletResponse destroyCallbackResponse = mockMvc.perform(
                         post("/webhook/terraform-boot/destroy/{serviceId}", uuid)
@@ -128,8 +130,10 @@ public class TerraformBootWebhookApiTest extends ApisTestCommon {
                 .andReturn().getResponse();
         // Verify the results
         assertEquals(HttpStatus.BAD_REQUEST.value(), destroyCallbackResponse.getStatus());
-        assertEquals(objectMapper.writeValueAsString(destroyCallbackResult),
-                destroyCallbackResponse.getContentAsString());
+        Response destroyCallbackResult = objectMapper.readValue(
+                destroyCallbackResponse.getContentAsString(), Response.class);
+        assertEquals(destroyCallbackResult.getResultType(), expectedResultType);
+        assertEquals(destroyCallbackResult.getDetails(), expectedDetails);
 
         // Run the test
         final MockHttpServletResponse rollbackCallbackResponse = mockMvc.perform(
@@ -140,8 +144,10 @@ public class TerraformBootWebhookApiTest extends ApisTestCommon {
                 .andReturn().getResponse();
         // Verify the results
         assertEquals(HttpStatus.BAD_REQUEST.value(), rollbackCallbackResponse.getStatus());
-        assertEquals(objectMapper.writeValueAsString(destroyCallbackResult),
-                rollbackCallbackResponse.getContentAsString());
+        Response rollbackCallbackResult = objectMapper.readValue(
+                rollbackCallbackResponse.getContentAsString(), Response.class);
+        assertEquals(rollbackCallbackResult.getResultType(), expectedResultType);
+        assertEquals(rollbackCallbackResult.getDetails(), expectedDetails);
 
 
         // Run the test
@@ -153,8 +159,10 @@ public class TerraformBootWebhookApiTest extends ApisTestCommon {
                 .andReturn().getResponse();
         // Verify the results
         assertEquals(HttpStatus.BAD_REQUEST.value(), purgeCallbackResponse.getStatus());
-        assertEquals(objectMapper.writeValueAsString(destroyCallbackResult),
-                purgeCallbackResponse.getContentAsString());
+        Response purgeCallbackResult =
+                objectMapper.readValue(purgeCallbackResponse.getContentAsString(), Response.class);
+        assertEquals(purgeCallbackResult.getResultType(), expectedResultType);
+        assertEquals(purgeCallbackResult.getDetails(), expectedDetails);
     }
 
     void testTerraformBootWebhookApisWell() throws Exception {

--- a/runtime/src/test/resources/ocl_terraform_from_git_test.yml
+++ b/runtime/src/test/resources/ocl_terraform_from_git_test.yml
@@ -235,8 +235,11 @@ serviceProviderContactDetails:
   chats: [ "test1234","test1235" ]
   websites: [ "https://hw.com","https://hwcloud.com" ]
 deployment:
-  # kind, Supported values are terraform, opentofu.
-  kind: terraform
+  deployerTool:
+    # kind, Supported values are terraform, opentofu.
+    kind: terraform
+    # version, the required version of the deployer tool for the deployer scripts.
+    version: "=1.6.0"
   serviceAvailabilityConfigs:
     - displayName: Availability Zone
       varName: availability_zone

--- a/runtime/src/test/resources/ocl_terraform_kafka_test.yml
+++ b/runtime/src/test/resources/ocl_terraform_kafka_test.yml
@@ -349,8 +349,11 @@ serviceConfigurationManage:
         isServiceInterrupted: true
       isReadOnly: false
 deployment:
-  # kind, Supported values are terraform, opentofu.
-  kind: terraform
+  deployerTool:
+    # kind, Supported values are terraform, opentofu.
+    kind: terraform
+    # version, the required version of the deployer tool for the deployer scripts.
+    version: "=1.6.0"
   serviceAvailabilityConfigs:
     - displayName: Availability Zone
       varName: availability_zone

--- a/runtime/src/test/resources/ocl_terraform_test.yml
+++ b/runtime/src/test/resources/ocl_terraform_test.yml
@@ -235,8 +235,11 @@ serviceProviderContactDetails:
   chats: [ "test1234","test1235" ]
   websites: [ "https://hw.com","https://hwcloud.com" ]
 deployment:
-  # kind, Supported values are terraform, opentofu.
-  kind: terraform
+  deployerTool:
+    # kind, Supported values are terraform, opentofu.
+    kind: terraform
+    # version, the required version of the deployer tool for the deployer scripts.
+    version: "=1.6.0"
   serviceAvailabilityConfigs:
     - displayName: Availability Zone
       varName: availability_zone

--- a/samples/compute/FlexibleEngine-Compute-terraform-dev.yml
+++ b/samples/compute/FlexibleEngine-Compute-terraform-dev.yml
@@ -93,8 +93,11 @@ flavors:
 serviceProviderContactDetails:
   emails: [ "test@test.com" ]
 deployment:
-  # kind, Supported values are terraform, opentofu.
-  kind: terraform
+  deployerTool:
+    # kind, Supported values are terraform, opentofu.
+    kind: terraform
+    # version, the required version of the deployer tool for the deployer scripts.
+    version: "=1.6.0"
   serviceAvailabilityConfigs:
     - displayName: Availability Zone
       varName: availability_zone

--- a/samples/compute/HuaweiCloud-Compute-opentofu-dev.yml
+++ b/samples/compute/HuaweiCloud-Compute-opentofu-dev.yml
@@ -347,8 +347,11 @@ eula: |
   9. Distribute, disseminate or send unsolicited email, bulk email or other messages, promotions, advertising or solicitations (such as "spam");
   10. Fraudulent offers of goods or services, or any advertising, promotional or other materials containing false, deceptive or misleading statements.
 deployment:
-  # kind, Supported values are terraform, opentofu.
-  kind: opentofu
+  deployerTool:
+    # kind, Supported values are terraform, opentofu.
+    kind: opentofu
+    # version, the required version of the deployer tool for the deployer scripts.
+    version: "=1.6.0"
   serviceAvailabilityConfigs:
     - displayName: Availability Zone
       varName: availability_zone

--- a/samples/compute/HuaweiCloud-Compute-terraform-dev-autofill.yml
+++ b/samples/compute/HuaweiCloud-Compute-terraform-dev-autofill.yml
@@ -328,8 +328,11 @@ flavors:
 serviceProviderContactDetails:
   emails: [ "test@test.com" ]
 deployment:
-  # kind, Supported values are terraform, opentofu.
-  kind: terraform
+  deployerTool:
+    # kind, Supported values are terraform, opentofu.
+    kind: terraform
+    # version, the required version of the deployer tool for the deployer scripts.
+    version: "=1.6.0"
   serviceAvailabilityConfigs:
     - displayName: Availability Zone
       varName: availability_zone

--- a/samples/compute/HuaweiCloud-Compute-terraform-dev.yml
+++ b/samples/compute/HuaweiCloud-Compute-terraform-dev.yml
@@ -347,8 +347,11 @@ eula: |
   9. Distribute, disseminate or send unsolicited email, bulk email or other messages, promotions, advertising or solicitations (such as "spam");
   10. Fraudulent offers of goods or services, or any advertising, promotional or other materials containing false, deceptive or misleading statements.
 deployment:
-  # kind, Supported values are terraform, opentofu.
-  kind: terraform
+  deployerTool:
+    # kind, Supported values are terraform, opentofu.
+    kind: terraform
+    # version, the required version of the deployer tool for the deployer scripts.
+    version: "=1.6.0"
   serviceAvailabilityConfigs:
     - displayName: Availability Zone
       varName: availability_zone

--- a/samples/compute/OpenstackTestLab-Compute-terraform-dev.yml
+++ b/samples/compute/OpenstackTestLab-Compute-terraform-dev.yml
@@ -77,8 +77,11 @@ flavors:
 serviceProviderContactDetails:
   emails: [ "test@test.com" ]
 deployment:
-  # kind, Supported values are terraform, opentofu.
-  kind: terraform
+  deployerTool:
+    # kind, Supported values are terraform, opentofu.
+    kind: terraform
+    # version, the required version of the deployer tool for the deployer scripts.
+    version: ""
   serviceAvailabilityConfigs:
     - displayName: Availability Zone
       varName: availability_zone

--- a/samples/compute/PlusServer-Compute-terraform-dev.yml
+++ b/samples/compute/PlusServer-Compute-terraform-dev.yml
@@ -77,8 +77,11 @@ flavors:
 serviceProviderContactDetails:
   emails: [ "test@test.com" ]
 deployment:
-  # kind, Supported values are terraform, opentofu.
-  kind: terraform
+  deployerTool:
+    # kind, Supported values are terraform, opentofu.
+    kind: terraform
+    # version, the required version of the deployer tool for the deployer scripts.
+    version: "=1.6.0"
   serviceAvailabilityConfigs:
     - displayName: Availability Zone
       varName: availability_zone

--- a/samples/compute/RegioCloud-Compute-terraform-dev.yml
+++ b/samples/compute/RegioCloud-Compute-terraform-dev.yml
@@ -77,8 +77,11 @@ flavors:
 serviceProviderContactDetails:
   emails: [ "test@test.com" ]
 deployment:
-  # kind, Supported values are terraform, opentofu.
-  kind: terraform
+  deployerTool:
+    # kind, Supported values are terraform, opentofu.
+    kind: terraform
+    # version, the required version of the deployer tool for the deployer scripts.
+    version: "=1.6.0"
   serviceAvailabilityConfigs:
     - displayName: Availability Zone
       varName: availability_zone

--- a/samples/container/HuaweiCloud-K8S-autofill.yml
+++ b/samples/container/HuaweiCloud-K8S-autofill.yml
@@ -139,8 +139,11 @@ flavors:
 serviceProviderContactDetails:
   emails: [ "test@test.com" ]
 deployment:
-  # kind, Supported values are terraform, opentofu.
-  kind: terraform
+  deployerTool:
+    # kind, Supported values are terraform, opentofu.
+    kind: terraform
+    # version, the required version of the deployer tool for the deployer scripts.
+    version: "=1.6.0"
   serviceAvailabilityConfigs:
     - displayName: Availability Zone
       varName: availability_zone

--- a/samples/container/HuaweiCloud-K8S.yml
+++ b/samples/container/HuaweiCloud-K8S.yml
@@ -139,8 +139,11 @@ flavors:
 serviceProviderContactDetails:
   emails: [ "test@test.com" ]
 deployment:
-  # kind, Supported values are terraform, opentofu.
-  kind: terraform
+  deployerTool:
+    # kind, Supported values are terraform, opentofu.
+    kind: terraform
+    # version, the required version of the deployer tool for the deployer scripts.
+    version: "=1.6.0"
   serviceAvailabilityConfigs:
     - displayName: Availability Zone
       varName: availability_zone

--- a/samples/container/flexibleEngine-K8S.yml
+++ b/samples/container/flexibleEngine-K8S.yml
@@ -73,8 +73,11 @@ flavors:
 serviceProviderContactDetails:
   emails: [ "test@test.com" ]
 deployment:
-  # kind, Supported values are terraform, opentofu.
-  kind: terraform
+  deployerTool:
+    # kind, Supported values are terraform, opentofu.
+    kind: terraform
+    # version, the required version of the deployer tool for the deployer scripts.
+    version: "=1.6.0"
   serviceAvailabilityConfigs:
     - displayName: Availability Zone
       varName: availability_zone

--- a/samples/database/HuaweiCloud-MySql.yml
+++ b/samples/database/HuaweiCloud-MySql.yml
@@ -155,8 +155,11 @@ flavors:
 serviceProviderContactDetails:
   emails: [ "test@test.com" ]
 deployment:
-  # kind, Supported values are terraform, opentofu.
-  kind: terraform
+  deployerTool:
+    # kind, Supported values are terraform, opentofu.
+    kind: terraform
+    # version, the required version of the deployer tool for the deployer scripts.
+    version: "=1.6.0"
   serviceAvailabilityConfigs:
     - displayName: Primary AZ
       varName: primary_az

--- a/samples/middleware/HuaweiCloud-Kafka-autofill.yml
+++ b/samples/middleware/HuaweiCloud-Kafka-autofill.yml
@@ -252,8 +252,11 @@ serviceConfigurationManage:
         isServiceInterrupted: true
       isReadOnly: false
 deployment:
-  # kind, Supported values are terraform, opentofu.
-  kind: terraform
+  deployerTool:
+    # kind, Supported values are terraform, opentofu.
+    kind: terraform
+    # version, the required version of the deployer tool for the deployer scripts.
+    version: "=1.6.0"
   serviceAvailabilityConfigs:
     - displayName: Availability Zone
       varName: availability_zone

--- a/samples/middleware/HuaweiCloud-Kafka-terraform_module.yml
+++ b/samples/middleware/HuaweiCloud-Kafka-terraform_module.yml
@@ -252,8 +252,11 @@ serviceConfigurationManage:
         isServiceInterrupted: true
       isReadOnly: false
 deployment:
-  # kind, Supported values are terraform, opentofu.
-  kind: terraform
+  deployerTool:
+    # kind, Supported values are terraform, opentofu.
+    kind: terraform
+    # version, the required version of the deployer tool for the deployer scripts.
+    version: "=1.6.0"
   serviceAvailabilityConfigs:
     - displayName: Availability Zone
       varName: availability_zone

--- a/samples/middleware/HuaweiCloud-Kafka.yml
+++ b/samples/middleware/HuaweiCloud-Kafka.yml
@@ -255,8 +255,11 @@ serviceConfigurationManage:
         isServiceInterrupted: true
       isReadOnly: false
 deployment:
-  # kind, Supported values are terraform, opentofu.
-  kind: terraform
+  deployerTool:
+    # kind, Supported values are terraform, opentofu.
+    kind: terraform
+    # version, the required version of the deployer tool for the deployer scripts.
+    version: "=1.6.0"
   serviceAvailabilityConfigs:
     - displayName: Availability Zone
       varName: availability_zone

--- a/samples/middleware/OpenstackTestLab-Kafka.yml
+++ b/samples/middleware/OpenstackTestLab-Kafka.yml
@@ -190,8 +190,11 @@ serviceConfigurationManage:
         isServiceInterrupted: true
       isReadOnly: false
 deployment:
-  # kind, Supported values are terraform, opentofu.
-  kind: terraform
+  deployerTool:
+    # kind, Supported values are terraform, opentofu.
+    kind: terraform
+    # version, the required version of the deployer tool for the deployer scripts.
+    version: "=1.6.0"
   serviceAvailabilityConfigs:
     - displayName: Availability Zone
       varName: availability_zone

--- a/samples/middleware/PlusServer-Kafka.yml
+++ b/samples/middleware/PlusServer-Kafka.yml
@@ -192,8 +192,11 @@ serviceConfigurationManage:
         isServiceInterrupted: true
       isReadOnly: false
 deployment:
-  # kind, Supported values are terraform, opentofu.
-  kind: terraform
+  deployerTool:
+    # kind, Supported values are terraform, opentofu.
+    kind: terraform
+    # version, the required version of the deployer tool for the deployer scripts.
+    version: "=1.6.0"
   serviceAvailabilityConfigs:
     - displayName: Availability Zone
       varName: availability_zone

--- a/samples/middleware/RegioCloud-Kafka.yml
+++ b/samples/middleware/RegioCloud-Kafka.yml
@@ -192,8 +192,11 @@ serviceConfigurationManage:
         isServiceInterrupted: true
       isReadOnly: false
 deployment:
-  # kind, Supported values are terraform, opentofu.
-  kind: terraform
+  deployerTool:
+    # kind, Supported values are terraform, opentofu.
+    kind: terraform
+    # version, the required version of the deployer tool for the deployer scripts.
+    version: "=1.6.0"
   serviceAvailabilityConfigs:
     - displayName: Availability Zone
       varName: availability_zone

--- a/samples/middleware/flexibleEngine-Kafka.yml
+++ b/samples/middleware/flexibleEngine-Kafka.yml
@@ -186,8 +186,11 @@ serviceConfigurationManage:
         isServiceInterrupted: true
       isReadOnly: false
 deployment:
-  # kind, Supported values are terraform, opentofu.
-  kind: terraform
+  deployerTool:
+    # kind, Supported values are terraform, opentofu.
+    kind: terraform
+    # version, the required version of the deployer tool for the deployer scripts.
+    version: "=1.6.0"
   serviceAvailabilityConfigs:
     - displayName: Availability Zone
       varName: availability_zone


### PR DESCRIPTION
**Fixed https://github.com/eclipse-xpanse/xpanse/issues/1940**

**Register service successfully:**
![image](https://github.com/user-attachments/assets/f1cebb87-6770-45b2-8516-b3faa7c43eee)

**Register services failed by invalid version of `deployerTool`:**
version of `deployerTool` is null:
![image](https://github.com/user-attachments/assets/e6c5e315-45c9-4031-866b-5de69aa3193c)
invalid version without comparing symbols:
![image](https://github.com/user-attachments/assets/edb71f4e-f204-47a9-8b61-c164b2a1b0ad)
version with invalid comparing symbols:
![image](https://github.com/user-attachments/assets/9e773ce4-3c51-4374-8ae1-79d9ac77d06a)
version with invalid version number:
![image](https://github.com/user-attachments/assets/afacde51-bdcd-4463-b3ea-ba2eca11cca5)




