### PR TITLE
service state management validate lock for modification

### DIFF
--- a/runtime/src/test/java/org/eclipse/xpanse/runtime/ServiceRecreateApiTest.java
+++ b/runtime/src/test/java/org/eclipse/xpanse/runtime/ServiceRecreateApiTest.java
@@ -1,0 +1,154 @@
+package org.eclipse.xpanse.runtime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+
+import com.c4_soft.springaddons.security.oauth2.test.annotations.WithJwt;
+import java.net.URI;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+import org.eclipse.xpanse.modules.database.service.ServiceDeploymentEntity;
+import org.eclipse.xpanse.modules.database.serviceorder.ServiceOrderEntity;
+import org.eclipse.xpanse.modules.models.response.ErrorResponse;
+import org.eclipse.xpanse.modules.models.response.ErrorType;
+import org.eclipse.xpanse.modules.models.service.config.ServiceLockConfig;
+import org.eclipse.xpanse.modules.models.service.enums.TaskStatus;
+import org.eclipse.xpanse.modules.models.service.order.ServiceOrder;
+import org.eclipse.xpanse.modules.models.servicetemplate.Ocl;
+import org.eclipse.xpanse.modules.models.servicetemplate.utils.OclLoader;
+import org.eclipse.xpanse.modules.models.servicetemplate.view.ServiceTemplateDetailVo;
+import org.eclipse.xpanse.runtime.util.ApisTestCommon;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(properties = {"spring.profiles.active=oauth,zitadel,zitadel-testbed,test"})
+@AutoConfigureMockMvc
+class ServiceRecreateApiTest extends ApisTestCommon {
+
+    @Test
+    @WithJwt(file = "jwt_all_roles.json")
+    void testServiceMigrationApis() throws Exception {
+        // prepare data
+        Ocl ocl =
+                new OclLoader()
+                        .getOcl(
+                                URI.create("file:src/test/resources/ocl_terraform_test.yml")
+                                        .toURL());
+        ServiceTemplateDetailVo serviceTemplate =
+                registerServiceTemplateAndApproveRegistration(ocl);
+        addCredentialForHuaweiCloud();
+        testServiceRecreateApisWell(serviceTemplate);
+        testServiceRecreateApisThrowsException(serviceTemplate);
+        deleteServiceTemplate(serviceTemplate.getServiceTemplateId());
+    }
+
+    void testServiceRecreateApisWell(ServiceTemplateDetailVo serviceTemplate) throws Exception {
+        ServiceOrder serviceOrder = deployService(serviceTemplate);
+        UUID serviceId = serviceOrder.getServiceId();
+        assertThat(waitServiceDeploymentIsCompleted(serviceId)).isTrue();
+        MockHttpServletResponse recreateResponse = recreateService(serviceId);
+        ServiceOrder migrationOrder =
+                objectMapper.readValue(recreateResponse.getContentAsString(), ServiceOrder.class);
+        assertThat(recreateResponse.getStatus()).isEqualTo(HttpStatus.ACCEPTED.value());
+        assertThat(migrationOrder).isNotNull();
+
+        assertThat(waitServiceOrderIsCompleted(migrationOrder.getOrderId())).isTrue();
+        ServiceOrderEntity orderEntity =
+                serviceOrderStorage.getEntityById(migrationOrder.getOrderId());
+        assertThat(orderEntity.getTaskStatus()).isEqualTo(TaskStatus.SUCCESSFUL);
+
+        ServiceOrderEntity query = new ServiceOrderEntity();
+        query.setWorkflowId(orderEntity.getWorkflowId());
+        List<ServiceOrderEntity> orderEntities = serviceOrderStorage.queryEntities(query);
+        assertThat(orderEntities).hasSize(3);
+        for (ServiceOrderEntity entity : orderEntities) {
+            deleteServiceDeployment(entity.getServiceDeploymentEntity().getId());
+        }
+    }
+
+    void testServiceRecreateApisThrowsException(ServiceTemplateDetailVo serviceTemplate)
+            throws Exception {
+        ServiceOrder serviceOrder = deployService(serviceTemplate);
+        UUID serviceId = serviceOrder.getServiceId();
+        assertThat(waitServiceDeploymentIsCompleted(serviceId)).isTrue();
+        testMigrateThrowsServiceNotFoundException();
+        testMigrateThrowsServiceLockedException(serviceId);
+        testMigrateThrowsServiceNotFoundException();
+        testMigrateThrowsAccessDeniedException(serviceId);
+    }
+
+    void testMigrateThrowsServiceNotFoundException() throws Exception {
+        UUID serviceId = UUID.randomUUID();
+        // Setup
+        ErrorResponse expectedErrorResponse =
+                ErrorResponse.errorResponse(
+                        ErrorType.SERVICE_DEPLOYMENT_NOT_FOUND,
+                        List.of(String.format("Service with id %s not found.", serviceId)));
+        // Run the test
+        final MockHttpServletResponse response = recreateService(serviceId);
+
+        // Verify the results
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+        assertThat(response.getContentAsString())
+                .isEqualTo(objectMapper.writeValueAsString(expectedErrorResponse));
+    }
+
+    void testMigrateThrowsServiceLockedException(UUID serviceId) throws Exception {
+        // Setup
+        ServiceLockConfig serviceLockConfig = new ServiceLockConfig();
+        serviceLockConfig.setModifyLocked(true);
+        ServiceDeploymentEntity deployService =
+                serviceDeploymentStorage.findServiceDeploymentById(serviceId);
+        deployService.setLockConfig(serviceLockConfig);
+        serviceDeploymentStorage.storeAndFlush(deployService);
+
+        String message = String.format("Service with id %s is locked from recreate.", serviceId);
+        ErrorResponse expectedErrorResponse =
+                ErrorResponse.errorResponse(
+                        ErrorType.SERVICE_LOCKED, Collections.singletonList(message));
+        String result = objectMapper.writeValueAsString(expectedErrorResponse);
+        // Run the test
+        final MockHttpServletResponse response = recreateService(serviceId);
+
+        // Verify the results
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+        assertThat(response.getContentAsString()).isEqualTo(result);
+    }
+
+    void testMigrateThrowsAccessDeniedException(UUID serviceId) throws Exception {
+
+        ErrorResponse expectedErrorResponse =
+                ErrorResponse.errorResponse(
+                        ErrorType.ACCESS_DENIED,
+                        Collections.singletonList(
+                                "No permissions to recreate services belonging to other users."));
+
+        ServiceDeploymentEntity deployService =
+                serviceDeploymentStorage.findServiceDeploymentById(serviceId);
+        deployService.setUserId(null);
+        serviceDeploymentStorage.storeAndFlush(deployService);
+        MockHttpServletResponse response = recreateService(serviceId);
+
+        // Verify the results
+        assertThat(response.getStatus()).isEqualTo(HttpStatus.FORBIDDEN.value());
+        assertThat(response.getContentAsString())
+                .isEqualTo(objectMapper.writeValueAsString(expectedErrorResponse));
+    }
+
+    MockHttpServletResponse recreateService(UUID serviceId) throws Exception {
+        return mockMvc.perform(
+                        put("/xpanse/services/recreate/{serviceId}", serviceId)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .accept(MediaType.APPLICATION_JSON))
+                .andReturn()
+                .getResponse();
+    }
+}


### PR DESCRIPTION
**Fixed https://github.com/eclipse-xpanse/xpanse/issues/2274
Related to https://github.com/eclipse-xpanse/xpanse-ui/pull/1405**

When service is not locked:
![image](https://github.com/user-attachments/assets/5c44a3a4-cb93-45cf-9b71-92d728fc17bd)
Lock service:
![image](https://github.com/user-attachments/assets/33d14f38-1836-4f23-bb35-b557a1603fd4)
Recreate/Stop/Restart is disabled:
![image](https://github.com/user-attachments/assets/84dd5a1e-9ca8-4001-8e88-cc6cd267d028)

