### PR TITLE
Create new API to query used service template by service id

### DIFF
--- a/modules/api/src/main/java/org/eclipse/xpanse/api/controllers/ServiceDeployerApi.java
+++ b/modules/api/src/main/java/org/eclipse/xpanse/api/controllers/ServiceDeployerApi.java
@@ -7,6 +7,7 @@
 package org.eclipse.xpanse.api.controllers;
 
 
+import static org.eclipse.xpanse.api.config.ServiceTemplateEntityConverter.convertToUserOrderableServiceVo;
 import static org.eclipse.xpanse.modules.security.common.RoleConstants.ROLE_ADMIN;
 import static org.eclipse.xpanse.modules.security.common.RoleConstants.ROLE_CSP;
 import static org.eclipse.xpanse.modules.security.common.RoleConstants.ROLE_ISV;
@@ -25,6 +26,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.eclipse.xpanse.api.config.AuditApiRequest;
 import org.eclipse.xpanse.api.config.OrderFailedApiResponses;
+import org.eclipse.xpanse.modules.database.servicetemplate.ServiceTemplateEntity;
 import org.eclipse.xpanse.modules.deployment.DeployService;
 import org.eclipse.xpanse.modules.deployment.ServiceDetailsViewManager;
 import org.eclipse.xpanse.modules.deployment.servicelock.ServiceLockConfigService;
@@ -41,6 +43,7 @@ import org.eclipse.xpanse.modules.models.service.order.ServiceOrder;
 import org.eclipse.xpanse.modules.models.service.view.DeployedService;
 import org.eclipse.xpanse.modules.models.service.view.DeployedServiceDetails;
 import org.eclipse.xpanse.modules.models.service.view.VendorHostedDeployedServiceDetails;
+import org.eclipse.xpanse.modules.models.servicetemplate.view.UserOrderableServiceVo;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.http.CacheControl;
@@ -342,6 +345,27 @@ public class ServiceDeployerApi {
             ServiceDeploymentState lastKnownServiceDeploymentState) {
         return deployService.getLatestServiceDeploymentStatus(UUID.fromString(serviceId),
                 lastKnownServiceDeploymentState);
+    }
+
+    /**
+     * Get service template details by service id.
+     *
+     * @param serviceId service id
+     * @return service template details
+     */
+    @Tag(name = "Service", description = "APIs to manage the services")
+    @Operation(description = "Get service template details by service id.")
+    @GetMapping(value = "/services/{serviceId}/service_template",
+            produces = MediaType.APPLICATION_JSON_VALUE)
+    @ResponseStatus(HttpStatus.OK)
+    @AuditApiRequest(methodName = "getCspFromServiceId")
+    @Secured({ROLE_ADMIN, ROLE_ISV, ROLE_USER})
+    public UserOrderableServiceVo getOrderableServiceDetailsByServiceId(
+            @Parameter(name = "serviceId", description = "The id of deployed service.")
+            @PathVariable("serviceId") String serviceId) {
+        ServiceTemplateEntity usedServiceTemplate =
+                deployService.getOrderableServiceDetailsByServiceId(UUID.fromString(serviceId));
+        return convertToUserOrderableServiceVo(usedServiceTemplate);
     }
 
 

--- a/modules/deployment/src/main/java/org/eclipse/xpanse/modules/deployment/DeployService.java
+++ b/modules/deployment/src/main/java/org/eclipse/xpanse/modules/deployment/DeployService.java
@@ -762,4 +762,17 @@ public class DeployService {
         return stateDeferredResult;
     }
 
+
+    /**
+     * Get used service template entity by service id.
+     *
+     * @param serviceId id of deployed service.
+     * @return service template entity used to deploy the service.
+     */
+    public ServiceTemplateEntity getOrderableServiceDetailsByServiceId(UUID serviceId) {
+        ServiceDeploymentEntity deployedService =
+                serviceDeploymentEntityHandler.getServiceDeploymentEntity(serviceId);
+        return serviceTemplateStorage.getServiceTemplateById(
+                deployedService.getServiceTemplateId());
+    }
 }

