### PR TITLE
add plugin methods to manage the lifecycle of service templates

### DIFF
--- a/modules/api/src/main/java/org/eclipse/xpanse/api/config/GetCspInfoFromRequest.java
+++ b/modules/api/src/main/java/org/eclipse/xpanse/api/config/GetCspInfoFromRequest.java
@@ -45,7 +45,7 @@ public class GetCspInfoFromRequest {
     @Resource private ServicePolicyStorage servicePolicyStorage;
     @Resource private UserPolicyStorage userPolicyStorage;
     @Resource private TaskService taskService;
-    @Resource private ServiceOrderStorage serviceOrderTaskStorage;
+    @Resource private ServiceOrderStorage serviceOrderStorage;
     @Resource private ServiceTemplateRequestHistoryStorage serviceTemplateHistoryStorage;
 
     /**
@@ -155,7 +155,7 @@ public class GetCspInfoFromRequest {
                     ServiceOrderEntity queryOrderEntity = new ServiceOrderEntity();
                     queryOrderEntity.setWorkflowId(processInstanceId);
                     List<ServiceOrderEntity> orderEntities =
-                            serviceOrderTaskStorage.queryEntities(queryOrderEntity);
+                            serviceOrderStorage.queryEntities(queryOrderEntity);
                     if (!CollectionUtils.isEmpty(orderEntities)) {
                         UUID serviceId = orderEntities.getFirst().getOriginalServiceId();
                         ServiceDeploymentEntity deployService =
@@ -178,7 +178,7 @@ public class GetCspInfoFromRequest {
      */
     public Csp getCspFromServiceOrderId(UUID orderId) {
         try {
-            ServiceOrderEntity order = serviceOrderTaskStorage.getEntityById(orderId);
+            ServiceOrderEntity order = serviceOrderStorage.getEntityById(orderId);
             if (Objects.nonNull(order)
                     && Objects.nonNull(order.getServiceDeploymentEntity().getId())) {
                 ServiceDeploymentEntity deployService =

--- a/modules/models/src/main/java/org/eclipse/xpanse/modules/models/servicetemplate/enums/ServiceTemplateReviewPluginResultType.java
+++ b/modules/models/src/main/java/org/eclipse/xpanse/modules/models/servicetemplate/enums/ServiceTemplateReviewPluginResultType.java
@@ -1,0 +1,42 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * SPDX-FileCopyrightText: Huawei Inc.
+ */
+
+package org.eclipse.xpanse.modules.models.servicetemplate.enums;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import org.apache.commons.lang3.StringUtils;
+import org.eclipse.xpanse.modules.models.common.exceptions.UnsupportedEnumValueException;
+
+/** Defines review result type for service template by plugin of CSPs. */
+public enum ServiceTemplateReviewPluginResultType {
+    APPROVED("approved"),
+    REJECTED("rejected"),
+    MANUAL_REVIEW_REQUIRED("manualReviewRequired");
+
+    private final String result;
+
+    ServiceTemplateReviewPluginResultType(String result) {
+        this.result = result;
+    }
+
+    /** For ServiceReviewResult deserialize. */
+    @JsonCreator
+    public static ServiceTemplateReviewPluginResultType getByValue(String result) {
+        for (ServiceTemplateReviewPluginResultType serviceState : values()) {
+            if (serviceState.result.equals(StringUtils.lowerCase(result))) {
+                return serviceState;
+            }
+        }
+        throw new UnsupportedEnumValueException(
+                String.format("ServiceReviewResult value %s is not supported.", result));
+    }
+
+    /** For ServiceReviewResult serialize. */
+    @JsonValue
+    public String toValue() {
+        return this.result;
+    }
+}

--- a/modules/orchestrator/src/main/java/org/eclipse/xpanse/modules/orchestrator/OrchestratorPlugin.java
+++ b/modules/orchestrator/src/main/java/org/eclipse/xpanse/modules/orchestrator/OrchestratorPlugin.java
@@ -17,6 +17,7 @@ import org.eclipse.xpanse.modules.orchestrator.deployment.ServiceResourceHandler
 import org.eclipse.xpanse.modules.orchestrator.monitor.ServiceMetricsExporter;
 import org.eclipse.xpanse.modules.orchestrator.price.ServicePriceCalculator;
 import org.eclipse.xpanse.modules.orchestrator.servicestate.ServiceStateManager;
+import org.eclipse.xpanse.modules.orchestrator.servicetemplate.ServiceTemplateManager;
 
 /**
  * This interface describes orchestrator plugin in charge of interacting with backend fundamental
@@ -28,7 +29,8 @@ public interface OrchestratorPlugin
                 ServiceMetricsExporter,
                 ServiceStateManager,
                 OperationalAudit,
-                ServicePriceCalculator {
+                ServicePriceCalculator,
+                ServiceTemplateManager {
 
     /**
      * Get the Csp of the plugin.
@@ -43,13 +45,6 @@ public interface OrchestratorPlugin
      * @return required properties.
      */
     List<String> requiredProperties();
-
-    /**
-     * Check if auto approve service template is enabled.
-     *
-     * @return true if auto approve service template is enabled.
-     */
-    boolean autoApproveServiceTemplateIsEnabled();
 
     /** Get all sites of the cloud service provider. */
     List<String> getSites();

--- a/modules/orchestrator/src/main/java/org/eclipse/xpanse/modules/orchestrator/servicetemplate/ServiceTemplateManager.java
+++ b/modules/orchestrator/src/main/java/org/eclipse/xpanse/modules/orchestrator/servicetemplate/ServiceTemplateManager.java
@@ -1,0 +1,20 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * SPDX-FileCopyrightText: Huawei Inc.
+ *
+ */
+
+package org.eclipse.xpanse.modules.orchestrator.servicetemplate;
+
+import org.eclipse.xpanse.modules.models.servicetemplate.Ocl;
+import org.eclipse.xpanse.modules.models.servicetemplate.enums.ServiceTemplateReviewPluginResultType;
+
+/** Service template management interface. */
+public interface ServiceTemplateManager {
+
+    /** Validate service template. */
+    ServiceTemplateReviewPluginResultType validateServiceTemplate(Ocl ocl);
+
+    /** Run necessary preparation steps. */
+    void prepareServiceTemplate(Ocl ocl);
+}

--- a/plugins/flexibleengine/src/test/java/org/eclipse/xpanse/plugins/flexibleengine/FlexibleEngineOrchestratorPluginTest.java
+++ b/plugins/flexibleengine/src/test/java/org/eclipse/xpanse/plugins/flexibleengine/FlexibleEngineOrchestratorPluginTest.java
@@ -25,6 +25,7 @@ import org.eclipse.xpanse.modules.models.servicetemplate.CloudServiceProvider;
 import org.eclipse.xpanse.modules.models.servicetemplate.Ocl;
 import org.eclipse.xpanse.modules.models.servicetemplate.Region;
 import org.eclipse.xpanse.modules.models.servicetemplate.enums.DeployerKind;
+import org.eclipse.xpanse.modules.models.servicetemplate.enums.ServiceTemplateReviewPluginResultType;
 import org.eclipse.xpanse.modules.models.servicetemplate.exceptions.UnavailableServiceRegionsException;
 import org.eclipse.xpanse.modules.orchestrator.monitor.ResourceMetricsRequest;
 import org.eclipse.xpanse.modules.orchestrator.monitor.ServiceMetricsRequest;
@@ -33,11 +34,14 @@ import org.eclipse.xpanse.plugins.flexibleengine.manage.FlexibleEngineResourceMa
 import org.eclipse.xpanse.plugins.flexibleengine.manage.FlexibleEngineVmStateManager;
 import org.eclipse.xpanse.plugins.flexibleengine.monitor.FlexibleEngineMetricsService;
 import org.eclipse.xpanse.plugins.flexibleengine.resourcehandler.FlexibleEngineTerraformResourceHandler;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
 class FlexibleEngineOrchestratorPluginTest {
@@ -46,6 +50,11 @@ class FlexibleEngineOrchestratorPluginTest {
     @Mock private FlexibleEngineVmStateManager mockFlexibleEngineVmStateManagerService;
     @Mock private FlexibleEngineResourceManager flexibleEngineResourceManager;
     @InjectMocks private FlexibleEngineOrchestratorPlugin plugin;
+
+    @BeforeEach
+    void setUp() {
+        ReflectionTestUtils.setField(plugin, "autoApproveServiceTemplateEnabled", true);
+    }
 
     @Test
     void testGetResourceHandler() {
@@ -89,8 +98,10 @@ class FlexibleEngineOrchestratorPluginTest {
     }
 
     @Test
-    void testAutoApproveServiceTemplateIsEnabled() {
-        assertThat(plugin.autoApproveServiceTemplateIsEnabled()).isFalse();
+    void testValidateServiceTemplate() {
+        Ocl ocl = Mockito.mock(Ocl.class);
+        assertThat(plugin.validateServiceTemplate(ocl))
+                .isEqualTo(ServiceTemplateReviewPluginResultType.APPROVED);
     }
 
     @Test

--- a/plugins/huaweicloud/src/main/java/org/eclipse/xpanse/plugins/huaweicloud/HuaweiCloudOrchestratorPlugin.java
+++ b/plugins/huaweicloud/src/main/java/org/eclipse/xpanse/plugins/huaweicloud/HuaweiCloudOrchestratorPlugin.java
@@ -30,6 +30,7 @@ import org.eclipse.xpanse.modules.models.service.enums.DeployResourceKind;
 import org.eclipse.xpanse.modules.models.servicetemplate.Ocl;
 import org.eclipse.xpanse.modules.models.servicetemplate.Region;
 import org.eclipse.xpanse.modules.models.servicetemplate.enums.DeployerKind;
+import org.eclipse.xpanse.modules.models.servicetemplate.enums.ServiceTemplateReviewPluginResultType;
 import org.eclipse.xpanse.modules.models.servicetemplate.exceptions.UnavailableServiceRegionsException;
 import org.eclipse.xpanse.modules.orchestrator.OrchestratorPlugin;
 import org.eclipse.xpanse.modules.orchestrator.audit.AuditLog;
@@ -105,8 +106,16 @@ public class HuaweiCloudOrchestratorPlugin implements OrchestratorPlugin {
     }
 
     @Override
-    public boolean autoApproveServiceTemplateIsEnabled() {
-        return autoApproveServiceTemplateEnabled;
+    public ServiceTemplateReviewPluginResultType validateServiceTemplate(Ocl ocl) {
+        if (autoApproveServiceTemplateEnabled) {
+            return ServiceTemplateReviewPluginResultType.APPROVED;
+        }
+        return ServiceTemplateReviewPluginResultType.MANUAL_REVIEW_REQUIRED;
+    }
+
+    @Override
+    public void prepareServiceTemplate(Ocl ocl) {
+        log.info("prepare service template.");
     }
 
     @Override

--- a/plugins/huaweicloud/src/test/java/org/eclipse/xpanse/plugins/huaweicloud/HuaweiCloudOrchestratorPluginTest.java
+++ b/plugins/huaweicloud/src/test/java/org/eclipse/xpanse/plugins/huaweicloud/HuaweiCloudOrchestratorPluginTest.java
@@ -25,6 +25,7 @@ import org.eclipse.xpanse.modules.models.servicetemplate.CloudServiceProvider;
 import org.eclipse.xpanse.modules.models.servicetemplate.Ocl;
 import org.eclipse.xpanse.modules.models.servicetemplate.Region;
 import org.eclipse.xpanse.modules.models.servicetemplate.enums.DeployerKind;
+import org.eclipse.xpanse.modules.models.servicetemplate.enums.ServiceTemplateReviewPluginResultType;
 import org.eclipse.xpanse.modules.models.servicetemplate.exceptions.UnavailableServiceRegionsException;
 import org.eclipse.xpanse.modules.orchestrator.monitor.ResourceMetricsRequest;
 import org.eclipse.xpanse.modules.orchestrator.monitor.ServiceMetricsRequest;
@@ -38,6 +39,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
@@ -52,7 +54,7 @@ class HuaweiCloudOrchestratorPluginTest {
 
     @BeforeEach
     void setUp() {
-        ReflectionTestUtils.setField(plugin, "autoApproveServiceTemplateEnabled", false);
+        ReflectionTestUtils.setField(plugin, "autoApproveServiceTemplateEnabled", true);
     }
 
     @Test
@@ -98,8 +100,10 @@ class HuaweiCloudOrchestratorPluginTest {
     }
 
     @Test
-    void testAutoApproveServiceTemplateIsEnabled() {
-        assertThat(plugin.autoApproveServiceTemplateIsEnabled()).isFalse();
+    void testValidateServiceTemplate() {
+        Ocl ocl = Mockito.mock(Ocl.class);
+        assertThat(plugin.validateServiceTemplate(ocl))
+                .isEqualTo(ServiceTemplateReviewPluginResultType.APPROVED);
     }
 
     @Test

--- a/plugins/openstacktestlab/src/main/java/org/eclipse/xpanse/plugins/openstacktestlab/OpenstackTestlabOrchestratorPlugin.java
+++ b/plugins/openstacktestlab/src/main/java/org/eclipse/xpanse/plugins/openstacktestlab/OpenstackTestlabOrchestratorPlugin.java
@@ -30,6 +30,7 @@ import org.eclipse.xpanse.modules.models.service.deploy.DeployResource;
 import org.eclipse.xpanse.modules.models.service.enums.DeployResourceKind;
 import org.eclipse.xpanse.modules.models.servicetemplate.Ocl;
 import org.eclipse.xpanse.modules.models.servicetemplate.enums.DeployerKind;
+import org.eclipse.xpanse.modules.models.servicetemplate.enums.ServiceTemplateReviewPluginResultType;
 import org.eclipse.xpanse.modules.models.servicetemplate.exceptions.UnavailableServiceRegionsException;
 import org.eclipse.xpanse.modules.orchestrator.OrchestratorPlugin;
 import org.eclipse.xpanse.modules.orchestrator.audit.AuditLog;
@@ -91,8 +92,16 @@ public class OpenstackTestlabOrchestratorPlugin implements OrchestratorPlugin {
     }
 
     @Override
-    public boolean autoApproveServiceTemplateIsEnabled() {
-        return autoApproveServiceTemplateEnabled;
+    public ServiceTemplateReviewPluginResultType validateServiceTemplate(Ocl ocl) {
+        if (autoApproveServiceTemplateEnabled) {
+            return ServiceTemplateReviewPluginResultType.APPROVED;
+        }
+        return ServiceTemplateReviewPluginResultType.MANUAL_REVIEW_REQUIRED;
+    }
+
+    @Override
+    public void prepareServiceTemplate(Ocl ocl) {
+        log.info("prepare service template.");
     }
 
     @Override

--- a/plugins/openstacktestlab/src/test/java/org/eclipse/xpanse/plugins/openstacktestlab/OpenstackTestlabOrchestratorPluginTest.java
+++ b/plugins/openstacktestlab/src/test/java/org/eclipse/xpanse/plugins/openstacktestlab/OpenstackTestlabOrchestratorPluginTest.java
@@ -62,6 +62,7 @@ import org.eclipse.xpanse.modules.models.servicetemplate.Deployment;
 import org.eclipse.xpanse.modules.models.servicetemplate.Ocl;
 import org.eclipse.xpanse.modules.models.servicetemplate.Region;
 import org.eclipse.xpanse.modules.models.servicetemplate.enums.DeployerKind;
+import org.eclipse.xpanse.modules.models.servicetemplate.enums.ServiceTemplateReviewPluginResultType;
 import org.eclipse.xpanse.modules.models.servicetemplate.exceptions.UnavailableServiceRegionsException;
 import org.eclipse.xpanse.modules.orchestrator.PluginManager;
 import org.eclipse.xpanse.modules.orchestrator.monitor.ResourceMetricsRequest;
@@ -91,6 +92,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.mockito.Mockito;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
@@ -157,7 +159,7 @@ class OpenstackTestlabOrchestratorPluginTest {
 
     @BeforeEach
     void setUp() {
-        ReflectionTestUtils.setField(plugin, "autoApproveServiceTemplateEnabled", false);
+        ReflectionTestUtils.setField(plugin, "autoApproveServiceTemplateEnabled", true);
     }
 
     @BeforeAll
@@ -215,8 +217,10 @@ class OpenstackTestlabOrchestratorPluginTest {
     }
 
     @Test
-    void testAutoApproveServiceTemplateIsEnabled() {
-        assertThat(plugin.autoApproveServiceTemplateIsEnabled()).isFalse();
+    void testValidateServiceTemplate() {
+        Ocl ocl = Mockito.mock(Ocl.class);
+        assertThat(plugin.validateServiceTemplate(ocl))
+                .isEqualTo(ServiceTemplateReviewPluginResultType.APPROVED);
     }
 
     @Test

--- a/plugins/plusserver/src/main/java/org/eclipse/xpanse/plugins/plusserver/PlusServerOrchestratorPlugin.java
+++ b/plugins/plusserver/src/main/java/org/eclipse/xpanse/plugins/plusserver/PlusServerOrchestratorPlugin.java
@@ -30,6 +30,7 @@ import org.eclipse.xpanse.modules.models.monitor.Metric;
 import org.eclipse.xpanse.modules.models.service.enums.DeployResourceKind;
 import org.eclipse.xpanse.modules.models.servicetemplate.Ocl;
 import org.eclipse.xpanse.modules.models.servicetemplate.enums.DeployerKind;
+import org.eclipse.xpanse.modules.models.servicetemplate.enums.ServiceTemplateReviewPluginResultType;
 import org.eclipse.xpanse.modules.models.servicetemplate.exceptions.UnavailableServiceRegionsException;
 import org.eclipse.xpanse.modules.orchestrator.OrchestratorPlugin;
 import org.eclipse.xpanse.modules.orchestrator.audit.AuditLog;
@@ -89,8 +90,16 @@ public class PlusServerOrchestratorPlugin implements OrchestratorPlugin {
     }
 
     @Override
-    public boolean autoApproveServiceTemplateIsEnabled() {
-        return autoApproveServiceTemplateEnabled;
+    public ServiceTemplateReviewPluginResultType validateServiceTemplate(Ocl ocl) {
+        if (autoApproveServiceTemplateEnabled) {
+            return ServiceTemplateReviewPluginResultType.APPROVED;
+        }
+        return ServiceTemplateReviewPluginResultType.MANUAL_REVIEW_REQUIRED;
+    }
+
+    @Override
+    public void prepareServiceTemplate(Ocl ocl) {
+        log.info("prepare service template.");
     }
 
     @Override

--- a/plugins/plusserver/src/test/java/org/eclipse/xpanse/plugins/plusserver/PlusServerOrchestratorPluginTest.java
+++ b/plugins/plusserver/src/test/java/org/eclipse/xpanse/plugins/plusserver/PlusServerOrchestratorPluginTest.java
@@ -30,6 +30,7 @@ import org.eclipse.xpanse.modules.models.servicetemplate.CloudServiceProvider;
 import org.eclipse.xpanse.modules.models.servicetemplate.Ocl;
 import org.eclipse.xpanse.modules.models.servicetemplate.Region;
 import org.eclipse.xpanse.modules.models.servicetemplate.enums.DeployerKind;
+import org.eclipse.xpanse.modules.models.servicetemplate.enums.ServiceTemplateReviewPluginResultType;
 import org.eclipse.xpanse.modules.models.servicetemplate.exceptions.UnavailableServiceRegionsException;
 import org.eclipse.xpanse.modules.orchestrator.audit.AuditLog;
 import org.eclipse.xpanse.modules.orchestrator.deployment.DeployResourceHandler;
@@ -47,6 +48,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.core.env.Environment;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -70,7 +72,7 @@ class PlusServerOrchestratorPluginTest {
 
     @BeforeEach
     void setUp() {
-        ReflectionTestUtils.setField(plugin, "autoApproveServiceTemplateEnabled", false);
+        ReflectionTestUtils.setField(plugin, "autoApproveServiceTemplateEnabled", true);
     }
 
     @Test
@@ -128,8 +130,10 @@ class PlusServerOrchestratorPluginTest {
     }
 
     @Test
-    void testAutoApproveServiceTemplateIsEnabled() {
-        assertThat(plugin.autoApproveServiceTemplateIsEnabled()).isFalse();
+    void testValidateServiceTemplate() {
+        Ocl ocl = Mockito.mock(Ocl.class);
+        assertThat(plugin.validateServiceTemplate(ocl))
+                .isEqualTo(ServiceTemplateReviewPluginResultType.APPROVED);
     }
 
     @Test

--- a/plugins/regiocloud/src/main/java/org/eclipse/xpanse/plugins/regiocloud/RegioCloudOrchestratorPlugin.java
+++ b/plugins/regiocloud/src/main/java/org/eclipse/xpanse/plugins/regiocloud/RegioCloudOrchestratorPlugin.java
@@ -30,6 +30,7 @@ import org.eclipse.xpanse.modules.models.monitor.Metric;
 import org.eclipse.xpanse.modules.models.service.enums.DeployResourceKind;
 import org.eclipse.xpanse.modules.models.servicetemplate.Ocl;
 import org.eclipse.xpanse.modules.models.servicetemplate.enums.DeployerKind;
+import org.eclipse.xpanse.modules.models.servicetemplate.enums.ServiceTemplateReviewPluginResultType;
 import org.eclipse.xpanse.modules.models.servicetemplate.exceptions.UnavailableServiceRegionsException;
 import org.eclipse.xpanse.modules.orchestrator.OrchestratorPlugin;
 import org.eclipse.xpanse.modules.orchestrator.audit.AuditLog;
@@ -89,8 +90,16 @@ public class RegioCloudOrchestratorPlugin implements OrchestratorPlugin {
     }
 
     @Override
-    public boolean autoApproveServiceTemplateIsEnabled() {
-        return autoApproveServiceTemplateEnabled;
+    public ServiceTemplateReviewPluginResultType validateServiceTemplate(Ocl ocl) {
+        if (autoApproveServiceTemplateEnabled) {
+            return ServiceTemplateReviewPluginResultType.APPROVED;
+        }
+        return ServiceTemplateReviewPluginResultType.MANUAL_REVIEW_REQUIRED;
+    }
+
+    @Override
+    public void prepareServiceTemplate(Ocl ocl) {
+        log.info("prepare service template.");
     }
 
     @Override

--- a/plugins/regiocloud/src/test/java/org/eclipse/xpanse/plugins/regiocloud/RegioCloudOrchestratorPluginTest.java
+++ b/plugins/regiocloud/src/test/java/org/eclipse/xpanse/plugins/regiocloud/RegioCloudOrchestratorPluginTest.java
@@ -30,6 +30,7 @@ import org.eclipse.xpanse.modules.models.servicetemplate.CloudServiceProvider;
 import org.eclipse.xpanse.modules.models.servicetemplate.Ocl;
 import org.eclipse.xpanse.modules.models.servicetemplate.Region;
 import org.eclipse.xpanse.modules.models.servicetemplate.enums.DeployerKind;
+import org.eclipse.xpanse.modules.models.servicetemplate.enums.ServiceTemplateReviewPluginResultType;
 import org.eclipse.xpanse.modules.models.servicetemplate.exceptions.UnavailableServiceRegionsException;
 import org.eclipse.xpanse.modules.orchestrator.audit.AuditLog;
 import org.eclipse.xpanse.modules.orchestrator.deployment.DeployResourceHandler;
@@ -47,6 +48,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.core.env.Environment;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -70,7 +72,7 @@ class RegioCloudOrchestratorPluginTest {
 
     @BeforeEach
     void setUp() {
-        ReflectionTestUtils.setField(plugin, "autoApproveServiceTemplateEnabled", false);
+        ReflectionTestUtils.setField(plugin, "autoApproveServiceTemplateEnabled", true);
     }
 
     @Test
@@ -119,8 +121,10 @@ class RegioCloudOrchestratorPluginTest {
     }
 
     @Test
-    void testAutoApproveServiceTemplateIsEnabled() {
-        assertThat(plugin.autoApproveServiceTemplateIsEnabled()).isFalse();
+    void testValidateServiceTemplate() {
+        Ocl ocl = Mockito.mock(Ocl.class);
+        assertThat(plugin.validateServiceTemplate(ocl))
+                .isEqualTo(ServiceTemplateReviewPluginResultType.APPROVED);
     }
 
     @Test


### PR DESCRIPTION
Fixed https://github.com/eclipse-xpanse/xpanse/issues/2226
Register service template with  auto-approved is disabled of `HuaweiCloud`:
![image](https://github.com/user-attachments/assets/b3b661b6-b01c-48aa-a801-c7cfe0016659)

Register service template with  auto-approved is enabled of `FlexibleEngine`:
![image](https://github.com/user-attachments/assets/8fbdc9b5-d5f0-4490-ba65-123991805129)
