### PR TITLE
Query service template history and query request ocl by changeId

### DIFF
--- a/modules/api/src/main/java/org/eclipse/xpanse/api/config/GetCspInfoFromRequest.java
+++ b/modules/api/src/main/java/org/eclipse/xpanse/api/config/GetCspInfoFromRequest.java
@@ -25,6 +25,8 @@ import org.eclipse.xpanse.modules.database.servicepolicy.DatabaseServicePolicySt
 import org.eclipse.xpanse.modules.database.servicepolicy.ServicePolicyEntity;
 import org.eclipse.xpanse.modules.database.servicetemplate.DatabaseServiceTemplateStorage;
 import org.eclipse.xpanse.modules.database.servicetemplate.ServiceTemplateEntity;
+import org.eclipse.xpanse.modules.database.servicetemplatehistory.ServiceTemplateHistoryEntity;
+import org.eclipse.xpanse.modules.database.servicetemplatehistory.ServiceTemplateHistoryStorage;
 import org.eclipse.xpanse.modules.database.userpolicy.DatabaseUserPolicyStorage;
 import org.eclipse.xpanse.modules.database.userpolicy.UserPolicyEntity;
 import org.eclipse.xpanse.modules.models.common.enums.Csp;
@@ -52,6 +54,8 @@ public class GetCspInfoFromRequest {
     private TaskService taskService;
     @Resource
     private DatabaseServiceOrderStorage serviceOrderTaskStorage;
+    @Resource
+    private ServiceTemplateHistoryStorage serviceTemplateHistoryStorage;
 
     /**
      * Get Csp with the URL of Ocl.
@@ -195,6 +199,27 @@ public class GetCspInfoFromRequest {
             }
         } catch (Exception e) {
             log.error("Get csp with service order id:{} failed.", orderId, e);
+        }
+        return null;
+    }
+
+
+    /**
+     * Get Csp with service template change id.
+     *
+     * @param changeId id of service template change.
+     * @return csp.
+     */
+    public Csp getCspFromServiceTemplateChangeId(String changeId) {
+        try {
+            ServiceTemplateHistoryEntity serviceTemplateHistory =
+                    serviceTemplateHistoryStorage.getEntityById(UUID.fromString(changeId));
+            if (Objects.nonNull(serviceTemplateHistory) && Objects.nonNull(
+                    serviceTemplateHistory.getServiceTemplate())) {
+                return serviceTemplateHistory.getServiceTemplate().getCsp();
+            }
+        } catch (Exception e) {
+            log.error("Get csp with service template change id:{} failed.", changeId, e);
         }
         return null;
     }

--- a/modules/api/src/main/java/org/eclipse/xpanse/api/config/ServiceTemplateChangeStatusEnumConverter.java
+++ b/modules/api/src/main/java/org/eclipse/xpanse/api/config/ServiceTemplateChangeStatusEnumConverter.java
@@ -1,0 +1,24 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * SPDX-FileCopyrightText: Huawei Inc.
+ */
+
+package org.eclipse.xpanse.api.config;
+
+import jakarta.annotation.Nonnull;
+import org.eclipse.xpanse.modules.models.servicetemplate.change.enums.ServiceTemplateChangeStatus;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.stereotype.Component;
+
+/**
+ * Bean for serializing string in request parameters to ServiceTemplateChangeStatus enum.
+ */
+@Component
+public class ServiceTemplateChangeStatusEnumConverter
+        implements Converter<String, ServiceTemplateChangeStatus> {
+
+    @Override
+    public ServiceTemplateChangeStatus convert(@Nonnull String type) {
+        return ServiceTemplateChangeStatus.getByValue(type);
+    }
+}

--- a/modules/api/src/main/java/org/eclipse/xpanse/api/config/ServiceTemplateRequestTypeEnumConverter.java
+++ b/modules/api/src/main/java/org/eclipse/xpanse/api/config/ServiceTemplateRequestTypeEnumConverter.java
@@ -1,0 +1,24 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * SPDX-FileCopyrightText: Huawei Inc.
+ */
+
+package org.eclipse.xpanse.api.config;
+
+import javax.annotation.Nonnull;
+import org.eclipse.xpanse.modules.models.servicetemplate.change.enums.ServiceTemplateRequestType;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.stereotype.Component;
+
+/**
+ * Bean for serializing string in request parameters to ServiceTemplateRequestType enum.
+ */
+@Component
+public class ServiceTemplateRequestTypeEnumConverter
+        implements Converter<String, ServiceTemplateRequestType> {
+
+    @Override
+    public ServiceTemplateRequestType convert(@Nonnull String type) {
+        return ServiceTemplateRequestType.getByValue(type);
+    }
+}

--- a/modules/api/src/main/java/org/eclipse/xpanse/api/exceptions/handler/RegistrationExceptionHandler.java
+++ b/modules/api/src/main/java/org/eclipse/xpanse/api/exceptions/handler/RegistrationExceptionHandler.java
@@ -12,6 +12,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.eclipse.xpanse.modules.models.billing.exceptions.InvalidBillingConfigException;
 import org.eclipse.xpanse.modules.models.response.ErrorResponse;
 import org.eclipse.xpanse.modules.models.response.ErrorType;
+import org.eclipse.xpanse.modules.models.servicetemplate.change.exceptions.ServiceTemplateChangeRequestNotFound;
 import org.eclipse.xpanse.modules.models.servicetemplate.exceptions.IconProcessingFailedException;
 import org.eclipse.xpanse.modules.models.servicetemplate.exceptions.InvalidServiceFlavorsException;
 import org.eclipse.xpanse.modules.models.servicetemplate.exceptions.InvalidServiceVersionException;
@@ -193,6 +194,18 @@ public class RegistrationExceptionHandler {
     public ErrorResponse handleServiceTemplateStillInUseException(
             ServiceTemplateStillInUseException ex) {
         return getErrorResponse(ErrorType.SERVICE_TEMPLATE_STILL_IN_USE,
+                Collections.singletonList(ex.getMessage()));
+    }
+
+    /**
+     * Exception handler for ServiceTemplateChangeRequestNotFound.
+     */
+    @ExceptionHandler({ServiceTemplateChangeRequestNotFound.class})
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ResponseBody
+    public ErrorResponse handleServiceTemplateChangeRequestNotFoundException(
+            ServiceTemplateChangeRequestNotFound ex) {
+        return getErrorResponse(ErrorType.SERVICE_TEMPLATE_CHANGE_REQUEST_NOT_FOUND,
                 Collections.singletonList(ex.getMessage()));
     }
 }

--- a/modules/api/src/test/java/org/eclipse/xpanse/api/config/ServiceTemplateChangeStatusEnumConverterTest.java
+++ b/modules/api/src/test/java/org/eclipse/xpanse/api/config/ServiceTemplateChangeStatusEnumConverterTest.java
@@ -1,0 +1,25 @@
+package org.eclipse.xpanse.api.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.eclipse.xpanse.modules.models.common.exceptions.UnsupportedEnumValueException;
+import org.eclipse.xpanse.modules.models.servicetemplate.change.enums.ServiceTemplateChangeStatus;
+import org.junit.jupiter.api.Test;
+
+class ServiceTemplateChangeStatusEnumConverterTest {
+
+    private final ServiceTemplateChangeStatusEnumConverter converterTest =
+            new ServiceTemplateChangeStatusEnumConverter();
+
+    @Test
+    void testConvert() throws Exception {
+        assertThat(converterTest.convert("in-review")).isEqualTo(
+                ServiceTemplateChangeStatus.IN_REVIEW);
+        assertThat(converterTest.convert("accepted")).isEqualTo(
+                ServiceTemplateChangeStatus.ACCEPTED);
+        assertThat(converterTest.convert("rejected")).isEqualTo(
+                ServiceTemplateChangeStatus.REJECTED);
+        assertThrows(UnsupportedEnumValueException.class, () -> converterTest.convert("unknown"));
+    }
+}

--- a/modules/api/src/test/java/org/eclipse/xpanse/api/config/ServiceTemplateRequestTypeEnumConverterTest.java
+++ b/modules/api/src/test/java/org/eclipse/xpanse/api/config/ServiceTemplateRequestTypeEnumConverterTest.java
@@ -1,0 +1,27 @@
+package org.eclipse.xpanse.api.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.eclipse.xpanse.modules.models.common.exceptions.UnsupportedEnumValueException;
+import org.eclipse.xpanse.modules.models.servicetemplate.change.enums.ServiceTemplateRequestType;
+import org.junit.jupiter.api.Test;
+
+class ServiceTemplateRequestTypeEnumConverterTest {
+
+    private final ServiceTemplateRequestTypeEnumConverter converterTest =
+            new ServiceTemplateRequestTypeEnumConverter();
+
+    @Test
+    void testConvert() {
+        assertThat(converterTest.convert("register"))
+                .isEqualTo(ServiceTemplateRequestType.REGISTER);
+        assertThat(converterTest.convert("update"))
+                .isEqualTo(ServiceTemplateRequestType.UPDATE);
+        assertThat(converterTest.convert("unregister"))
+                .isEqualTo(ServiceTemplateRequestType.UNREGISTER);
+        assertThat(converterTest.convert("re-register"))
+                .isEqualTo(ServiceTemplateRequestType.RE_REGISTER);
+        assertThrows(UnsupportedEnumValueException.class, () -> converterTest.convert("unknown"));
+    }
+}

--- a/modules/database/src/main/java/org/eclipse/xpanse/modules/database/serviceorder/DatabaseServiceOrderStorage.java
+++ b/modules/database/src/main/java/org/eclipse/xpanse/modules/database/serviceorder/DatabaseServiceOrderStorage.java
@@ -72,7 +72,6 @@ public class DatabaseServiceOrderStorage implements ServiceOrderStorage {
                         predicateList.add(criteriaBuilder.equal(root.get("workflowId"),
                                 entity.getWorkflowId()));
                     }
-                    assert query != null;
                     query.orderBy(criteriaBuilder.desc(root.get("startedTime")));
                     query.distinct(true);
                     return query.where(criteriaBuilder.and(predicateList.toArray(new Predicate[0])))

--- a/modules/database/src/main/java/org/eclipse/xpanse/modules/database/servicetemplatehistory/DatabaseServiceTemplateHistoryStorage.java
+++ b/modules/database/src/main/java/org/eclipse/xpanse/modules/database/servicetemplatehistory/DatabaseServiceTemplateHistoryStorage.java
@@ -6,12 +6,10 @@
 
 package org.eclipse.xpanse.modules.database.servicetemplatehistory;
 
-import jakarta.persistence.criteria.Predicate;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
+import org.eclipse.xpanse.modules.models.servicetemplate.change.exceptions.ServiceTemplateChangeRequestNotFound;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -38,21 +36,11 @@ public class DatabaseServiceTemplateHistoryStorage implements ServiceTemplateHis
     }
 
     @Override
