### PR TITLE
namespace validation in service template update requests

### DIFF
--- a/modules/servicetemplate/src/main/java/org/eclipse/xpanse/modules/servicetemplate/ServiceTemplateManage.java
+++ b/modules/servicetemplate/src/main/java/org/eclipse/xpanse/modules/servicetemplate/ServiceTemplateManage.java
@@ -188,6 +188,10 @@ public class ServiceTemplateManage {
         String oldServiceHostingType = existingTemplate.getServiceHostingType().toValue();
         String newServiceHostingType = ocl.getServiceHostingType().toValue();
         compare(oldServiceHostingType, newServiceHostingType, "service hosting type");
+
+        String oldNamespace = existingTemplate.getNamespace();
+        String newNamespace = ocl.getNamespace();
+        compare(oldNamespace, newNamespace, "namespace");
     }
 
     private void compare(String oldParams, String newParams, String type) {


### PR DESCRIPTION
Fixed https://github.com/eclipse-xpanse/xpanse/issues/2187

Register a service template with namespace 'ISV-A' successfully:
![image](https://github.com/user-attachments/assets/9310e1a6-ff10-4ae2-b350-a11cc8c8da13)
Update the service template with changed namespace 'ISV-B' thrown exception:
![image](https://github.com/user-attachments/assets/50df4201-e144-4c40-bfb7-7f3a5d66ee26)

