### PR TITLE
update state of service after deployment order completed

### DIFF
--- a/modules/deployment/src/main/java/org/eclipse/xpanse/modules/deployment/DeployResultManager.java
+++ b/modules/deployment/src/main/java/org/eclipse/xpanse/modules/deployment/DeployResultManager.java
@@ -126,7 +126,6 @@ public class DeployResultManager {
                 return;
             }
         }
-
         updateServiceOrderEntityWithDeployResult(deployResult, storedServiceOrder);
     }
 
@@ -183,6 +182,7 @@ public class DeployResultManager {
         boolean isTaskSuccessful = deployResult.getIsTaskSuccessful();
         ServiceDeploymentState deploymentState =
                 getServiceDeploymentState(taskType, isTaskSuccessful);
+        updateServiceState(deploymentState, serviceDeploymentToUpdate);
         if (Objects.nonNull(deploymentState)) {
             if (deploymentState == ServiceDeploymentState.DEPLOY_FAILED) {
                 // when the task failed and task type is deploy or retry, and tfState is null,
@@ -216,7 +216,6 @@ public class DeployResultManager {
                         serviceTemplateEntity.getOcl().getServiceConfigurationManage())) {
             updateServiceConfiguration(deploymentState, serviceDeployment);
         }
-        updateServiceState(deploymentState, serviceDeployment);
 
         if (CollectionUtils.isEmpty(deployResult.getDeploymentGeneratedFiles())) {
             if (isTaskSuccessful) {
@@ -312,6 +311,7 @@ public class DeployResultManager {
         if (state == ServiceDeploymentState.DEPLOY_FAILED
                 || state == ServiceDeploymentState.DESTROY_SUCCESS) {
             serviceDeploymentEntity.setServiceState(ServiceState.NOT_RUNNING);
+            serviceDeploymentEntity.setLastStoppedAt(OffsetDateTime.now());
         }
         // case other cases, do not change the state of service.
     }


### PR DESCRIPTION
**Fixed https://github.com/eclipse-xpanse/xpanse/issues/2263**
When deploy service successfully, the state of service is `running`:
![image](https://github.com/user-attachments/assets/08d373c5-924d-46aa-83a7-f7e3706b7afb)
When deploy service failed, the state of service is `not running`:
![image](https://github.com/user-attachments/assets/99235090-4b2b-4916-a102-acbc200f36d5)

**Fixed https://github.com/eclipse-xpanse/xpanse/issues/2249**
Migrate service successfully:
![image](https://github.com/user-attachments/assets/9759bcd5-27d9-4b92-b7b7-59df78db1d46)
The state of old service is `not running` and the state of new service  is `running`:
![image](https://github.com/user-attachments/assets/417337b4-b190-4d97-a45f-59b1e37a422a)