--- a/runtime/src/test/java/org/eclipse/xpanse/runtime/database/mysql/DeploymentWithMysqlTest.java
+++ b/runtime/src/test/java/org/eclipse/xpanse/runtime/database/mysql/DeploymentWithMysqlTest.java
@@ -5,6 +5,8 @@
 
 package org.eclipse.xpanse.runtime.database.mysql;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import com.c4_soft.springaddons.security.oauth2.test.annotations.WithJwt;
 import jakarta.annotation.Resource;
 import java.net.URI;
@@ -45,6 +47,7 @@ import org.eclipse.xpanse.modules.models.servicetemplate.Ocl;
 import org.eclipse.xpanse.modules.models.servicetemplate.enums.ServiceTemplateRegistrationState;
 import org.eclipse.xpanse.modules.models.servicetemplate.utils.OclLoader;
 import org.eclipse.xpanse.modules.models.servicetemplate.view.ServiceTemplateDetailVo;
+import org.eclipse.xpanse.modules.models.servicetemplate.view.UserOrderableServiceVo;
 import org.eclipse.xpanse.modules.models.servicetemplatechange.ServiceTemplateChangeInfo;
 import org.eclipse.xpanse.modules.models.workflow.migrate.MigrateRequest;
 import org.eclipse.xpanse.plugins.huaweicloud.monitor.constant.HuaweiCloudMonitorConstants;
@@ -99,6 +102,11 @@ class DeploymentWithMysqlTest extends AbstractMysqlIntegrationTest {
         boolean deployOrderIsCompleted = waitServiceOrderIsCompleted(deployOrderId);
         if (deployOrderIsCompleted) {
             DeployedServiceDetails deployedServiceDetails = getDeployedServiceDetails(serviceId);
+
+            UserOrderableServiceVo orderableServiceDetails =
+                    serviceDeployerApi.getOrderableServiceDetailsByServiceId(serviceId.toString());
+            assertEquals(orderableServiceDetails.getServiceTemplateId(),
+                    serviceTemplateHistory.getServiceTemplateId());
             ServiceDeploymentState serviceDeploymentState =
                     deployedServiceDetails.getServiceDeploymentState();
 
@@ -211,7 +219,6 @@ class DeploymentWithMysqlTest extends AbstractMysqlIntegrationTest {
         return serviceMigrationApi.migrate(migrateRequest);
     }
 
-
     void testModifyAndGetDetails(UUID serviceId, ServiceTemplateDetailVo serviceTemplate)
             throws Exception {
         // SetUp
@@ -230,9 +237,9 @@ class DeploymentWithMysqlTest extends AbstractMysqlIntegrationTest {
             ServiceOrderDetails serviceOrderDetails =
                     serviceOrderManageApi.getOrderDetailsByOrderId(
                             serviceOrder.getOrderId().toString());
-            Assertions.assertEquals(serviceOrderDetails.getTaskStatus(),
+            assertEquals(serviceOrderDetails.getTaskStatus(),
                     TaskStatus.SUCCESSFUL);
-            Assertions.assertEquals(serviceOrderDetails.getTaskType(),
+            assertEquals(serviceOrderDetails.getTaskType(),
                     ServiceOrderType.MODIFY);
 
         }
@@ -246,9 +253,9 @@ class DeploymentWithMysqlTest extends AbstractMysqlIntegrationTest {
             ServiceOrderDetails serviceOrderDetails =
                     serviceOrderManageApi.getOrderDetailsByOrderId(
                             serviceOrder.getOrderId().toString());
-            Assertions.assertEquals(serviceOrderDetails.getTaskStatus(),
+            assertEquals(serviceOrderDetails.getTaskStatus(),
                     TaskStatus.SUCCESSFUL);
-            Assertions.assertEquals(serviceOrderDetails.getTaskType(),
+            assertEquals(serviceOrderDetails.getTaskType(),
                     ServiceOrderType.DESTROY);
         }
     }


### PR DESCRIPTION
**Fixed https://github.com/eclipse-xpanse/xpanse/issues/2105**

New service getOrderdableServiceDetailsByServiceId:
![image](https://github.com/user-attachments/assets/bb9d67e5-8b18-4db7-83df-4c37380c290c)

Call service getOrderdableServiceDetailsByServiceId work well:
![image](https://github.com/user-attachments/assets/55383ed7-2b5c-42ee-ac86-fad3c0ca029c)

Call service getOrderdableServiceDetailsByServiceId throw exception:
![image](https://github.com/user-attachments/assets/6086bcbe-7137-400b-9272-117bf316890f)


