### PR TITLE
Implement changes to service template query Apis

### DIFF
--- a/modules/api/src/main/java/org/eclipse/xpanse/api/controllers/IsvCloudCredentialsApi.java
+++ b/modules/api/src/main/java/org/eclipse/xpanse/api/controllers/IsvCloudCredentialsApi.java
@@ -130,9 +130,8 @@ public class IsvCloudCredentialsApi {
     @DeleteMapping(value = "/credentials",
             produces = MediaType.APPLICATION_JSON_VALUE)
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    @Operation(description =
-            "Delete the credentials of the user in the USER role to connect to the cloud service "
-                    + "provider.")
+    @Operation(description = "Delete the credentials of the user in the USER role "
+            + "to connect to the cloud service provider.")
     @AuditApiRequest(methodName = "getCspFromRequestUri")
     public void deleteIsvCloudCredential(
             @Parameter(name = "cspName", description = "The cloud service provider.")
@@ -141,7 +140,7 @@ public class IsvCloudCredentialsApi {
             @RequestParam(name = "siteName") String siteName,
             @Parameter(name = "type", description = "The type of credential.")
             @RequestParam(name = "type") CredentialType type,
-            @Parameter(name = "name", description = "The name of of credential.")
+            @Parameter(name = "name", description = "The name of credential.")
             @RequestParam(name = "name") String name) {
         credentialCenter.deleteCredential(csp, siteName, type, name, null);
     }

--- a/modules/api/src/main/java/org/eclipse/xpanse/api/controllers/ServiceCatalogApi.java
+++ b/modules/api/src/main/java/org/eclipse/xpanse/api/controllers/ServiceCatalogApi.java
@@ -27,7 +27,7 @@ import org.eclipse.xpanse.modules.database.servicetemplate.ServiceTemplateQueryM
 import org.eclipse.xpanse.modules.models.common.enums.Category;
 import org.eclipse.xpanse.modules.models.common.enums.Csp;
 import org.eclipse.xpanse.modules.models.servicetemplate.enums.ServiceHostingType;
-import org.eclipse.xpanse.modules.models.servicetemplate.exceptions.UnavailableServiceTemplateException;
+import org.eclipse.xpanse.modules.models.servicetemplate.exceptions.ServiceTemplateDisabledException;
 import org.eclipse.xpanse.modules.models.servicetemplate.view.UserOrderableServiceVo;
 import org.eclipse.xpanse.modules.servicetemplate.ServiceTemplateManage;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -114,15 +114,15 @@ public class ServiceCatalogApi {
             produces = MediaType.APPLICATION_JSON_VALUE)
     @ResponseStatus(HttpStatus.OK)
     @AuditApiRequest(methodName = "getCspFromServiceTemplateId")
-    public UserOrderableServiceVo getOrderableServiceDetails(
+    public UserOrderableServiceVo getOrderableServiceDetailsById(
             @Parameter(name = "id", description = "The id of orderable service.")
             @PathVariable("id") String id) {
         ServiceTemplateEntity serviceTemplateEntity =
                 serviceTemplateManage.getServiceTemplateDetails(UUID.fromString(id), false, false);
         if (Objects.equals(false, serviceTemplateEntity.getAvailableInCatalog())) {
-            String errMsg = String.format("Service template with id %s is unavailable.", id);
+            String errMsg = "Service template with id " + id + " is disabled to order service.";
             log.error(errMsg);
-            throw new UnavailableServiceTemplateException(errMsg);
+            throw new ServiceTemplateDisabledException(errMsg);
         }
         String successMsg = String.format("Get orderable service with id %s successful.", id);
         log.info(successMsg);

--- a/modules/api/src/main/java/org/eclipse/xpanse/api/controllers/ServiceMigrationApi.java
+++ b/modules/api/src/main/java/org/eclipse/xpanse/api/controllers/ServiceMigrationApi.java
@@ -37,7 +37,7 @@ import org.eclipse.xpanse.modules.models.service.deploy.exceptions.EulaNotAccept
 import org.eclipse.xpanse.modules.models.service.deploy.exceptions.ServiceLockedException;
 import org.eclipse.xpanse.modules.models.service.order.ServiceOrder;
 import org.eclipse.xpanse.modules.models.service.order.enums.ServiceOrderType;
-import org.eclipse.xpanse.modules.models.servicetemplate.exceptions.UnavailableServiceTemplateException;
+import org.eclipse.xpanse.modules.models.servicetemplate.exceptions.ServiceTemplateNotRegistered;
 import org.eclipse.xpanse.modules.models.workflow.migrate.MigrateRequest;
 import org.eclipse.xpanse.modules.orchestrator.deployment.DeployTask;
 import org.eclipse.xpanse.modules.security.UserServiceHelper;
@@ -129,7 +129,7 @@ public class ServiceMigrationApi {
         ServiceTemplateEntity existingTemplate = existingServiceTemplates.stream()
                 .filter(serviceTemplate -> serviceTemplate.getAvailableInCatalog()
                         && Objects.nonNull(serviceTemplate.getOcl()))
-                .findFirst().orElseThrow(() -> new UnavailableServiceTemplateException(
+                .findFirst().orElseThrow(() -> new ServiceTemplateNotRegistered(
                         "No available service templates found"));
         if (StringUtils.isNotBlank(existingTemplate.getOcl().getEula())
                 && !migrateRequest.isEulaAccepted()) {

--- a/modules/api/src/main/java/org/eclipse/xpanse/api/controllers/ServiceTemplateApi.java
+++ b/modules/api/src/main/java/org/eclipse/xpanse/api/controllers/ServiceTemplateApi.java
@@ -246,7 +246,7 @@ public class ServiceTemplateApi {
     @GetMapping(value = "/service_templates", produces = MediaType.APPLICATION_JSON_VALUE)
     @ResponseStatus(HttpStatus.OK)
     @AuditApiRequest(methodName = "getCspFromRequestUri")
-    public List<ServiceTemplateDetailVo> listServiceTemplates(
+    public List<ServiceTemplateDetailVo> getAllServiceTemplatesByIsv(
             @Parameter(name = "categoryName", description = "category of the service")
             @RequestParam(name = "categoryName", required = false) Category category,
             @Parameter(name = "cspName", description = "name of the cloud service provider")

--- a/modules/api/src/main/java/org/eclipse/xpanse/api/controllers/UserCloudCredentialsApi.java
+++ b/modules/api/src/main/java/org/eclipse/xpanse/api/controllers/UserCloudCredentialsApi.java
@@ -140,7 +140,7 @@ public class UserCloudCredentialsApi {
             @RequestParam(name = "siteName") String siteName,
             @Parameter(name = "type", description = "The type of credential.")
             @RequestParam(name = "type") CredentialType type,
-            @Parameter(name = "name", description = "The name of of credential.")
+            @Parameter(name = "name", description = "The name of credential.")
             @RequestParam(name = "name") String name) {
         credentialCenter.deleteCredential(csp, siteName, type, name, getUserId());
     }

--- a/modules/api/src/main/java/org/eclipse/xpanse/api/exceptions/handler/RegistrationExceptionHandler.java
+++ b/modules/api/src/main/java/org/eclipse/xpanse/api/exceptions/handler/RegistrationExceptionHandler.java
@@ -18,12 +18,12 @@ import org.eclipse.xpanse.modules.models.servicetemplate.exceptions.InvalidServi
 import org.eclipse.xpanse.modules.models.servicetemplate.exceptions.InvalidValueSchemaException;
 import org.eclipse.xpanse.modules.models.servicetemplate.exceptions.ServiceTemplateAlreadyRegistered;
 import org.eclipse.xpanse.modules.models.servicetemplate.exceptions.ServiceTemplateAlreadyReviewed;
+import org.eclipse.xpanse.modules.models.servicetemplate.exceptions.ServiceTemplateDisabledException;
 import org.eclipse.xpanse.modules.models.servicetemplate.exceptions.ServiceTemplateNotRegistered;
 import org.eclipse.xpanse.modules.models.servicetemplate.exceptions.ServiceTemplateStillInUseException;
 import org.eclipse.xpanse.modules.models.servicetemplate.exceptions.ServiceTemplateUpdateNotAllowed;
 import org.eclipse.xpanse.modules.models.servicetemplate.exceptions.TerraformScriptFormatInvalidException;
 import org.eclipse.xpanse.modules.models.servicetemplate.exceptions.UnavailableServiceRegionsException;
-import org.eclipse.xpanse.modules.models.servicetemplate.exceptions.UnavailableServiceTemplateException;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpStatus;
@@ -115,14 +115,14 @@ public class RegistrationExceptionHandler {
     }
 
     /**
-     * Exception handler for UnavailableServiceTemplateException.
+     * Exception handler for ServiceTemplateDisabledException.
      */
-    @ExceptionHandler({UnavailableServiceTemplateException.class})
+    @ExceptionHandler({ServiceTemplateDisabledException.class})
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     @ResponseBody
-    public ErrorResponse handleUnavailableServiceTemplateException(
-            UnavailableServiceTemplateException ex) {
-        return getErrorResponse(ErrorType.UNAVAILABLE_SERVICE_TEMPLATE,
+    public ErrorResponse handleServiceTemplateDisabledException(
+            ServiceTemplateDisabledException ex) {
+        return getErrorResponse(ErrorType.SERVICE_TEMPLATE_DISABLED,
                 Collections.singletonList(ex.getMessage()));
     }
 

--- a/modules/api/src/test/java/org/eclipse/xpanse/api/exceptions/handler/RegistrationExceptionHandlerTest.java
+++ b/modules/api/src/test/java/org/eclipse/xpanse/api/exceptions/handler/RegistrationExceptionHandlerTest.java
@@ -21,7 +21,7 @@ import org.eclipse.xpanse.modules.models.servicetemplate.exceptions.InvalidServi
 import org.eclipse.xpanse.modules.models.servicetemplate.exceptions.InvalidValueSchemaException;
 import org.eclipse.xpanse.modules.models.servicetemplate.exceptions.ServiceTemplateAlreadyRegistered;
 import org.eclipse.xpanse.modules.models.servicetemplate.exceptions.ServiceTemplateAlreadyReviewed;
-import org.eclipse.xpanse.modules.models.servicetemplate.exceptions.UnavailableServiceTemplateException;
+import org.eclipse.xpanse.modules.models.servicetemplate.exceptions.ServiceTemplateDisabledException;
 import org.eclipse.xpanse.modules.models.servicetemplate.exceptions.ServiceTemplateNotRegistered;
 import org.eclipse.xpanse.modules.models.servicetemplate.exceptions.ServiceTemplateUpdateNotAllowed;
 import org.eclipse.xpanse.modules.models.servicetemplate.exceptions.TerraformScriptFormatInvalidException;
@@ -116,12 +116,12 @@ class RegistrationExceptionHandlerTest {
     @Test
     void testUnavailableServiceTemplateException() throws Exception {
         when(serviceTemplateManage.registerServiceTemplate(any())).thenThrow(
-                new UnavailableServiceTemplateException("test error"));
+                new ServiceTemplateDisabledException("test error"));
 
         this.mockMvc.perform(
                         post("/xpanse/service_templates/file").param("oclLocation", oclLocation))
                 .andExpect(status().is(400))
-                .andExpect(jsonPath("$.errorType").value("Service Template Is Unavailable"))
+                .andExpect(jsonPath("$.errorType").value("Service Template Disabled"))
                 .andExpect(jsonPath("$.details[0]").value("test error"));
     }
 

--- a/modules/deployment/src/main/java/org/eclipse/xpanse/modules/deployment/DeployService.java
+++ b/modules/deployment/src/main/java/org/eclipse/xpanse/modules/deployment/DeployService.java
@@ -54,7 +54,6 @@ import org.eclipse.xpanse.modules.models.servicetemplate.FlavorsWithPrice;
 import org.eclipse.xpanse.modules.models.servicetemplate.ServiceFlavor;
 import org.eclipse.xpanse.modules.models.servicetemplate.ServiceFlavorWithPrice;
 import org.eclipse.xpanse.modules.models.servicetemplate.exceptions.ServiceTemplateNotRegistered;
-import org.eclipse.xpanse.modules.models.servicetemplate.exceptions.UnavailableServiceTemplateException;
 import org.eclipse.xpanse.modules.orchestrator.OrchestratorPlugin;
 import org.eclipse.xpanse.modules.orchestrator.PluginManager;
 import org.eclipse.xpanse.modules.orchestrator.deployment.DeployResult;
@@ -275,7 +274,7 @@ public class DeployService {
         ServiceTemplateEntity existingServiceTemplate = existingServiceTemplates.stream()
                 .filter(serviceTemplate -> serviceTemplate.getAvailableInCatalog()
                         && Objects.nonNull(serviceTemplate.getOcl()))
-                .findFirst().orElseThrow(() -> new UnavailableServiceTemplateException(
+                .findFirst().orElseThrow(() -> new ServiceTemplateNotRegistered(
                         "No available service templates found"));
         if (StringUtils.isNotBlank(existingServiceTemplate.getOcl().getEula())
                 && !deployRequest.isEulaAccepted()) {
@@ -364,11 +363,7 @@ public class DeployService {
         entity.setDeployResourceList(new ArrayList<>());
         entity.setNamespace(deployTask.getNamespace());
         entity.setServiceDeploymentState(ServiceDeploymentState.DEPLOYING);
-        if (Objects.nonNull(deployTask.getServiceTemplateId())) {
-            entity.setServiceTemplateId(deployTask.getServiceTemplateId());
-        } else {
-            throw new ServiceTemplateNotRegistered("service template id can't be null.");
-        }
+        entity.setServiceTemplateId(deployTask.getServiceTemplateId());
         ServiceLockConfig defaultLockConfig = new ServiceLockConfig();
         defaultLockConfig.setDestroyLocked(false);
         defaultLockConfig.setModifyLocked(false);

--- a/modules/models/src/main/java/org/eclipse/xpanse/modules/models/response/ErrorType.java
+++ b/modules/models/src/main/java/org/eclipse/xpanse/modules/models/response/ErrorType.java
@@ -34,7 +34,7 @@ public enum ErrorType {
     SERVICE_TEMPLATE_ALREADY_REGISTERED("Service Template Already Registered"),
     ICON_PROCESSING_FAILED("Icon Processing Failed"),
     SERVICE_TEMPLATE_NOT_REGISTERED("Service Template Not Registered"),
-    UNAVAILABLE_SERVICE_TEMPLATE("Service Template Is Unavailable"),
+    SERVICE_TEMPLATE_DISABLED("Service Template Disabled"),
     SERVICE_TEMPLATE_ALREADY_REVIEWED("Service Template Already Reviewed"),
     INVALID_SERVICE_VERSION("Invalid Service Version"),
     INVALID_SERVICE_FLAVORS("Invalid Service Flavors"),

--- a/modules/models/src/main/java/org/eclipse/xpanse/modules/models/servicetemplate/exceptions/ServiceTemplateDisabledException.java
+++ b/modules/models/src/main/java/org/eclipse/xpanse/modules/models/servicetemplate/exceptions/ServiceTemplateDisabledException.java
@@ -8,8 +8,8 @@ package org.eclipse.xpanse.modules.models.servicetemplate.exceptions;
 /**
  * Exception thrown when the deployer mentioned in the service template is not available.
  */
-public class UnavailableServiceTemplateException extends RuntimeException {
-    public UnavailableServiceTemplateException(String message) {
+public class ServiceTemplateDisabledException extends RuntimeException {
+    public ServiceTemplateDisabledException(String message) {
         super(message);
     }
 

--- a/modules/models/src/main/java/org/eclipse/xpanse/modules/models/servicetemplate/view/ServiceTemplateDetailVo.java
+++ b/modules/models/src/main/java/org/eclipse/xpanse/modules/models/servicetemplate/view/ServiceTemplateDetailVo.java
@@ -127,9 +127,6 @@ public class ServiceTemplateDetailVo extends RepresentationModel<ServiceTemplate
     @Schema(description = "Is available in catalog.")
     private Boolean availableInCatalog;
 
-    @Schema(description = "Comment of reviewed service template.")
-    private String reviewComment;
-
     @NotNull
     @Schema(description = "The contact details of the service provider.")
     private ServiceProviderContactDetails serviceProviderContactDetails;

--- a/modules/models/src/test/java/org/eclipse/xpanse/modules/models/servicetemplate/exceptions/ServiceTemplateDisabledExceptionTest.java
+++ b/modules/models/src/test/java/org/eclipse/xpanse/modules/models/servicetemplate/exceptions/ServiceTemplateDisabledExceptionTest.java
@@ -13,16 +13,16 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 /**
- * Test of UnavailableServiceTemplateException.
+ * Test of ServiceTemplateDisabledException.
  */
-class UnavailableServiceTemplateExceptionTest {
+class ServiceTemplateDisabledExceptionTest {
 
     private static final String message = "service template is unavailable.";
-    private static UnavailableServiceTemplateException exception;
+    private static ServiceTemplateDisabledException exception;
 
     @BeforeEach
     void setUp() {
-        exception = new UnavailableServiceTemplateException(message);
+        exception = new ServiceTemplateDisabledException(message);
     }
 
     @Test
@@ -40,10 +40,10 @@ class UnavailableServiceTemplateExceptionTest {
         assertNotEquals(exception, null);
         assertNotEquals(exception.hashCode(), obj.hashCode());
 
-        UnavailableServiceTemplateException exception1 =
-                new UnavailableServiceTemplateException(message);
-        UnavailableServiceTemplateException exception2 =
-                new UnavailableServiceTemplateException("different message");
+        ServiceTemplateDisabledException exception1 =
+                new ServiceTemplateDisabledException(message);
+        ServiceTemplateDisabledException exception2 =
+                new ServiceTemplateDisabledException("different message");
 
         assertNotEquals(exception, exception1);
         assertNotEquals(exception, exception2);

--- a/modules/models/src/test/java/org/eclipse/xpanse/modules/models/servicetemplate/view/ServiceTemplateDetailVoTest.java
+++ b/modules/models/src/test/java/org/eclipse/xpanse/modules/models/servicetemplate/view/ServiceTemplateDetailVoTest.java
@@ -53,7 +53,6 @@ class ServiceTemplateDetailVoTest {
             ServiceTemplateRegistrationState.APPROVED;
     private final Boolean availableInCatalog = true;
     private final Boolean isUpdatePending = false;
-    private final String reviewComment = "reviewComment";
     private final ServiceConfigurationManage serviceConfigurationManage =
             new ServiceConfigurationManage();
     @Mock
@@ -103,7 +102,6 @@ class ServiceTemplateDetailVoTest {
                 serviceTemplateRegistrationState);
         serviceTemplateDetailVo.setAvailableInCatalog(availableInCatalog);
         serviceTemplateDetailVo.setIsUpdatePending(isUpdatePending);
-        serviceTemplateDetailVo.setReviewComment(reviewComment);
         serviceTemplateDetailVo.setServiceHostingType(serviceHostingType);
         serviceTemplateDetailVo.setServiceProviderContactDetails(serviceProviderContactDetails);
         serviceTemplateDetailVo.setEula(eula);
@@ -130,7 +128,6 @@ class ServiceTemplateDetailVoTest {
                 serviceTemplateDetailVo.getServiceTemplateRegistrationState());
         assertEquals(availableInCatalog, serviceTemplateDetailVo.getAvailableInCatalog());
         assertEquals(isUpdatePending, serviceTemplateDetailVo.getIsUpdatePending());
-        assertEquals(reviewComment, serviceTemplateDetailVo.getReviewComment());
         assertEquals(serviceHostingType, serviceTemplateDetailVo.getServiceHostingType());
         assertEquals(serviceProviderContactDetails,
                 serviceTemplateDetailVo.getServiceProviderContactDetails());
@@ -174,7 +171,6 @@ class ServiceTemplateDetailVoTest {
                 + ", serviceTemplateRegistrationState=" + serviceTemplateRegistrationState
                 + ", isUpdatePending=" + isUpdatePending
                 + ", availableInCatalog=" + availableInCatalog
-                + ", reviewComment=" + reviewComment
                 + ", serviceProviderContactDetails=" + serviceProviderContactDetails
                 + ", eula=" + eula
                 + ", serviceConfigurationManage=" + serviceConfigurationManage

--- a/modules/servicetemplate/src/main/java/org/eclipse/xpanse/modules/servicetemplate/ServiceTemplateManage.java
+++ b/modules/servicetemplate/src/main/java/org/eclipse/xpanse/modules/servicetemplate/ServiceTemplateManage.java
@@ -218,13 +218,12 @@ public class ServiceTemplateManage {
         serviceTemplateHistory.setServiceTemplate(serviceTemplate);
         serviceTemplateHistory.setOcl(serviceTemplate.getOcl());
         serviceTemplateHistory.setRequestType(requestType);
+        serviceTemplateHistory.setBlockTemplateUntilReviewed(false);
         if (isAutoApproveEnabled) {
             serviceTemplateHistory.setStatus(ServiceTemplateChangeStatus.ACCEPTED);
             serviceTemplateHistory.setReviewComment(AUTO_APPROVED_REVIEW_COMMENT);
-            serviceTemplateHistory.setBlockTemplateUntilReviewed(false);
         } else {
             serviceTemplateHistory.setStatus(ServiceTemplateChangeStatus.IN_REVIEW);
-            serviceTemplateHistory.setBlockTemplateUntilReviewed(true);
         }
         return serviceTemplateHistoryStorage.storeAndFlush(serviceTemplateHistory);
     }

--- a/runtime/src/test/java/org/eclipse/xpanse/runtime/ServiceCatalogApiTest.java
+++ b/runtime/src/test/java/org/eclipse/xpanse/runtime/ServiceCatalogApiTest.java
@@ -184,10 +184,9 @@ class ServiceCatalogApiTest extends ApisTestCommon {
             ServiceTemplateDetailVo serviceTemplateDetailVo) throws Exception {
         // Setup request 1
         UUID id1 = serviceTemplateDetailVo.getServiceTemplateId();
+        String errMsg = "Service template with id " + id1 + " is disabled to order service.";
         ErrorResponse expectedErrorResponse1 = ErrorResponse.errorResponse(
-                ErrorType.UNAVAILABLE_SERVICE_TEMPLATE,
-                Collections.singletonList(
-                        String.format("Service template with id %s is unavailable.", id1)));
+                ErrorType.SERVICE_TEMPLATE_DISABLED, Collections.singletonList(errMsg));
         String result1 = objectMapper.writeValueAsString(expectedErrorResponse1);
         // Run the test case 1
         final MockHttpServletResponse response1 = getOrderableServiceDetailsWithId(id1);

--- a/runtime/src/test/java/org/eclipse/xpanse/runtime/ServiceDeployerApiTest.java
+++ b/runtime/src/test/java/org/eclipse/xpanse/runtime/ServiceDeployerApiTest.java
@@ -378,7 +378,7 @@ class ServiceDeployerApiTest extends ApisTestCommon {
         lowerPriorityFlavor.setPriority(10);
         ocl.getFlavors().getServiceFlavors().add(lowerPriorityFlavor);
         ServiceTemplateDetailVo serviceTemplate = registerServiceTemplate(ocl);
-        testDeployThrowsUnavailableServiceTemplate(serviceTemplate);
+        testDeployThrowsServiceTemplateNotRegistered(serviceTemplate);
         approveServiceTemplateRegistration(serviceTemplate.getServiceTemplateId());
         setMockPoliciesValidateApi();
         addServicePolicies(serviceTemplate);
@@ -884,7 +884,7 @@ class ServiceDeployerApiTest extends ApisTestCommon {
                 });
     }
 
-    void testDeployThrowsUnavailableServiceTemplate(ServiceTemplateDetailVo template)
+    void testDeployThrowsServiceTemplateNotRegistered(ServiceTemplateDetailVo template)
             throws Exception {
         String errorMsg = "No available service templates found";
         DeployRequest deployRequest = getDeployRequest(template);
@@ -894,7 +894,7 @@ class ServiceDeployerApiTest extends ApisTestCommon {
         assertEquals(HttpStatus.BAD_REQUEST.value(), deployResponse.getStatus());
         OrderFailedErrorResponse response = objectMapper.readValue(
                 deployResponse.getContentAsString(), OrderFailedErrorResponse.class);
-        assertEquals(response.getErrorType(), ErrorType.UNAVAILABLE_SERVICE_TEMPLATE);
+        assertEquals(response.getErrorType(), ErrorType.SERVICE_TEMPLATE_NOT_REGISTERED);
         assertEquals(response.getDetails(), List.of(errorMsg));
 
         // SetUp
@@ -906,7 +906,7 @@ class ServiceDeployerApiTest extends ApisTestCommon {
         assertEquals(HttpStatus.BAD_REQUEST.value(), deployResponse1.getStatus());
         OrderFailedErrorResponse response1 = objectMapper.readValue(
                 deployResponse1.getContentAsString(), OrderFailedErrorResponse.class);
-        assertEquals(response1.getErrorType(), ErrorType.UNAVAILABLE_SERVICE_TEMPLATE);
+        assertEquals(response1.getErrorType(), ErrorType.SERVICE_TEMPLATE_NOT_REGISTERED);
         assertEquals(response1.getDetails(), List.of(errorMsg));
     }
 

--- a/runtime/src/test/java/org/eclipse/xpanse/runtime/database/mysql/RegistrationWithMysqlTest.java
+++ b/runtime/src/test/java/org/eclipse/xpanse/runtime/database/mysql/RegistrationWithMysqlTest.java
@@ -71,7 +71,7 @@ class RegistrationWithMysqlTest extends AbstractMysqlIntegrationTest {
 
         // Setup list request
         List<ServiceTemplateDetailVo> serviceTemplateDetailVos =
-                serviceTemplateApi.listServiceTemplates(ocl.getCategory(),
+                serviceTemplateApi.getAllServiceTemplatesByIsv(ocl.getCategory(),
                         serviceTemplateDetailVo.getCsp(), ocl.getName(),
                         serviceTemplateDetailVo.getVersion(), ocl.getServiceHostingType(),
                         ServiceTemplateRegistrationState.APPROVED, true, false);


### PR DESCRIPTION
**Related to https://github.com/eclipse-xpanse/xpanse-ui/pull/1323**

**Fixed https://github.com/eclipse-xpanse/xpanse/issues/2102**
Call service `getAllServiceTemplatesByIsv` return service templates with ServiceTemplateRegistrationState, isAvailableInCatalog and isUpdatePending state:
![image](https://github.com/user-attachments/assets/d20d30f6-b9c4-4d8c-8b24-397a71b540af)

**Fixed https://github.com/eclipse-xpanse/xpanse/issues/2103**
Call service `getOrderableServices` return service templates with AVAILABLE_IN_CATALOG=true
![image](https://github.com/user-attachments/assets/c2d61c94-b488-4bc7-b922-1b59af133785)

**Fixed https://github.com/eclipse-xpanse/xpanse/issues/2104**
Call service `getOrderableServiceDetailsById` throw ServiceTemplateDisabledException
![image](https://github.com/user-attachments/assets/65959947-c900-4ab3-a515-f4bb363f7977)