-    public List<ServiceTemplateHistoryEntity> listServiceTemplateHistory(
-            ServiceTemplateHistoryEntity queryEntity) {
-        Specification<ServiceTemplateHistoryEntity> specification =
-                (root, query, criteriaBuilder) -> {
-                    List<Predicate> predicateList = new ArrayList<>();
-                    predicateList.add(criteriaBuilder.equal(root.get("serviceTemplate").get("id"),
-                            queryEntity.getServiceTemplate().getId()));
-                    predicateList.add(criteriaBuilder.equal(root.get("requestType"),
-                            queryEntity.getRequestType()));
-                    predicateList.add(criteriaBuilder.equal(root.get("status"),
-                            queryEntity.getStatus()));
-                    return query.where(criteriaBuilder.and(predicateList.toArray(new Predicate[0])))
-                            .getRestriction();
-                };
-        return repository.findAll(specification);
+    public ServiceTemplateHistoryEntity getEntityById(UUID changeId) {
+        return repository.findById(changeId).orElseThrow(() ->
+                new ServiceTemplateChangeRequestNotFound(
+                        "Service template change request with id " + changeId + " not found.")
+        );
     }
 
 }

--- a/modules/database/src/main/java/org/eclipse/xpanse/modules/database/servicetemplatehistory/ServiceTemplateHistoryEntity.java
+++ b/modules/database/src/main/java/org/eclipse/xpanse/modules/database/servicetemplatehistory/ServiceTemplateHistoryEntity.java
@@ -25,8 +25,8 @@ import org.eclipse.xpanse.modules.database.common.CreateModifiedTime;
 import org.eclipse.xpanse.modules.database.common.ObjectJsonConverter;
 import org.eclipse.xpanse.modules.database.servicetemplate.ServiceTemplateEntity;
 import org.eclipse.xpanse.modules.models.servicetemplate.Ocl;
