### PR TITLE
Optimize method for initializing cache of versions of the deployer tool

### DIFF
--- a/modules/deployment/src/main/java/org/eclipse/xpanse/modules/deployment/deployers/deployertools/DeployerToolVersionsCache.java
+++ b/modules/deployment/src/main/java/org/eclipse/xpanse/modules/deployment/deployers/deployertools/DeployerToolVersionsCache.java
@@ -36,6 +36,8 @@ public class DeployerToolVersionsCache {
         try {
             return versionsFetcher.fetchOfficialVersionsOfDeployerTool(deployerKind);
         } catch (Exception e) {
+            log.error("Failed to fetch versions from website for deploy tool {}, get "
+                    + "versions from default config.", deployerKind.toValue(), e);
             return versionsFetcher.getVersionsFromDefaultConfigOfDeployerTool(deployerKind);
         }
     }
@@ -51,7 +53,6 @@ public class DeployerToolVersionsCache {
         log.info("Updated versions cache of deployer:{} with versions:{}.",
                 deployerKind.toValue(), versions);
     }
-
 
 
 }

--- a/modules/deployment/src/main/java/org/eclipse/xpanse/modules/deployment/deployers/deployertools/DeployerToolVersionsFetcher.java
+++ b/modules/deployment/src/main/java/org/eclipse/xpanse/modules/deployment/deployers/deployertools/DeployerToolVersionsFetcher.java
@@ -5,13 +5,17 @@
 
 package org.eclipse.xpanse.modules.deployment.deployers.deployertools;
 
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.net.URL;
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Set;
 import java.util.regex.Pattern;
 import javax.annotation.Nonnull;
 import lombok.extern.slf4j.Slf4j;
 import org.eclipse.xpanse.modules.models.common.exceptions.ClientApiCallFailedException;
-import org.eclipse.xpanse.modules.models.common.exceptions.InvalidDeployerToolException;
 import org.eclipse.xpanse.modules.models.servicetemplate.enums.DeployerKind;
 import org.kohsuke.github.GHRepository;
 import org.kohsuke.github.GHTag;
@@ -21,8 +25,11 @@ import org.kohsuke.github.GitHubRateLimitHandler;
 import org.kohsuke.github.PagedIterable;
 import org.kohsuke.github.connector.GitHubConnectorResponse;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
 import org.springframework.retry.annotation.Backoff;
 import org.springframework.retry.annotation.Retryable;
+import org.springframework.retry.support.RetrySynchronizationManager;
 import org.springframework.stereotype.Component;
 
 /**
@@ -54,33 +61,47 @@ public class DeployerToolVersionsFetcher {
      *
      * @return all available versions.
      */
-    @Retryable(retryFor = Exception.class,
+    @Retryable(retryFor = ClientApiCallFailedException.class,
             maxAttemptsExpression = "${http.request.retry.max.attempts}",
             backoff = @Backoff(delayExpression = "${http.request.retry.delay.milliseconds}"))
-    public Set<String> fetchOfficialVersionsOfDeployerTool(DeployerKind deployerKind)
-            throws Exception {
+    public Set<String> fetchOfficialVersionsOfDeployerTool(DeployerKind deployerKind) {
+        int retryCount = Objects.isNull(RetrySynchronizationManager.getContext())
+                ? 0 : RetrySynchronizationManager.getContext().getRetryCount();
+        log.info("Start to fetch available versions from website for deployer tool {}."
+                + " Retry count: {}", deployerKind.toValue(), retryCount);
         Set<String> allVersions = new HashSet<>();
-        String apiEndpoint = getGithubApiEndpoint(deployerKind);
-        String githubRepository = getGithubRepository(deployerKind);
-        GitHub gitHub = new GitHubBuilder()
-                .withEndpoint(apiEndpoint)
-                .withRateLimitHandler(getGithubRateLimitHandler())
-                .build();
-        GHRepository repository = gitHub.getRepository(githubRepository);
-        PagedIterable<GHTag> tags = repository.listTags();
-        tags.forEach(tag -> {
-            String version = tag.getName();
-            if (OFFICIAL_VERSION_PATTERN.matcher(version).matches()) {
-                // remove the prefix 'v'
-                allVersions.add(version.substring(1));
+        try {
+            String apiEndpoint = getGithubApiEndpoint(deployerKind);
+            if (!isEndpointReachable(apiEndpoint)) {
+                throw new ClientApiCallFailedException(
+                        String.format("Endpoint %s is not reachable.", apiEndpoint));
             }
-        });
-        log.info("Get available versions {} from website for deployer tool {}.", allVersions,
-                deployerKind.toValue());
+            String githubRepository = getGithubRepository(deployerKind);
+            GitHub gitHub = new GitHubBuilder()
+                    .withEndpoint(apiEndpoint)
+                    .withRateLimitHandler(getGithubRateLimitHandler())
+                    .build();
+            GHRepository repository = gitHub.getRepository(githubRepository);
+            PagedIterable<GHTag> tags = repository.listTags();
+            tags.forEach(tag -> {
+                String version = tag.getName();
+                if (OFFICIAL_VERSION_PATTERN.matcher(version).matches()) {
+                    // remove the prefix 'v'
+                    allVersions.add(version.substring(1));
+                }
+            });
+        } catch (Exception e) {
+            String errorMsg = String.format("Failed to fetch available versions from website for "
+                    + "deployer tool %s.", deployerKind.toValue());
+            log.error(errorMsg + " Retry count: " + retryCount, e.getMessage());
+            throw new ClientApiCallFailedException(errorMsg);
+        }
+        log.info("Get available versions {} from website for deployer tool {}."
+                + " Retry count: {}", allVersions, deployerKind.toValue(), retryCount);
         if (allVersions.isEmpty()) {
-            String errorMsg = String.format("No available versions found from website for deployer "
-                    + "tool %s", deployerKind.toValue());
-            throw new InvalidDeployerToolException(errorMsg);
+            String errorMsg = String.format("No available versions found from website for "
+                    + "deployer tool %s", deployerKind.toValue());
+            throw new ClientApiCallFailedException(errorMsg);
         }
         return allVersions;
     }
@@ -106,6 +127,19 @@ public class DeployerToolVersionsFetcher {
             case OPEN_TOFU -> openTofuGithubApiEndpoint;
         };
     }
+
+    private boolean isEndpointReachable(String endpoint) throws IOException {
+        try {
+            URL url = URI.create(endpoint).toURL();
+            HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+            connection.setConnectTimeout(10000);
+            connection.setRequestMethod(HttpMethod.HEAD.name());
+            return connection.getResponseCode() == HttpStatus.OK.value();
+        } catch (IOException e) {
+            throw new IOException("Failed to connect to the endpoint: " + endpoint);
+        }
+    }
+
 
     private String getGithubRepository(DeployerKind deployerKind) {
         return switch (deployerKind) {


### PR DESCRIPTION
Fixed https://github.com/eclipse-xpanse/xpanse/issues/2089

Related to https://github.com/eclipse-xpanse/tofu-maker/pull/78 and  https://github.com/eclipse-xpanse/terraform-boot/pull/159

Initializing versions cache after the application started:
![image](https://github.com/user-attachments/assets/ed74c334-0a15-4c58-abf6-42236c4bc9b7)
