### PR TITLE
Fix error when deployment fails with missing credentials

### DIFF
--- a/modules/deployment/src/main/java/org/eclipse/xpanse/modules/deployment/deployers/opentofu/opentofulocal/OpenTofuLocalDeployment.java
+++ b/modules/deployment/src/main/java/org/eclipse/xpanse/modules/deployment/deployers/opentofu/opentofulocal/OpenTofuLocalDeployment.java
@@ -16,7 +16,6 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.Executor;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.StringUtils;
 import org.eclipse.xpanse.modules.database.service.ServiceDeploymentEntity;
 import org.eclipse.xpanse.modules.deployment.ServiceDeploymentEntityHandler;
 import org.eclipse.xpanse.modules.deployment.deployers.opentofu.callbacks.OpenTofuDeploymentResultCallbackManager;
@@ -26,7 +25,6 @@ import org.eclipse.xpanse.modules.deployment.deployers.opentofu.tofumaker.genera
 import org.eclipse.xpanse.modules.deployment.deployers.opentofu.utils.TfResourceTransUtils;
 import org.eclipse.xpanse.modules.deployment.utils.DeployEnvironments;
 import org.eclipse.xpanse.modules.deployment.utils.DeploymentScriptsHelper;
-import org.eclipse.xpanse.modules.models.service.deploy.exceptions.ServiceNotDeployedException;
 import org.eclipse.xpanse.modules.models.servicetemplate.Deployment;
 import org.eclipse.xpanse.modules.models.servicetemplate.enums.DeployerKind;
 import org.eclipse.xpanse.modules.orchestrator.deployment.DeployResult;
@@ -76,14 +74,6 @@ public class OpenTofuLocalDeployment implements Deployer {
         ServiceDeploymentEntity serviceDeploymentEntity =
                 serviceDeploymentEntityHandler.getServiceDeploymentEntity(task.getServiceId());
         String resourceState = TfResourceTransUtils.getStoredStateContent(serviceDeploymentEntity);
-        if (StringUtils.isBlank(resourceState)) {
-            String errorMsg =
-                    String.format(
-                            "tfState of deployed service with id %s not found.",
-                            task.getServiceId());
-            log.error(errorMsg);
-            throw new ServiceNotDeployedException(errorMsg);
-        }
         DeployResult destroyResult = new DeployResult();
         destroyResult.setOrderId(task.getOrderId());
         asyncExecDestroy(task, resourceState);
@@ -100,14 +90,6 @@ public class OpenTofuLocalDeployment implements Deployer {
         ServiceDeploymentEntity serviceDeploymentEntity =
                 serviceDeploymentEntityHandler.getServiceDeploymentEntity(task.getServiceId());
         String resourceState = TfResourceTransUtils.getStoredStateContent(serviceDeploymentEntity);
-        if (StringUtils.isBlank(resourceState)) {
-            String errorMsg =
-                    String.format(
-                            "tfState of service deployment with id %s not found.",
-                            task.getServiceId());
-            log.error(errorMsg);
-            throw new ServiceNotDeployedException(errorMsg);
-        }
         DeployResult modifyResult = new DeployResult();
         modifyResult.setOrderId(task.getOrderId());
         asyncExecModify(task, resourceState);

--- a/modules/deployment/src/main/java/org/eclipse/xpanse/modules/deployment/deployers/terraform/terraformlocal/TerraformLocalDeployment.java
+++ b/modules/deployment/src/main/java/org/eclipse/xpanse/modules/deployment/deployers/terraform/terraformlocal/TerraformLocalDeployment.java
@@ -15,7 +15,6 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.Executor;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.StringUtils;
 import org.eclipse.xpanse.modules.database.service.ServiceDeploymentEntity;
 import org.eclipse.xpanse.modules.deployment.ServiceDeploymentEntityHandler;
 import org.eclipse.xpanse.modules.deployment.deployers.terraform.callbacks.TerraformDeploymentResultCallbackManager;
@@ -25,7 +24,6 @@ import org.eclipse.xpanse.modules.deployment.deployers.terraform.terraformlocal.
 import org.eclipse.xpanse.modules.deployment.deployers.terraform.utils.TfResourceTransUtils;
 import org.eclipse.xpanse.modules.deployment.utils.DeployEnvironments;
 import org.eclipse.xpanse.modules.deployment.utils.DeploymentScriptsHelper;
-import org.eclipse.xpanse.modules.models.service.deploy.exceptions.ServiceNotDeployedException;
 import org.eclipse.xpanse.modules.models.servicetemplate.Deployment;
 import org.eclipse.xpanse.modules.models.servicetemplate.enums.DeployerKind;
 import org.eclipse.xpanse.modules.orchestrator.deployment.DeployResult;
@@ -75,14 +73,6 @@ public class TerraformLocalDeployment implements Deployer {
         ServiceDeploymentEntity serviceDeploymentEntity =
                 serviceDeploymentEntityHandler.getServiceDeploymentEntity(task.getServiceId());
         String resourceState = TfResourceTransUtils.getStoredStateContent(serviceDeploymentEntity);
-        if (StringUtils.isBlank(resourceState)) {
-            String errorMsg =
-                    String.format(
-                            "tfState of deployed service with id %s not found.",
-                            task.getServiceId());
-            log.error(errorMsg);
-            throw new ServiceNotDeployedException(errorMsg);
-        }
         DeployResult destroyResult = new DeployResult();
         destroyResult.setOrderId(task.getOrderId());
         asyncExecDestroy(task, resourceState);
@@ -99,14 +89,6 @@ public class TerraformLocalDeployment implements Deployer {
         ServiceDeploymentEntity serviceDeploymentEntity =
                 serviceDeploymentEntityHandler.getServiceDeploymentEntity(task.getServiceId());
         String resourceState = TfResourceTransUtils.getStoredStateContent(serviceDeploymentEntity);
-        if (StringUtils.isBlank(resourceState)) {
-            String errorMsg =
-                    String.format(
-                            "tfState of deployed service with id %s not found.",
-                            task.getServiceId());
-            log.error(errorMsg);
-            throw new ServiceNotDeployedException(errorMsg);
-        }
         DeployResult modifyResult = new DeployResult();
         modifyResult.setOrderId(task.getOrderId());
         asyncExecModify(task, resourceState);


### PR DESCRIPTION
**Fixed https://github.com/eclipse-xpanse/xpanse/issues/2150**

Deploy service without credentials:
After deploy failed, there is no rollback order to destroy resources any more:
![chrome_oUou3SB4br](https://github.com/user-attachments/assets/e02d3a1b-c8b2-4791-9bb1-7cb4fb704885)

Add credentials successfully:
![chrome_n6CVxWMFc4](https://github.com/user-attachments/assets/85878040-a005-41c3-b3c9-7582e6a703b5)

Retry to deploy the failed service and then  the retry is successful:
![chrome_nB6s6xPQis](https://github.com/user-attachments/assets/b02dcce7-b9e1-4a31-93fe-8a777266dfb3)