-import org.eclipse.xpanse.modules.models.servicetemplate.enums.ServiceTemplateChangeStatus;
-import org.eclipse.xpanse.modules.models.servicetemplate.enums.ServiceTemplateRequestType;
+import org.eclipse.xpanse.modules.models.servicetemplate.change.enums.ServiceTemplateChangeStatus;
+import org.eclipse.xpanse.modules.models.servicetemplate.change.enums.ServiceTemplateRequestType;
 import org.hibernate.annotations.Type;
 
 /**

--- a/modules/database/src/main/java/org/eclipse/xpanse/modules/database/servicetemplatehistory/ServiceTemplateHistoryStorage.java
+++ b/modules/database/src/main/java/org/eclipse/xpanse/modules/database/servicetemplatehistory/ServiceTemplateHistoryStorage.java
@@ -6,7 +6,7 @@
 
 package org.eclipse.xpanse.modules.database.servicetemplatehistory;
 
-import java.util.List;
+import java.util.UUID;
 
 /**
  * Interface for persist of ServiceTemplateHistory.
@@ -24,12 +24,11 @@ public interface ServiceTemplateHistoryStorage {
             ServiceTemplateHistoryEntity serviceTemplateHistoryEntity);
 
     /**
-     * List ServiceTemplateHistoryEntity by queryEntity.
+     * Get ServiceTemplateHistoryEntity by changeId.
      *
-     * @param queryEntity to be queried.
-     * @return list of ServiceTemplateHistoryEntity.
+     * @param changeId given changeId
+     * @return ServiceTemplateHistoryEntity
      */
