### PR TITLE
rename service template methods and enums

### DIFF
--- a/modules/api/src/main/java/org/eclipse/xpanse/api/controllers/ServiceTemplateApi.java
+++ b/modules/api/src/main/java/org/eclipse/xpanse/api/controllers/ServiceTemplateApi.java
@@ -73,7 +73,10 @@ public class ServiceTemplateApi {
      * @return response
      */
     @Tag(name = "ServiceVendor", description = "APIs to manage service templates.")
-    @Operation(description = "Register new service template using ocl model.")
+    @Operation(
+            description =
+                    "Submits a new service template using Ocl model. When the request is approved,"
+                            + " the service template will be published to catalog.")
     @PostMapping(value = "/service_templates", produces = MediaType.APPLICATION_JSON_VALUE)
     @ResponseStatus(HttpStatus.OK)
     @Transactional
@@ -91,7 +94,10 @@ public class ServiceTemplateApi {
      * @return response
      */
     @Tag(name = "ServiceVendor", description = "APIs to manage service templates.")
-    @Operation(description = "Update service template using id and ocl model.")
+    @Operation(
+            description =
+                    "Updates an existing service template using Ocl model.  When the request is"
+                        + " approved, the updated service template will be published to catalog.")
     @PutMapping(
             value = "/service_templates/{serviceTemplateId}",
             produces = MediaType.APPLICATION_JSON_VALUE)
@@ -103,16 +109,16 @@ public class ServiceTemplateApi {
                     @PathVariable("serviceTemplateId")
                     UUID serviceTemplateId,
             @Parameter(
-                            name = "isRemoveServiceTemplateUntilApproved",
+                            name = "isUnpublishUntilApproved",
                             description =
                                     "If true, the old service template is also removed from catalog"
                                             + " until the updated one is reviewed and approved.")
-                    @RequestParam(name = "isRemoveServiceTemplateUntilApproved")
-                    Boolean isRemoveServiceTemplateUntilApproved,
+                    @RequestParam(name = "isUnpublishUntilApproved")
+                    Boolean isUnpublishUntilApproved,
             @Valid @RequestBody Ocl ocl) {
         ServiceTemplateRequestHistoryEntity updateRequest =
                 serviceTemplateManage.updateServiceTemplate(
-                        serviceTemplateId, ocl, isRemoveServiceTemplateUntilApproved);
+                        serviceTemplateId, ocl, isUnpublishUntilApproved);
         return getServiceTemplateRequestInfo(updateRequest);
     }
 
@@ -123,7 +129,10 @@ public class ServiceTemplateApi {
      * @return response
      */
     @Tag(name = "ServiceVendor", description = "APIs to manage service templates.")
-    @Operation(description = "Register new service template using URL of Ocl file.")
+    @Operation(
+            description =
+                    "Submits a new service template using URL of Ocl file. When the request is"
+                            + " approved, the service template will be published to catalog.")
     @PostMapping(value = "/service_templates/file", produces = MediaType.APPLICATION_JSON_VALUE)
     @ResponseStatus(HttpStatus.OK)
     @Transactional
@@ -147,7 +156,11 @@ public class ServiceTemplateApi {
      * @return response
      */
     @Tag(name = "ServiceVendor", description = "APIs to manage service templates.")
-    @Operation(description = "Update service template using id and URL of Ocl file.")
+    @Operation(
+            description =
+                    "Updates an existing service template using URL of Ocl file. When the request"
+                            + " is approved, the updated service template will be published to"
+                            + " catalog.")
     @PutMapping(
             value = "/service_templates/file/{serviceTemplateId}",
             produces = MediaType.APPLICATION_JSON_VALUE)
@@ -159,12 +172,12 @@ public class ServiceTemplateApi {
                     @PathVariable(name = "serviceTemplateId")
                     UUID serviceTemplateId,
             @Parameter(
-                            name = "isRemoveServiceTemplateUntilApproved",
+                            name = "isUnpublishUntilApproved",
                             description =
                                     "If true, the old service template is also removed from catalog"
                                             + " until the updated one is reviewed and approved.")
-                    @RequestParam(name = "isRemoveServiceTemplateUntilApproved")
-                    Boolean isRemoveServiceTemplateUntilApproved,
+                    @RequestParam(name = "isUnpublishUntilApproved")
+                    Boolean isUnpublishUntilApproved,
             @Parameter(name = "oclLocation", description = "URL of Ocl file")
                     @RequestParam(name = "oclLocation")
                     String oclLocation)
@@ -172,7 +185,7 @@ public class ServiceTemplateApi {
         Ocl ocl = oclLoader.getOcl(URI.create(oclLocation).toURL());
         ServiceTemplateRequestHistoryEntity updateRequest =
                 serviceTemplateManage.updateServiceTemplate(
-                        serviceTemplateId, ocl, isRemoveServiceTemplateUntilApproved);
+                        serviceTemplateId, ocl, isUnpublishUntilApproved);
         return getServiceTemplateRequestInfo(updateRequest);
     }
 
@@ -183,18 +196,18 @@ public class ServiceTemplateApi {
      * @return response
      */
     @Tag(name = "ServiceVendor", description = "APIs to manage service templates.")
-    @Operation(description = "Remove service template from catalog using id.")
-    @PutMapping("/service_templates/remove_from_catalog/{serviceTemplateId}")
+    @Operation(description = "Remove the service template from catalog.")
+    @PutMapping("/service_templates/unpublish/{serviceTemplateId}")
     @ResponseStatus(HttpStatus.OK)
     @Transactional
     @AuditApiRequest(methodName = "getCspFromServiceTemplateId", paramTypes = UUID.class)
-    public ServiceTemplateRequestInfo removeFromCatalog(
+    public ServiceTemplateRequestInfo unpublish(
             @Parameter(name = "serviceTemplateId", description = "id of service template")
                     @PathVariable("serviceTemplateId")
                     UUID serviceTemplateId) {
-        ServiceTemplateRequestHistoryEntity removeFromCatalogRequest =
-                serviceTemplateManage.removeFromCatalog(serviceTemplateId);
-        return getServiceTemplateRequestInfo(removeFromCatalogRequest);
+        ServiceTemplateRequestHistoryEntity unpublishRequest =
+                serviceTemplateManage.unpublish(serviceTemplateId);
+        return getServiceTemplateRequestInfo(unpublishRequest);
     }
 
     /**
@@ -204,18 +217,18 @@ public class ServiceTemplateApi {
      * @return response
      */
     @Tag(name = "ServiceVendor", description = "APIs to manage service templates.")
-    @Operation(description = "Re-add the service template to catalog using id.")
-    @PutMapping("/service_templates/re_add_to_catalog/{serviceTemplateId}")
+    @Operation(description = "Publishes the same service template to catalog again.")
+    @PutMapping("/service_templates/republish/{serviceTemplateId}")
     @ResponseStatus(HttpStatus.OK)
     @Transactional
     @AuditApiRequest(methodName = "getCspFromServiceTemplateId", paramTypes = UUID.class)
-    public ServiceTemplateRequestInfo reAddToCatalog(
+    public ServiceTemplateRequestInfo republish(
             @Parameter(name = "serviceTemplateId", description = "id of service template")
                     @PathVariable("serviceTemplateId")
                     UUID serviceTemplateId) {
-        ServiceTemplateRequestHistoryEntity reAddToCatalogRequest =
-                serviceTemplateManage.reAddToCatalog(serviceTemplateId);
-        return getServiceTemplateRequestInfo(reAddToCatalogRequest);
+        ServiceTemplateRequestHistoryEntity republishRequest =
+                serviceTemplateManage.republish(serviceTemplateId);
+        return getServiceTemplateRequestInfo(republishRequest);
     }
 
     /**

--- a/modules/api/src/test/java/org/eclipse/xpanse/api/config/ServiceTemplateRequestTypeEnumConverterTest.java
+++ b/modules/api/src/test/java/org/eclipse/xpanse/api/config/ServiceTemplateRequestTypeEnumConverterTest.java
@@ -17,10 +17,10 @@ class ServiceTemplateRequestTypeEnumConverterTest {
         assertThat(converterTest.convert("register"))
                 .isEqualTo(ServiceTemplateRequestType.REGISTER);
         assertThat(converterTest.convert("update")).isEqualTo(ServiceTemplateRequestType.UPDATE);
-        assertThat(converterTest.convert("remove from catalog"))
-                .isEqualTo(ServiceTemplateRequestType.REMOVE_FROM_CATALOG);
-        assertThat(converterTest.convert("re-add to catalog"))
-                .isEqualTo(ServiceTemplateRequestType.RE_ADD_TO_CATALOG);
+        assertThat(converterTest.convert("unpublish"))
+                .isEqualTo(ServiceTemplateRequestType.UNPUBLISH);
+        assertThat(converterTest.convert("republish"))
+                .isEqualTo(ServiceTemplateRequestType.REPUBLISH);
         assertThrows(UnsupportedEnumValueException.class, () -> converterTest.convert("unknown"));
     }
 }

--- a/modules/models/src/main/java/org/eclipse/xpanse/modules/models/servicetemplate/request/enums/ServiceTemplateRequestType.java
+++ b/modules/models/src/main/java/org/eclipse/xpanse/modules/models/servicetemplate/request/enums/ServiceTemplateRequestType.java
@@ -14,8 +14,8 @@ import org.eclipse.xpanse.modules.models.common.exceptions.UnsupportedEnumValueE
 public enum ServiceTemplateRequestType {
     REGISTER("register"),
     UPDATE("update"),
-    REMOVE_FROM_CATALOG("remove from catalog"),
-    RE_ADD_TO_CATALOG("re-add to catalog");
+    UNPUBLISH("unpublish"),
+    REPUBLISH("republish");
 
     private final String type;
 

--- a/modules/servicetemplate/src/main/java/org/eclipse/xpanse/modules/servicetemplate/ServiceTemplateManage.java
+++ b/modules/servicetemplate/src/main/java/org/eclipse/xpanse/modules/servicetemplate/ServiceTemplateManage.java
@@ -525,8 +525,7 @@ public class ServiceTemplateManage {
                 serviceTemplateOpenApiGenerator.updateServiceApi(serviceTemplateToUpdate);
             }
             boolean isAvailableInCatalog =
-                    ServiceTemplateRequestType.REMOVE_FROM_CATALOG
-                            != reviewedRequest.getRequestType();
+                    ServiceTemplateRequestType.UNPUBLISH != reviewedRequest.getRequestType();
             serviceTemplateToUpdate.setIsAvailableInCatalog(isAvailableInCatalog);
         } else if (ServiceTemplateRequestStatus.REJECTED == reviewedRequest.getStatus()) {
             if (ServiceTemplateRequestType.REGISTER == reviewedRequest.getRequestType()) {
@@ -544,14 +543,14 @@ public class ServiceTemplateManage {
      * @param id ID of service template.
      * @return Returns updated service template.
      */
-    public ServiceTemplateRequestHistoryEntity removeFromCatalog(UUID id) {
+    public ServiceTemplateRequestHistoryEntity unpublish(UUID id) {
         ServiceTemplateEntity existingTemplate = getServiceTemplateDetails(id, true, false);
         if (existingTemplate.getServiceTemplateRegistrationState()
                 != ServiceTemplateRegistrationState.APPROVED) {
             String errMsg =
                     String.format(
                             "The registration of service template with id %s not approved. The"
-                                    + " request to remove_from_catalog is not allowed.",
+                                    + " request to unpublish is not allowed.",
                             id);
             throw new ServiceTemplateRequestNotAllowed(errMsg);
         }
@@ -560,26 +559,27 @@ public class ServiceTemplateManage {
         existingTemplate.setIsAvailableInCatalog(false);
         existingTemplate.setIsReviewInProgress(false);
         ServiceTemplateEntity updatedTemplate = templateStorage.storeAndFlush(existingTemplate);
-        ServiceTemplateRequestType requestType = ServiceTemplateRequestType.REMOVE_FROM_CATALOG;
+        ServiceTemplateRequestType requestType = ServiceTemplateRequestType.UNPUBLISH;
         // auto-approve the request to remove from catalog.
         return createServiceTemplateHistory(true, requestType, updatedTemplate);
     }
 
     /**
-     * Re-register service template using the ID of service template.
+     * Republish the service template to catalog again.
      *
-     * @param id ID of service template.
+     * @param serviceTemplateId id of service template.
      * @return Returns updated service template.
      */
-    public ServiceTemplateRequestHistoryEntity reAddToCatalog(UUID id) {
-        ServiceTemplateEntity existingTemplate = getServiceTemplateDetails(id, true, false);
+    public ServiceTemplateRequestHistoryEntity republish(UUID serviceTemplateId) {
+        ServiceTemplateEntity existingTemplate =
+                getServiceTemplateDetails(serviceTemplateId, true, false);
         if (existingTemplate.getServiceTemplateRegistrationState()
                 != ServiceTemplateRegistrationState.APPROVED) {
             String errMsg =
                     String.format(
                             "The registration of service template with id %s not approved. The"
-                                    + " request to re_add_to_catalog is not allowed.",
-                            id);
+                                    + " request to republish is not allowed.",
+                            serviceTemplateId);
             throw new ServiceTemplateRequestNotAllowed(errMsg);
         }
         checkAnyInProgressRequestForServiceTemplate(existingTemplate);
@@ -590,7 +590,7 @@ public class ServiceTemplateManage {
             existingTemplate.setIsReviewInProgress(true);
         }
         ServiceTemplateEntity updatedTemplate = templateStorage.storeAndFlush(existingTemplate);
-        ServiceTemplateRequestType requestType = ServiceTemplateRequestType.RE_ADD_TO_CATALOG;
+        ServiceTemplateRequestType requestType = ServiceTemplateRequestType.REPUBLISH;
         return createServiceTemplateHistory(isAutoApprovedEnabled, requestType, updatedTemplate);
     }
 

--- a/runtime/src/test/java/org/eclipse/xpanse/runtime/database/mysql/RegistrationWithMysqlTest.java
+++ b/runtime/src/test/java/org/eclipse/xpanse/runtime/database/mysql/RegistrationWithMysqlTest.java
@@ -101,11 +101,10 @@ class RegistrationWithMysqlTest extends AbstractMysqlIntegrationTest {
 
         // Setup update request
         ocl.setDescription("update-test");
-        // Run the update test with 'isRemoveServiceTemplateUntilApproved' is true
-        boolean isRemoveServiceTemplateUntilApproved = true;
+        // Run the update test with 'isUnpublishUntilApproved' is true
+        boolean isUnpublishUntilApproved = true;
         ServiceTemplateRequestInfo updateRequestInfo =
-                serviceTemplateApi.update(
-                        serviceTemplateId, isRemoveServiceTemplateUntilApproved, ocl);
+                serviceTemplateApi.update(serviceTemplateId, isUnpublishUntilApproved, ocl);
         // Verify the results
         assertEquals(serviceTemplateId, updateRequestInfo.getServiceTemplateId());
         assertFalse(updateRequestInfo.isRequestSubmittedForReview());
@@ -126,10 +125,10 @@ class RegistrationWithMysqlTest extends AbstractMysqlIntegrationTest {
         assertEquals(updateHistoryVos.size(), 1);
         assertEquals(updateHistoryVos.getFirst().getRequestId(), updateRequestInfo.getRequestId());
 
-        // Setup unregister request
+        // Setup unpublish request
         // Run the test
         ServiceTemplateRequestInfo unregisterRequest =
-                serviceTemplateApi.removeFromCatalog(serviceTemplateId);
+                serviceTemplateApi.unpublish(serviceTemplateId);
         // Verify the results
         assertEquals(serviceTemplateId, unregisterRequest.getServiceTemplateId());
         assertFalse(unregisterRequest.isRequestSubmittedForReview());
@@ -141,7 +140,7 @@ class RegistrationWithMysqlTest extends AbstractMysqlIntegrationTest {
         List<ServiceTemplateRequestHistory> unregisterHistoryVos =
                 serviceTemplateApi.getServiceTemplateRequestHistoryByServiceTemplateId(
                         serviceTemplateId,
-                        ServiceTemplateRequestType.REMOVE_FROM_CATALOG,
+                        ServiceTemplateRequestType.UNPUBLISH,
                         ServiceTemplateRequestStatus.ACCEPTED);
         assertEquals(unregisterHistoryVos.size(), 1);
         assertEquals(
@@ -150,7 +149,7 @@ class RegistrationWithMysqlTest extends AbstractMysqlIntegrationTest {
         // Setup reRegister request
         // Run the test
         ServiceTemplateRequestInfo reRegisterRequest =
-                serviceTemplateApi.reAddToCatalog(serviceTemplateId);
+                serviceTemplateApi.republish(serviceTemplateId);
         // Verify the results
         assertEquals(serviceTemplateId, reRegisterRequest.getServiceTemplateId());
         assertFalse(reRegisterRequest.isRequestSubmittedForReview());
@@ -162,14 +161,14 @@ class RegistrationWithMysqlTest extends AbstractMysqlIntegrationTest {
         List<ServiceTemplateRequestHistory> reRegisterHistoryVos =
                 serviceTemplateApi.getServiceTemplateRequestHistoryByServiceTemplateId(
                         serviceTemplateId,
-                        ServiceTemplateRequestType.RE_ADD_TO_CATALOG,
+                        ServiceTemplateRequestType.REPUBLISH,
                         ServiceTemplateRequestStatus.ACCEPTED);
         assertEquals(reRegisterHistoryVos.size(), 1);
         assertEquals(
                 reRegisterHistoryVos.getFirst().getRequestId(), reRegisterRequest.getRequestId());
 
         // Setup delete request
-        serviceTemplateApi.removeFromCatalog(serviceTemplateId);
+        serviceTemplateApi.unpublish(serviceTemplateId);
         // Run the test
         assertDoesNotThrow(() -> serviceTemplateApi.deleteServiceTemplate(serviceTemplateId));
 


### PR DESCRIPTION
**Fixed https://github.com/eclipse-xpanse/xpanse/issues/2232
Related to https://github.com/eclipse-xpanse/xpanse-ui/pull/1377**
Register service template with `auto-approve` is false:
![image](https://github.com/user-attachments/assets/dbda68f4-a95f-4dc0-ab23-281ee62da76b)
In this state, `isAvailableInCatalog=false` , `registrationState=IN-REVIEW`, `isReviewInProgress=true`, operations `Update` and `Delete` are available:
![image](https://github.com/user-attachments/assets/3c9dfff8-d7d3-4371-8c10-f9eea9f6e0cd)
Approved service template and the update service template with ‘isRemovedUtilApproved’ is true:
In this state,  `isAvailableInCatalog=false` , `registrationState=APPROVED`, `isReviewInProgress=true`, operations `Delete` is available:
![image](https://github.com/user-attachments/assets/a9fb6951-7827-404f-9539-fadb19e316a9)
Approve the update request, in this case, operations `Update` and `Unpublish` are available:
![image](https://github.com/user-attachments/assets/f9b83a86-997c-411f-8851-ae6bfcc8ee2f)
Unpublish the service template successfully;
![image](https://github.com/user-attachments/assets/aeeb2824-6138-4e92-9f6d-bce06551990c)
In this case, the operations `Update`,`Republish` and `Delete` are available:
![image](https://github.com/user-attachments/assets/b7792a90-0a41-46d9-8f6d-cc27a26fb00d)
Republish the service template successfully:
![image](https://github.com/user-attachments/assets/26b5cc26-1210-4e87-9856-ee184646309e)
In this case, the operations `Update`,`Republish` and `Delete` are available:
![image](https://github.com/user-attachments/assets/18c306c4-b0b2-46b4-b498-a79c7ca347bc)
Approve the republish request:
![image](https://github.com/user-attachments/assets/41f94c5b-8dc2-4486-8961-0ae752eca3bc)






