### PR TITLE
Add service to cancel service template request

### DIFF
--- a/modules/api/src/test/java/org/eclipse/xpanse/api/config/ServiceTemplateRegistrationStateConverterTest.java
+++ b/modules/api/src/test/java/org/eclipse/xpanse/api/config/ServiceTemplateRegistrationStateConverterTest.java
@@ -18,6 +18,8 @@ class ServiceTemplateRegistrationStateConverterTest {
                 ServiceTemplateRegistrationState.IN_REVIEW, converterTest.convert("in-review"));
         assertEquals(ServiceTemplateRegistrationState.APPROVED, converterTest.convert("approved"));
         assertEquals(ServiceTemplateRegistrationState.REJECTED, converterTest.convert("rejected"));
+        assertEquals(
+                ServiceTemplateRegistrationState.CANCELLED, converterTest.convert("cancelled"));
         assertThrows(UnsupportedEnumValueException.class, () -> converterTest.convert(" "));
         assertThrows(
                 UnsupportedEnumValueException.class, () -> converterTest.convert("error_value"));

--- a/modules/api/src/test/java/org/eclipse/xpanse/api/config/ServiceTemplateRequestStatusEnumConverterTest.java
+++ b/modules/api/src/test/java/org/eclipse/xpanse/api/config/ServiceTemplateRequestStatusEnumConverterTest.java
@@ -20,8 +20,8 @@ class ServiceTemplateRequestStatusEnumConverterTest {
                 .isEqualTo(ServiceTemplateRequestStatus.ACCEPTED);
         assertThat(converterTest.convert("rejected"))
                 .isEqualTo(ServiceTemplateRequestStatus.REJECTED);
-        assertThat(converterTest.convert("canceled"))
-                .isEqualTo(ServiceTemplateRequestStatus.CANCELED);
+        assertThat(converterTest.convert("cancelled"))
+                .isEqualTo(ServiceTemplateRequestStatus.CANCELLED);
         assertThrows(UnsupportedEnumValueException.class, () -> converterTest.convert("unknown"));
     }
 }

--- a/modules/database/src/main/java/org/eclipse/xpanse/modules/database/servicetemplaterequest/DatabaseServiceTemplateRequestHistoryStorage.java
+++ b/modules/database/src/main/java/org/eclipse/xpanse/modules/database/servicetemplaterequest/DatabaseServiceTemplateRequestHistoryStorage.java
@@ -90,7 +90,7 @@ public class DatabaseServiceTemplateRequestHistoryStorage
     @Override
     public void cancelRequestsInBatch(List<ServiceTemplateRequestHistoryEntity> requests) {
         for (ServiceTemplateRequestHistoryEntity request : requests) {
-            request.setStatus(ServiceTemplateRequestStatus.CANCELED);
+            request.setStatus(ServiceTemplateRequestStatus.CANCELLED);
         }
         repository.saveAll(requests);
     }

--- a/modules/database/src/main/java/org/eclipse/xpanse/modules/database/servicetemplaterequest/ServiceTemplateRequestHistoryStorage.java
+++ b/modules/database/src/main/java/org/eclipse/xpanse/modules/database/servicetemplaterequest/ServiceTemplateRequestHistoryStorage.java
@@ -38,6 +38,10 @@ public interface ServiceTemplateRequestHistoryStorage {
     List<ServiceTemplateRequestHistoryEntity> listServiceTemplateRequestHistoryByQueryModel(
             ServiceTemplateRequestHistoryQueryModel queryModel);
 
-    /** cancel requests in batch. */
+    /**
+     * cancel requests in batch.
+     *
+     * @param requests requests to cancel
+     */
     void cancelRequestsInBatch(List<ServiceTemplateRequestHistoryEntity> requests);
 }

--- a/modules/models/src/main/java/org/eclipse/xpanse/modules/models/servicetemplate/enums/ServiceTemplateRegistrationState.java
+++ b/modules/models/src/main/java/org/eclipse/xpanse/modules/models/servicetemplate/enums/ServiceTemplateRegistrationState.java
@@ -14,6 +14,7 @@ import org.eclipse.xpanse.modules.models.common.exceptions.UnsupportedEnumValueE
 public enum ServiceTemplateRegistrationState {
     IN_REVIEW("in-review"),
     APPROVED("approved"),
+    CANCELLED("cancelled"),
     REJECTED("rejected");
 
     private final String state;

--- a/modules/models/src/main/java/org/eclipse/xpanse/modules/models/servicetemplate/request/enums/ServiceTemplateRequestStatus.java
+++ b/modules/models/src/main/java/org/eclipse/xpanse/modules/models/servicetemplate/request/enums/ServiceTemplateRequestStatus.java
@@ -15,7 +15,7 @@ public enum ServiceTemplateRequestStatus {
     IN_REVIEW("in-review"),
     ACCEPTED("accepted"),
     REJECTED("rejected"),
-    CANCELED("canceled");
+    CANCELLED("cancelled");
 
     private final String state;
 


### PR DESCRIPTION
Fixed https://github.com/eclipse-xpanse/xpanse/issues/2199

Add new API to cancel service template request:
![image](https://github.com/user-attachments/assets/086a1824-41dc-4ace-958f-6018c938d50e)

Register service template , approve the register request, update the service template: 
![image](https://github.com/user-attachments/assets/f539fe90-f11d-4ad1-a251-3fe15ba1b624)

Cancel update request in status 'IN-REVIEW' well:
![image](https://github.com/user-attachments/assets/970b3033-e389-4555-a532-f65f9a7d2910)

Cancel request not in status 'IN-REVIEW' returns error:
![image](https://github.com/user-attachments/assets/d1763a35-6ce0-4822-be5f-b7e3faeb337c)