-    List<ServiceTemplateHistoryEntity> listServiceTemplateHistory(
-            ServiceTemplateHistoryEntity queryEntity);
+    ServiceTemplateHistoryEntity getEntityById(UUID changeId);
 
 }

--- a/modules/database/src/main/java/org/eclipse/xpanse/modules/database/utils/EntityTransUtils.java
+++ b/modules/database/src/main/java/org/eclipse/xpanse/modules/database/utils/EntityTransUtils.java
@@ -19,6 +19,7 @@ import org.eclipse.xpanse.modules.database.service.ServiceDeploymentEntity;
 import org.eclipse.xpanse.modules.database.serviceconfiguration.ServiceConfigurationEntity;
 import org.eclipse.xpanse.modules.database.serviceconfiguration.update.ServiceConfigurationChangeDetailsEntity;
 import org.eclipse.xpanse.modules.database.serviceorder.ServiceOrderEntity;
+import org.eclipse.xpanse.modules.database.servicetemplatehistory.ServiceTemplateHistoryEntity;
 import org.eclipse.xpanse.modules.models.service.deploy.DeployResource;
 import org.eclipse.xpanse.modules.models.service.order.ServiceOrderDetails;
 import org.eclipse.xpanse.modules.models.service.view.DeployedService;
@@ -27,6 +28,7 @@ import org.eclipse.xpanse.modules.models.service.view.VendorHostedDeployedServic
 import org.eclipse.xpanse.modules.models.serviceconfiguration.ServiceConfigurationChangeDetails;
 import org.eclipse.xpanse.modules.models.serviceconfiguration.ServiceConfigurationChangeOrderDetails;
 import org.eclipse.xpanse.modules.models.serviceconfiguration.ServiceConfigurationDetails;
