### PR TITLE
fix and handle errors when processing deployment result

### DIFF
--- a/modules/deployment/src/main/java/org/eclipse/xpanse/modules/deployment/deployers/deployertools/DeployerToolUtils.java
+++ b/modules/deployment/src/main/java/org/eclipse/xpanse/modules/deployment/deployers/deployertools/DeployerToolUtils.java
@@ -21,6 +21,7 @@ import java.util.Arrays;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -70,8 +71,12 @@ public class DeployerToolUtils {
         if (!installDir.exists() || !installDir.isDirectory()) {
             return null;
         }
+        File[] files = installDir.listFiles();
+        if (Objects.isNull(files) || files.length == 0) {
+            return null;
+        }
         Map<String, File> executorVersionFileMap = new HashMap<>();
-        Arrays.stream(installDir.listFiles())
+        Arrays.stream(files)
                 .filter(
                         f ->
                                 f.isFile()
@@ -375,10 +380,12 @@ public class DeployerToolUtils {
     public String getExactVersionOfExecutor(
             String executorPath, Pattern versionCommandOutputPattern) {
         String versionOutput = getVersionCommandOutput(new File(executorPath));
-        Matcher matcher = versionCommandOutputPattern.matcher(versionOutput);
-        if (matcher.find()) {
-            // return only the version number.
-            return matcher.group(1);
+        if (StringUtils.isNotBlank(versionOutput)) {
+            Matcher matcher = versionCommandOutputPattern.matcher(versionOutput);
+            if (matcher.find()) {
+                // return only the version number.
+                return matcher.group(1);
+            }
         }
         return null;
     }

--- a/modules/deployment/src/main/java/org/eclipse/xpanse/modules/deployment/utils/DeploymentScriptsHelper.java
+++ b/modules/deployment/src/main/java/org/eclipse/xpanse/modules/deployment/utils/DeploymentScriptsHelper.java
@@ -153,14 +153,15 @@ public class DeploymentScriptsHelper {
             File[] files = workPath.listFiles();
             if (Objects.nonNull(files)) {
                 Arrays.stream(files)
+                        .filter(
+                                file ->
+                                        !preparedFiles.contains(file)
+                                                && file.isFile()
+                                                && !isExcludedFile(file.getName()))
                         .forEach(
                                 file -> {
-                                    if (file.isFile()
-                                            && !isExcludedFile(file.getName())
-                                            && !preparedFiles.contains(file)) {
-                                        String content = readFileContent(file);
-                                        fileContentMap.put(file.getName(), content);
-                                    }
+                                    String content = readFileContent(file);
+                                    fileContentMap.put(file.getName(), content);
                                 });
             }
         }
@@ -250,8 +251,11 @@ public class DeploymentScriptsHelper {
     }
 
     private boolean isExcludedFile(String fileName) {
-        String fileSuffix = fileName.substring(fileName.lastIndexOf("."));
-        return EXCLUDED_FILE_SUFFIX_LIST.contains(fileSuffix);
+        if (StringUtils.isNotBlank(fileName) && fileName.contains(".")) {
+            String fileSuffix = fileName.substring(fileName.lastIndexOf("."));
+            return EXCLUDED_FILE_SUFFIX_LIST.contains(fileSuffix);
+        }
+        return false;
     }
 
     private String readFileContent(File file) {

--- a/plugins/flexibleengine/src/main/java/org/eclipse/xpanse/plugins/flexibleengine/resourcehandler/FlexibleEngineTerraformResourceHandler.java
+++ b/plugins/flexibleengine/src/main/java/org/eclipse/xpanse/plugins/flexibleengine/resourcehandler/FlexibleEngineTerraformResourceHandler.java
@@ -45,7 +45,7 @@ public class FlexibleEngineTerraformResourceHandler implements DeployResourceHan
             var stateFile = deployResult.getTfStateContent();
             tfState = objectMapper.readValue(stateFile, TfState.class);
         } catch (IOException ex) {
-            log.error("Parse terraform state content failed.");
+            log.error("Parse terraform state content failed.", ex);
             throw new TerraformExecutorException("Parse terraform state content failed.", ex);
         }
         if (Objects.nonNull(tfState)) {


### PR DESCRIPTION
Fixed https://github.com/eclipse-xpanse/xpanse/issues/2254
Related to https://github.com/eclipse-xpanse/xpanse-samples/pull/17
Related to https://github.com/eclipse-xpanse/terraform-boot/pull/181
Related to https://github.com/eclipse-xpanse/tofu-maker/pull/99

Deploy service with `terraformLocal` successfully:
![chrome_lL2ghHvRbJ](https://github.com/user-attachments/assets/559120d9-6229-456e-b472-e5807b4f526f)
Deploy service with `openTofuLocal` successfully:
![image](https://github.com/user-attachments/assets/7912dc75-4d96-4d0e-bb86-33b9c7df4d29)


