### PR TITLE
Add new table SERVICE_TEMPLATE_HISTORY

### DIFF
--- a/modules/api/src/test/java/org/eclipse/xpanse/api/config/ServiceTemplateRegistrationStateConverterTest.java
+++ b/modules/api/src/test/java/org/eclipse/xpanse/api/config/ServiceTemplateRegistrationStateConverterTest.java
@@ -15,7 +15,7 @@ class ServiceTemplateRegistrationStateConverterTest {
     @Test
     void testConvert() {
         assertEquals(ServiceTemplateRegistrationState.IN_PROGRESS,
-                converterTest.convert("inProgress"));
+                converterTest.convert("in-progress"));
         assertEquals(ServiceTemplateRegistrationState.APPROVED, converterTest.convert("approved"));
         assertEquals(ServiceTemplateRegistrationState.REJECTED, converterTest.convert("rejected"));
         assertThrows(UnsupportedEnumValueException.class,

--- a/modules/api/src/test/java/org/eclipse/xpanse/api/config/TaskStatusEnumConverterTest.java
+++ b/modules/api/src/test/java/org/eclipse/xpanse/api/config/TaskStatusEnumConverterTest.java
@@ -15,7 +15,7 @@ class TaskStatusEnumConverterTest {
     @Test
     void testConvert() {
         assertThat(converterTest.convert("created")).isEqualTo(TaskStatus.CREATED);
-        assertThat(converterTest.convert("in progress")).isEqualTo(TaskStatus.IN_PROGRESS);
+        assertThat(converterTest.convert("in-progress")).isEqualTo(TaskStatus.IN_PROGRESS);
         assertThat(converterTest.convert("successful")).isEqualTo(TaskStatus.SUCCESSFUL);
         assertThat(converterTest.convert("failed")).isEqualTo(TaskStatus.FAILED);
         assertThrows(UnsupportedEnumValueException.class, () -> converterTest.convert("unknown"));

--- a/modules/database/src/main/java/org/eclipse/xpanse/modules/database/servicetemplate/ServiceTemplateEntity.java
+++ b/modules/database/src/main/java/org/eclipse/xpanse/modules/database/servicetemplate/ServiceTemplateEntity.java
@@ -25,6 +25,7 @@ import lombok.ToString;
 import org.eclipse.xpanse.modules.database.common.CreateModifiedTime;
 import org.eclipse.xpanse.modules.database.common.ObjectJsonConverter;
 import org.eclipse.xpanse.modules.database.servicepolicy.ServicePolicyEntity;
+import org.eclipse.xpanse.modules.database.servicetemplatehistory.ServiceTemplateHistoryEntity;
 import org.eclipse.xpanse.modules.models.common.enums.Category;
 import org.eclipse.xpanse.modules.models.common.enums.Csp;
 import org.eclipse.xpanse.modules.models.servicetemplate.Ocl;
@@ -86,9 +87,6 @@ public class ServiceTemplateEntity extends CreateModifiedTime {
     @Column(name = "AVAILABLE_IN_CATALOG", nullable = false)
     private Boolean availableInCatalog;
 
-    @Column(name = "REVIEW_COMMENT", length = Integer.MAX_VALUE)
-    private String reviewComment;
-
     @Column(name = "SERVICE_PROVIDER_CONTACT_DETAILS", columnDefinition = "json", nullable = false)
     @Type(value = JsonType.class)
     @Convert(converter = ObjectJsonConverter.class)
@@ -99,8 +97,12 @@ public class ServiceTemplateEntity extends CreateModifiedTime {
     @Convert(converter = ObjectJsonConverter.class)
     private JsonObjectSchema jsonObjectSchema;
 
-    @OneToMany(mappedBy = "serviceTemplate", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "serviceTemplate", cascade = CascadeType.REMOVE, orphanRemoval = true)
     @ToString.Exclude
     private List<ServicePolicyEntity> servicePolicyList;
+
+    @OneToMany(mappedBy = "serviceTemplate", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    @ToString.Exclude
+    private List<ServiceTemplateHistoryEntity> serviceTemplateHistory;
 
 }

--- a/modules/database/src/main/java/org/eclipse/xpanse/modules/database/servicetemplatehistory/DatabaseServiceTemplateHistoryStorage.java
+++ b/modules/database/src/main/java/org/eclipse/xpanse/modules/database/servicetemplatehistory/DatabaseServiceTemplateHistoryStorage.java
@@ -1,0 +1,37 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * SPDX-FileCopyrightText: Huawei Inc.
+ *
+ */
+
+package org.eclipse.xpanse.modules.database.servicetemplatehistory;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Implements methods of ServiceTemplateHistoryStorage interface.
+ */
+@Slf4j
+@Component
+@Transactional
+public class DatabaseServiceTemplateHistoryStorage implements ServiceTemplateHistoryStorage {
+
+    private final ServiceTemplateHistoryRepository repository;
+
+    @Autowired
+    public DatabaseServiceTemplateHistoryStorage(
+            ServiceTemplateHistoryRepository serviceTemplateHistoryRepository) {
+        this.repository = serviceTemplateHistoryRepository;
+    }
+
+    @Override
+    public ServiceTemplateHistoryEntity storeAndFlush(
+            ServiceTemplateHistoryEntity serviceTemplateHistoryEntity) {
+        return repository.saveAndFlush(serviceTemplateHistoryEntity);
+    }
+
+
+}

--- a/modules/database/src/main/java/org/eclipse/xpanse/modules/database/servicetemplatehistory/ServiceTemplateHistoryEntity.java
+++ b/modules/database/src/main/java/org/eclipse/xpanse/modules/database/servicetemplatehistory/ServiceTemplateHistoryEntity.java
@@ -1,0 +1,66 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * SPDX-FileCopyrightText: Huawei Inc.
+ *
+ */
+
+package org.eclipse.xpanse.modules.database.servicetemplatehistory;
+
+import io.hypersistence.utils.hibernate.type.json.JsonType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.util.UUID;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import org.eclipse.xpanse.modules.database.common.CreateModifiedTime;
+import org.eclipse.xpanse.modules.database.common.ObjectJsonConverter;
+import org.eclipse.xpanse.modules.database.servicetemplate.ServiceTemplateEntity;
+import org.eclipse.xpanse.modules.models.servicetemplate.Ocl;
+import org.eclipse.xpanse.modules.models.servicetemplate.enums.ServiceTemplateChangeStatus;
+import org.eclipse.xpanse.modules.models.servicetemplate.enums.ServiceTemplateRequestType;
+import org.hibernate.annotations.Type;
+
+/**
+ * Represents the SERVICE_TEMPLATE_HISTORY table in the database.
+ */
+@Table(name = "SERVICE_TEMPLATE_HISTORY")
+@Entity
+@Data
+@EqualsAndHashCode(callSuper = true)
+public class ServiceTemplateHistoryEntity extends CreateModifiedTime {
+
+    @Id
+    @Column(name = "CHANGE_ID", nullable = false)
+    private UUID changeId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "SERVICE_TEMPLATE_ID", nullable = false)
+    private ServiceTemplateEntity serviceTemplate;
+
+    @Column(name = "REQUEST_TYPE", nullable = false)
+    @Enumerated(EnumType.STRING)
+    private ServiceTemplateRequestType requestType;
+
+    @Column(name = "STATUS", nullable = false)
+    @Enumerated(EnumType.STRING)
+    private ServiceTemplateChangeStatus status;
+
+    @Column(name = "SERVICE_TEMPLATE_REQUEST", columnDefinition = "json")
+    @Type(value = JsonType.class)
+    @Convert(converter = ObjectJsonConverter.class)
+    private Ocl ocl;
+
+    @Column(name = "REVIEW_COMMENT", length = Integer.MAX_VALUE)
+    private String reviewComment;
+
+    @Column(name = "BLOCK_TEMPLATE_UNTIL_REVIEWED", nullable = false)
+    private Boolean blockTemplateUntilReviewed = false;
+}

--- a/modules/database/src/main/java/org/eclipse/xpanse/modules/database/servicetemplatehistory/ServiceTemplateHistoryRepository.java
+++ b/modules/database/src/main/java/org/eclipse/xpanse/modules/database/servicetemplatehistory/ServiceTemplateHistoryRepository.java
@@ -1,0 +1,22 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * SPDX-FileCopyrightText: Huawei Inc.
+ *
+ */
+
+package org.eclipse.xpanse.modules.database.servicetemplatehistory;
+
+import java.util.UUID;
+import org.eclipse.xpanse.modules.database.CustomJpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.stereotype.Repository;
+
+/**
+ * Interface to access default JPA methods.
+ */
+@Repository
+public interface ServiceTemplateHistoryRepository extends
+        CustomJpaRepository<ServiceTemplateHistoryEntity, UUID>,
+        JpaSpecificationExecutor<ServiceTemplateHistoryEntity> {
+
+}

--- a/modules/database/src/main/java/org/eclipse/xpanse/modules/database/servicetemplatehistory/ServiceTemplateHistoryStorage.java
+++ b/modules/database/src/main/java/org/eclipse/xpanse/modules/database/servicetemplatehistory/ServiceTemplateHistoryStorage.java
@@ -1,0 +1,24 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * SPDX-FileCopyrightText: Huawei Inc.
+ *
+ */
+
+package org.eclipse.xpanse.modules.database.servicetemplatehistory;
+
+/**
+ * Interface for persist of ServiceTemplateHistory.
+ */
+public interface ServiceTemplateHistoryStorage {
+
+
+    /**
+     * Store and flush serviceTemplateHistoryEntity.
+     *
+     * @param serviceTemplateHistoryEntity to be stored.
+     * @return updated serviceTemplateHistoryEntity.
+     */
+    ServiceTemplateHistoryEntity storeAndFlush(
+            ServiceTemplateHistoryEntity serviceTemplateHistoryEntity);
+
+}

--- a/modules/database/src/test/java/org/eclipse/xpanse/modules/database/servicetemplate/ServiceTemplateEntityTest.java
+++ b/modules/database/src/test/java/org/eclipse/xpanse/modules/database/servicetemplate/ServiceTemplateEntityTest.java
@@ -11,7 +11,10 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import java.net.URI;
+import java.util.List;
 import java.util.UUID;
+import org.eclipse.xpanse.modules.database.servicepolicy.ServicePolicyEntity;
+import org.eclipse.xpanse.modules.database.servicetemplatehistory.ServiceTemplateHistoryEntity;
 import org.eclipse.xpanse.modules.models.common.enums.Category;
 import org.eclipse.xpanse.modules.models.common.enums.Csp;
 import org.eclipse.xpanse.modules.models.service.utils.ServiceDeployVariablesJsonSchemaGenerator;
@@ -23,14 +26,17 @@ import org.eclipse.xpanse.modules.models.servicetemplate.utils.JsonObjectSchema;
 import org.eclipse.xpanse.modules.models.servicetemplate.utils.OclLoader;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.BeanUtils;
 
+@ExtendWith(MockitoExtension.class)
 class ServiceTemplateEntityTest {
     private final UUID id = UUID.randomUUID();
     private final ServiceTemplateRegistrationState serviceTemplateRegistrationState =
             ServiceTemplateRegistrationState.APPROVED;
     private final String namespace = "namespace";
-    private final String reviewComment = "reviewComment";
     private Category category;
     private Csp csp;
     private String name;
@@ -40,6 +46,10 @@ class ServiceTemplateEntityTest {
     private JsonObjectSchema jsonObjectSchema;
     private ServiceProviderContactDetails serviceProviderContactDetails;
     private ServiceTemplateEntity testEntity;
+    @Mock
+    private List<ServicePolicyEntity> mockServicePolicyList;
+    @Mock
+    private List<ServiceTemplateHistoryEntity> mockServiceTemplateHistory;
 
     @BeforeEach
     void setUp() throws Exception {
@@ -69,9 +79,10 @@ class ServiceTemplateEntityTest {
         testEntity.setServiceTemplateRegistrationState(serviceTemplateRegistrationState);
         testEntity.setIsUpdatePending(false);
         testEntity.setAvailableInCatalog(true);
-        testEntity.setReviewComment(reviewComment);
         testEntity.setJsonObjectSchema(jsonObjectSchema);
         testEntity.setServiceProviderContactDetails(serviceProviderContactDetails);
+        testEntity.setServicePolicyList(mockServicePolicyList);
+        testEntity.setServiceTemplateHistory(mockServiceTemplateHistory);
     }
 
     @Test
@@ -90,6 +101,8 @@ class ServiceTemplateEntityTest {
         assertEquals(ocl, testEntity.getOcl());
         assertEquals(id, testEntity.getId());
         assertEquals(serviceProviderContactDetails, testEntity.getServiceProviderContactDetails());
+        assertEquals(mockServicePolicyList, testEntity.getServicePolicyList());
+        assertEquals(mockServiceTemplateHistory, testEntity.getServiceTemplateHistory());
     }
 
     @Test
@@ -121,7 +134,6 @@ class ServiceTemplateEntityTest {
                 + ", serviceTemplateRegistrationState=" + serviceTemplateRegistrationState
                 + ", isUpdatePending=false"
                 + ", availableInCatalog=true"
-                + ", reviewComment=" + reviewComment
                 + ", serviceProviderContactDetails=" + serviceProviderContactDetails
                 + ", jsonObjectSchema=" + jsonObjectSchema
                 + ")";

--- a/modules/models/src/main/java/org/eclipse/xpanse/modules/models/service/enums/TaskStatus.java
+++ b/modules/models/src/main/java/org/eclipse/xpanse/modules/models/service/enums/TaskStatus.java
@@ -16,7 +16,7 @@ import org.eclipse.xpanse.modules.models.common.exceptions.UnsupportedEnumValueE
  */
 public enum TaskStatus {
     CREATED("created"),
-    IN_PROGRESS("in progress"),
+    IN_PROGRESS("in-progress"),
     SUCCESSFUL("successful"),
     FAILED("failed");
 

--- a/modules/models/src/main/java/org/eclipse/xpanse/modules/models/servicetemplate/enums/ServiceTemplateChangeStatus.java
+++ b/modules/models/src/main/java/org/eclipse/xpanse/modules/models/servicetemplate/enums/ServiceTemplateChangeStatus.java
@@ -11,37 +11,37 @@ import org.apache.commons.lang3.StringUtils;
 import org.eclipse.xpanse.modules.models.common.exceptions.UnsupportedEnumValueException;
 
 /**
- * Defines possible states of a managed service template registration.
+ * Defines status enumerations for change of service template.
  */
-public enum ServiceTemplateRegistrationState {
+public enum ServiceTemplateChangeStatus {
 
-    IN_PROGRESS("in-progress"),
-    APPROVED("approved"),
+    IN_REVIEW("in-review"),
+    ACCEPTED("accepted"),
     REJECTED("rejected");
 
     private final String state;
 
-    ServiceTemplateRegistrationState(String state) {
+    ServiceTemplateChangeStatus(String state) {
         this.state = state;
     }
 
     /**
-     * For ServiceTemplateRegistrationState deserialize.
+     * For ServiceTemplateChangeStatus deserialize.
      */
     @JsonCreator
-    public static ServiceTemplateRegistrationState getByValue(String state) {
-        for (ServiceTemplateRegistrationState registrationState : values()) {
+    public static ServiceTemplateChangeStatus getByValue(String state) {
+        for (ServiceTemplateChangeStatus registrationState : values()) {
             if (StringUtils.equalsIgnoreCase(registrationState.state, state)) {
                 return registrationState;
             }
         }
         throw new UnsupportedEnumValueException(
-                String.format("ServiceTemplateRegistrationState value %s is not supported.",
+                String.format("ServiceTemplateChangeStatus value %s is not supported.",
                         state));
     }
 
     /**
-     * For ServiceTemplateRegistrationState serialize.
+     * For ServiceTemplateChangeStatus serialize.
      */
     @JsonValue
     public String toValue() {

--- a/modules/models/src/main/java/org/eclipse/xpanse/modules/models/servicetemplate/enums/ServiceTemplateRequestType.java
+++ b/modules/models/src/main/java/org/eclipse/xpanse/modules/models/servicetemplate/enums/ServiceTemplateRequestType.java
@@ -1,0 +1,51 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * SPDX-FileCopyrightText: Huawei Inc.
+ */
+
+package org.eclipse.xpanse.modules.models.servicetemplate.enums;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import org.apache.commons.lang3.StringUtils;
+import org.eclipse.xpanse.modules.models.common.exceptions.UnsupportedEnumValueException;
+
+/**
+ * Defines types of request for managing service template.
+ */
+public enum ServiceTemplateRequestType {
+
+    REGISTER("register"),
+    UPDATE("update"),
+    UNREGISTER("unregister"),
+    RE_REGISTER("re-register");
+
+    private final String type;
+
+    ServiceTemplateRequestType(String type) {
+        this.type = type;
+    }
+
+    /**
+     * For ServiceTemplateRequestType deserialize.
+     */
+    @JsonCreator
+    public static ServiceTemplateRequestType getByValue(String type) {
+        for (ServiceTemplateRequestType registrationState : values()) {
+            if (StringUtils.equalsIgnoreCase(registrationState.type, type)) {
+                return registrationState;
+            }
+        }
+        throw new UnsupportedEnumValueException(
+                String.format("ServiceTemplateRequestType value %s is not supported.", type));
+    }
+
+    /**
+     * For ServiceTemplateRequestType serialize.
+     */
+    @JsonValue
+    public String toValue() {
+        return this.type;
+    }
+}
+

--- a/modules/models/src/test/java/org/eclipse/xpanse/modules/models/service/enums/TaskStatusTest.java
+++ b/modules/models/src/test/java/org/eclipse/xpanse/modules/models/service/enums/TaskStatusTest.java
@@ -12,7 +12,7 @@ class TaskStatusTest {
     void testGetByValue() {
         assertThat(TaskStatus.getByValue("created")).isEqualTo(
                 TaskStatus.CREATED);
-        assertThat(TaskStatus.getByValue("in progress")).isEqualTo(
+        assertThat(TaskStatus.getByValue("in-progress")).isEqualTo(
                 TaskStatus.IN_PROGRESS);
         assertThat(TaskStatus.getByValue("successful")).isEqualTo(
                 TaskStatus.SUCCESSFUL);
@@ -25,7 +25,7 @@ class TaskStatusTest {
     @Test
     void testToValue() {
         assertThat(TaskStatus.CREATED.toValue()).isEqualTo("created");
-        assertThat(TaskStatus.IN_PROGRESS.toValue()).isEqualTo("in progress");
+        assertThat(TaskStatus.IN_PROGRESS.toValue()).isEqualTo("in-progress");
         assertThat(TaskStatus.SUCCESSFUL.toValue()).isEqualTo("successful");
         assertThat(TaskStatus.FAILED.toValue()).isEqualTo("failed");
     }

--- a/modules/models/src/test/java/org/eclipse/xpanse/modules/models/servicetemplate/enums/ServiceTemplateRegistrationStateTest.java
+++ b/modules/models/src/test/java/org/eclipse/xpanse/modules/models/servicetemplate/enums/ServiceTemplateRegistrationStateTest.java
@@ -16,7 +16,7 @@ class ServiceTemplateRegistrationStateTest {
     @Test
     void testGetByValue() {
         assertEquals(ServiceTemplateRegistrationState.IN_PROGRESS,
-                ServiceTemplateRegistrationState.getByValue("InProgress"));
+                ServiceTemplateRegistrationState.getByValue("in-progress"));
         assertEquals(ServiceTemplateRegistrationState.APPROVED,
                 ServiceTemplateRegistrationState.getByValue("approved"));
         assertEquals(ServiceTemplateRegistrationState.REJECTED,
@@ -30,7 +30,7 @@ class ServiceTemplateRegistrationStateTest {
 
     @Test
     void testToValue() {
-        assertEquals("inProgress", ServiceTemplateRegistrationState.IN_PROGRESS.toValue());
+        assertEquals("in-progress", ServiceTemplateRegistrationState.IN_PROGRESS.toValue());
         assertEquals("approved", ServiceTemplateRegistrationState.APPROVED.toValue());
         assertEquals("rejected", ServiceTemplateRegistrationState.REJECTED.toValue());
     }

--- a/modules/servicetemplate/src/main/java/org/eclipse/xpanse/modules/servicetemplate/ServiceTemplateManage.java
+++ b/modules/servicetemplate/src/main/java/org/eclipse/xpanse/modules/servicetemplate/ServiceTemplateManage.java
@@ -352,9 +352,6 @@ public class ServiceTemplateManage {
                     ServiceTemplateRegistrationState.REJECTED);
             existingTemplate.setAvailableInCatalog(false);
         }
-        String reviewComment = StringUtils.isNotBlank(request.getReviewComment())
-                ? request.getReviewComment() : request.getReviewResult().toValue();
-        existingTemplate.setReviewComment(reviewComment);
         templateStorage.storeAndFlush(existingTemplate);
     }
 


### PR DESCRIPTION
Fixed https://github.com/eclipse-xpanse/xpanse/issues/2099

Constructor of table service_template_history in H2 database:
![chrome_D4dDXv5RsT](https://github.com/user-attachments/assets/4fed7632-4621-4ee7-b39f-5b1fc9cdc9d7)

Constructor of table service_template_history in MySql database:
![image](https://github.com/user-attachments/assets/7b8c1592-8d94-4977-8760-a81a7f123238)