+import org.eclipse.xpanse.modules.models.servicetemplate.change.ServiceTemplateHistoryVo;
 import org.springframework.beans.BeanUtils;
 import org.springframework.util.CollectionUtils;
 
@@ -88,8 +90,8 @@ public class EntityTransUtils {
      * @param entity DeployServiceEntity.
      * @return DeployedServiceDetails
      */
-    public static DeployedServiceDetails
-            transToDeployedServiceDetails(ServiceDeploymentEntity entity) {
+    public static DeployedServiceDetails transToDeployedServiceDetails(
+            ServiceDeploymentEntity entity) {
         DeployedServiceDetails details = new DeployedServiceDetails();
         details.setServiceHostingType(entity.getDeployRequest().getServiceHostingType());
         details.setBillingMode(entity.getDeployRequest().getBillingMode());
@@ -195,5 +197,21 @@ public class EntityTransUtils {
             orderDetailsList.add(orderDetails);
         });
         return orderDetailsList;
+    }
+
+
+    /**
+     * ServiceTemplateHistoryEntity converted to ServiceTemplateHistoryVo.
+     *
+     * @param serviceTemplateHistoryEntity ServiceTemplateHistoryEntity.
+     * @return serviceTemplateHistoryVo
+     */
+    public static ServiceTemplateHistoryVo convertToServiceTemplateHistoryVo(
+            ServiceTemplateHistoryEntity serviceTemplateHistoryEntity) {
+        ServiceTemplateHistoryVo serviceTemplateHistoryVo = new ServiceTemplateHistoryVo();
+        serviceTemplateHistoryVo.setServiceTemplateId(
+                serviceTemplateHistoryEntity.getServiceTemplate().getId());
+        BeanUtils.copyProperties(serviceTemplateHistoryEntity, serviceTemplateHistoryVo);
+        return serviceTemplateHistoryVo;
     }
 }

--- a/modules/models/src/main/java/org/eclipse/xpanse/modules/models/response/ErrorType.java
+++ b/modules/models/src/main/java/org/eclipse/xpanse/modules/models/response/ErrorType.java
@@ -45,6 +45,7 @@ public enum ErrorType {
     DEPLOYMENT_VARIABLE_INVALID("Deployment Variable Invalid"),
     SERVICE_TEMPLATE_UPDATE_NOT_ALLOWED("Service Template Update Not Allowed"),
     SERVICE_TEMPLATE_STILL_IN_USE("Service Template Still In Use"),
+    SERVICE_TEMPLATE_CHANGE_REQUEST_NOT_FOUND("Service Template Change Request Not Found"),
     UNAUTHORIZED("Unauthorized"),
     ACCESS_DENIED("Access Denied"),
     SENSITIVE_FIELD_ENCRYPTION_DECRYPTION_EXCEPTION("Sensitive "

--- a/modules/models/src/main/java/org/eclipse/xpanse/modules/models/servicetemplate/change/ServiceTemplateChangeInfo.java
+++ b/modules/models/src/main/java/org/eclipse/xpanse/modules/models/servicetemplate/change/ServiceTemplateChangeInfo.java
@@ -4,7 +4,7 @@
  */
 
 
-package org.eclipse.xpanse.modules.models.servicetemplatechange;
+package org.eclipse.xpanse.modules.models.servicetemplate.change;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
@@ -14,7 +14,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 /**
- * Defines view object for service template history.
+ * Defines view object for service template request.
  */
 @Data
 @AllArgsConstructor

--- a/modules/models/src/main/java/org/eclipse/xpanse/modules/models/servicetemplate/change/ServiceTemplateHistoryVo.java
+++ b/modules/models/src/main/java/org/eclipse/xpanse/modules/models/servicetemplate/change/ServiceTemplateHistoryVo.java
@@ -1,0 +1,59 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * SPDX-FileCopyrightText: Huawei Inc.
+ */
+
+
+package org.eclipse.xpanse.modules.models.servicetemplate.change;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.ser.OffsetDateTimeSerializer;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import java.time.OffsetDateTime;
+import java.util.UUID;
+import lombok.Data;
+import org.eclipse.xpanse.modules.models.servicetemplate.change.enums.ServiceTemplateChangeStatus;
+import org.eclipse.xpanse.modules.models.servicetemplate.change.enums.ServiceTemplateRequestType;
+
+/**
+ * Defines view object for service template history.
+ */
+@Data
+public class ServiceTemplateHistoryVo {
+
+    @NotNull
+    @Schema(description = "ID of the registered service template.")
+    private UUID serviceTemplateId;
+
+    @NotNull
+    @Schema(description = "ID of the change history of the service template.")
+    private UUID changeId;
+
+    @NotNull
+    @Schema(description = "Type of the request.")
+    private ServiceTemplateRequestType requestType;
+
+    @NotNull
+    @Schema(description = "Status of the request.")
+    private ServiceTemplateChangeStatus status;
+
+    @Schema(description = "Comment of the review request.")
+    private String reviewComment;
+
+    @Schema(description = "Status of the request.")
+    private Boolean blockTemplateUntilReviewed;
+
+    @NotNull
+    @Schema(description = "Create time of the service template request.")
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss XXX")
+    @JsonSerialize(using = OffsetDateTimeSerializer.class)
+    private OffsetDateTime createTime;
+
+    @NotNull
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss XXX")
+    @JsonSerialize(using = OffsetDateTimeSerializer.class)
+    @Schema(description = "Last update time of the service template request.")
+    private OffsetDateTime lastModifiedTime;
+}

--- a/modules/models/src/main/java/org/eclipse/xpanse/modules/models/servicetemplate/change/enums/ServiceTemplateChangeStatus.java
+++ b/modules/models/src/main/java/org/eclipse/xpanse/modules/models/servicetemplate/change/enums/ServiceTemplateChangeStatus.java
@@ -3,7 +3,7 @@
  * SPDX-FileCopyrightText: Huawei Inc.
  */
 
-package org.eclipse.xpanse.modules.models.servicetemplate.enums;
+package org.eclipse.xpanse.modules.models.servicetemplate.change.enums;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;

--- a/modules/models/src/main/java/org/eclipse/xpanse/modules/models/servicetemplate/change/enums/ServiceTemplateRequestType.java
+++ b/modules/models/src/main/java/org/eclipse/xpanse/modules/models/servicetemplate/change/enums/ServiceTemplateRequestType.java
@@ -3,7 +3,7 @@
  * SPDX-FileCopyrightText: Huawei Inc.
  */
 
-package org.eclipse.xpanse.modules.models.servicetemplate.enums;
+package org.eclipse.xpanse.modules.models.servicetemplate.change.enums;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;

--- a/modules/models/src/main/java/org/eclipse/xpanse/modules/models/servicetemplate/change/exceptions/ServiceTemplateChangeRequestNotFound.java
+++ b/modules/models/src/main/java/org/eclipse/xpanse/modules/models/servicetemplate/change/exceptions/ServiceTemplateChangeRequestNotFound.java
@@ -1,0 +1,17 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * SPDX-FileCopyrightText: Huawei Inc.
+ */
+
+package org.eclipse.xpanse.modules.models.servicetemplate.change.exceptions;
+
+/**
+ * Exception thrown when the queried service template change request is not found.
+ */
+public class ServiceTemplateChangeRequestNotFound extends RuntimeException {
+    public ServiceTemplateChangeRequestNotFound(String message) {
+        super(message);
+    }
+
+}
+

--- a/modules/models/src/main/java/org/eclipse/xpanse/modules/models/servicetemplate/exceptions/ServiceTemplateNotRegistered.java
+++ b/modules/models/src/main/java/org/eclipse/xpanse/modules/models/servicetemplate/exceptions/ServiceTemplateNotRegistered.java
@@ -13,6 +13,5 @@ public class ServiceTemplateNotRegistered extends RuntimeException {
         super(message);
     }
 
-
 }
 

--- a/runtime/src/test/java/org/eclipse/xpanse/runtime/database/mysql/DeploymentWithMysqlTest.java
+++ b/runtime/src/test/java/org/eclipse/xpanse/runtime/database/mysql/DeploymentWithMysqlTest.java
@@ -48,7 +48,7 @@ import org.eclipse.xpanse.modules.models.servicetemplate.enums.ServiceTemplateRe
 import org.eclipse.xpanse.modules.models.servicetemplate.utils.OclLoader;
 import org.eclipse.xpanse.modules.models.servicetemplate.view.ServiceTemplateDetailVo;
 import org.eclipse.xpanse.modules.models.servicetemplate.view.UserOrderableServiceVo;
-import org.eclipse.xpanse.modules.models.servicetemplatechange.ServiceTemplateChangeInfo;
+import org.eclipse.xpanse.modules.models.servicetemplate.change.ServiceTemplateChangeInfo;
 import org.eclipse.xpanse.modules.models.workflow.migrate.MigrateRequest;
 import org.eclipse.xpanse.plugins.huaweicloud.monitor.constant.HuaweiCloudMonitorConstants;
 import org.junit.jupiter.api.Assertions;

--- a/runtime/src/test/java/org/eclipse/xpanse/runtime/database/mysql/RegistrationWithMysqlTest.java
+++ b/runtime/src/test/java/org/eclipse/xpanse/runtime/database/mysql/RegistrationWithMysqlTest.java
@@ -22,7 +22,7 @@ import org.eclipse.xpanse.modules.models.servicetemplate.Ocl;
 import org.eclipse.xpanse.modules.models.servicetemplate.enums.ServiceTemplateRegistrationState;
 import org.eclipse.xpanse.modules.models.servicetemplate.utils.OclLoader;
 import org.eclipse.xpanse.modules.models.servicetemplate.view.ServiceTemplateDetailVo;
-import org.eclipse.xpanse.modules.models.servicetemplatechange.ServiceTemplateChangeInfo;
+import org.eclipse.xpanse.modules.models.servicetemplate.change.ServiceTemplateChangeInfo;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.semver4j.Semver;

--- a/runtime/src/test/java/org/eclipse/xpanse/runtime/util/ApisTestCommon.java
+++ b/runtime/src/test/java/org/eclipse/xpanse/runtime/util/ApisTestCommon.java
@@ -60,7 +60,7 @@ import org.eclipse.xpanse.modules.models.servicetemplate.ReviewRegistrationReque
 import org.eclipse.xpanse.modules.models.servicetemplate.enums.ServiceReviewResult;
 import org.eclipse.xpanse.modules.models.servicetemplate.utils.OclLoader;
 import org.eclipse.xpanse.modules.models.servicetemplate.view.ServiceTemplateDetailVo;
-import org.eclipse.xpanse.modules.models.servicetemplatechange.ServiceTemplateChangeInfo;
+import org.eclipse.xpanse.modules.models.servicetemplate.change.ServiceTemplateChangeInfo;
 import org.eclipse.xpanse.plugins.flexibleengine.common.FlexibleEngineClient;
 import org.eclipse.xpanse.plugins.flexibleengine.monitor.constant.FlexibleEngineMonitorConstants;
 import org.eclipse.xpanse.plugins.huaweicloud.common.HuaweiCloudClient;


### PR DESCRIPTION
**Fixed https://github.com/eclipse-xpanse/xpanse/issues/2106**

**New service `getServiceTemplateHistoryById`:**
![chrome_4vUeJ8Yi7Q](https://github.com/user-attachments/assets/5574106c-7edf-4a24-8d47-f58924351119)
Call this service with serviceTemplateId well:
![image](https://github.com/user-attachments/assets/f16461d8-9cc7-4a4c-96a1-323724d11aa4)
Call this service throw exception:
![image](https://github.com/user-attachments/assets/3000b9ea-2475-475d-a778-697284423dba)


**New service `getRequestedServiceTemplateByChangeId`:**
![image](https://github.com/user-attachments/assets/aa2b8da8-0d06-40c9-9ce5-d2f11ebf256b)
Call this service with changeId well:
![image](https://github.com/user-attachments/assets/1c793812-e781-4148-bbbc-04ff9f0c385e)
Call this service throw exception:
![image](https://github.com/user-attachments/assets/8095e440-acc6-4986-810c-5987a6e401ee)

