### PR TITLE
isv credential set managed service vendor as userId

### DIFF
--- a/modules/api/src/main/java/org/eclipse/xpanse/api/controllers/CspServiceTemplateApi.java
+++ b/modules/api/src/main/java/org/eclipse/xpanse/api/controllers/CspServiceTemplateApi.java
@@ -105,7 +105,7 @@ public class CspServiceTemplateApi {
                             description = "is any request in review progress")
                     @RequestParam(name = "isReviewInProgress", required = false)
                     Boolean isReviewInProgress) {
-        Csp csp = userServiceHelper.getCurrentUserManageCsp();
+        Csp csp = userServiceHelper.getCspManagedByCurrentUser();
         ServiceTemplateQueryModel queryRequest =
                 ServiceTemplateQueryModel.builder()
                         .csp(csp)
@@ -173,7 +173,7 @@ public class CspServiceTemplateApi {
             @Parameter(name = "serviceTemplateId", description = "id of service template")
                     @RequestParam(name = "serviceTemplateId", required = false)
                     UUID serviceTemplateId) {
-        Csp csp = userServiceHelper.getCurrentUserManageCsp();
+        Csp csp = userServiceHelper.getCspManagedByCurrentUser();
         ServiceTemplateRequestHistoryQueryModel queryModel =
                 ServiceTemplateRequestHistoryQueryModel.builder()
                         .csp(csp)

--- a/modules/credential/src/main/java/org/eclipse/xpanse/modules/credential/CredentialCenter.java
+++ b/modules/credential/src/main/java/org/eclipse/xpanse/modules/credential/CredentialCenter.java
@@ -115,16 +115,16 @@ public class CredentialCenter {
     }
 
     /**
-     * List the credential info of the @csp and @type and @userId. This method is called from REST
+     * List the credential info of the @csp and @type and @userKey. This method is called from REST
      * API and hence all sensitive fields are masked in the response.
      *
      * @param csp The cloud service provider.
      * @param type The type of the credential.
-     * @param userId The id of user who provided the credential info.
+     * @param userKey The id of user who provided the credential info.
      * @return the credentials.
      */
     public List<AbstractCredentialInfo> listCredentials(
-            Csp csp, CredentialType type, String userId) {
+            Csp csp, CredentialType type, String userKey) {
         List<AbstractCredentialInfo> abstractCredentialInfos = new ArrayList<>();
         if (Objects.isNull(csp)) {
             for (Csp key : pluginManager.getPluginsMap().keySet()) {
@@ -134,7 +134,7 @@ public class CredentialCenter {
                         .forEach(
                                 site -> {
                                     abstractCredentialInfos.addAll(
-                                            listUserCredentials(key, site, type, userId));
+                                            listUserCredentials(key, site, type, userKey));
                                 });
             }
         } else {
@@ -144,14 +144,14 @@ public class CredentialCenter {
                     .forEach(
                             site -> {
                                 abstractCredentialInfos.addAll(
-                                        listUserCredentials(csp, site, type, userId));
+                                        listUserCredentials(csp, site, type, userKey));
                             });
         }
         return maskSensitiveValues(abstractCredentialInfos);
     }
 
     private List<AbstractCredentialInfo> listUserCredentials(
-            Csp csp, String site, CredentialType type, String userId) {
+            Csp csp, String site, CredentialType type, String userKey) {
         List<AbstractCredentialInfo> userCredentials = new ArrayList<>();
         List<AbstractCredentialInfo> definedCredentialInfos =
                 pluginManager.getOrchestratorPlugin(csp).getCredentialDefinitions();
@@ -173,7 +173,7 @@ public class CredentialCenter {
                                         site,
                                         credential.getType(),
                                         credential.getName(),
-                                        userId);
+                                        userKey);
                         if (Objects.nonNull(credentialInfo)) {
                             userCredentials.add(credentialInfo);
                         }
@@ -183,9 +183,9 @@ public class CredentialCenter {
     }
 
     private AbstractCredentialInfo getCredentialFromCache(
-            Csp csp, String site, CredentialType type, String credentialName, String userId) {
+            Csp csp, String site, CredentialType type, String credentialName, String userKey) {
         CredentialCacheKey cacheKey =
-                new CredentialCacheKey(csp, site, type, credentialName, userId);
+                new CredentialCacheKey(csp, site, type, credentialName, userKey);
         AbstractCredentialInfo credentialInfo = null;
         try {
             credentialInfo = credentialsStore.getCredential(cacheKey);
@@ -264,32 +264,32 @@ public class CredentialCenter {
      * @param siteName site name
      * @param credentialType credential type
      * @param credentialName credential name
-     * @param userId user id
+     * @param userKey user id
      */
     public void deleteCredential(
             Csp csp,
             String siteName,
             CredentialType credentialType,
             String credentialName,
-            String userId) {
+            String userKey) {
         CredentialCacheKey cacheKey =
-                new CredentialCacheKey(csp, siteName, credentialType, credentialName, userId);
+                new CredentialCacheKey(csp, siteName, credentialType, credentialName, userKey);
         credentialsStore.deleteCredential(cacheKey);
     }
 
     /**
-     * Get credential for the @Csp with @userId. This method is used only within Xpanse application.
-     * This method joins credential variables from all sources.
+     * Get credential for the @Csp with @userKey. This method is used only within Xpanse
+     * application. This method joins credential variables from all sources.
      *
      * @param csp The cloud service provider.
      * @param site The site which the credential belongs to.
      * @param credentialType Type of the credential
-     * @param userId The user who provided the credential info.
+     * @param userKey The user who provided the credential info.
      */
     public AbstractCredentialInfo getCredential(
-            Csp csp, String site, CredentialType credentialType, String userId) {
+            Csp csp, String site, CredentialType credentialType, String userKey) {
         List<AbstractCredentialInfo> credentialInfos =
-                joinCredentialsFromAllSources(csp, site, credentialType, userId);
+                joinCredentialsFromAllSources(csp, site, credentialType, userKey);
         if (credentialInfos.isEmpty()) {
             throw new CredentialsNotFoundException(
                     String.format(
@@ -310,7 +310,7 @@ public class CredentialCenter {
                             String.format(
                                     "All mandatory variables for credential of type %s for Csp:%s"
                                             + " and user %s is not available",
-                                    csp, credentialType, userId)));
+                                    csp, credentialType, userKey)));
         }
         return decodeSensitiveVariables(credentialWithAllVariables.get());
     }
@@ -515,10 +515,10 @@ public class CredentialCenter {
     }
 
     private List<AbstractCredentialInfo> joinCredentialsFromAllSources(
-            Csp csp, String site, CredentialType requestedCredentialType, String userId) {
+            Csp csp, String site, CredentialType requestedCredentialType, String userKey) {
         List<AbstractCredentialInfo> joinCredentials = new ArrayList<>();
         List<AbstractCredentialInfo> userCredentials =
-                listUserCredentials(csp, site, requestedCredentialType, userId);
+                listUserCredentials(csp, site, requestedCredentialType, userKey);
         if (!CollectionUtils.isEmpty(userCredentials)) {
             for (AbstractCredentialInfo userCredential : userCredentials) {
                 if (Objects.nonNull(userCredential)) {

--- a/modules/deployment/src/main/java/org/eclipse/xpanse/modules/deployment/ServiceDetailsViewManager.java
+++ b/modules/deployment/src/main/java/org/eclipse/xpanse/modules/deployment/ServiceDetailsViewManager.java
@@ -235,7 +235,7 @@ public class ServiceDetailsViewManager {
 
         ServiceQueryModel query =
                 getServiceQueryModel(category, csp, serviceName, serviceVersion, state);
-        String isv = userServiceHelper.getCurrentUserManageIsv();
+        String isv = userServiceHelper.getIsvManagedByCurrentUser();
         query.setServiceVendor(isv);
         List<ServiceDeploymentEntity> deployServices = serviceDeploymentStorage.listServices(query);
         deployServices.forEach(

--- a/modules/deployment/src/main/java/org/eclipse/xpanse/modules/deployment/utils/DeployEnvironments.java
+++ b/modules/deployment/src/main/java/org/eclipse/xpanse/modules/deployment/utils/DeployEnvironments.java
@@ -273,7 +273,7 @@ public class DeployEnvironments {
         String userId =
                 serviceHostingType == ServiceHostingType.SELF
                         ? task.getDeployRequest().getUserId()
-                        : null;
+                        : task.getServiceVendor();
         Map<String, String> variables = new HashMap<>();
         AbstractCredentialInfo abstractCredentialInfo =
                 this.credentialCenter.getCredential(csp, site, credentialType, userId);

--- a/modules/security/src/main/java/org/eclipse/xpanse/modules/security/UserServiceHelper.java
+++ b/modules/security/src/main/java/org/eclipse/xpanse/modules/security/UserServiceHelper.java
@@ -76,7 +76,7 @@ public class UserServiceHelper {
         if (!webSecurityIsEnabled) {
             return true;
         }
-        return StringUtils.equals(ownerIsv, getCurrentUserManageIsv());
+        return StringUtils.equals(ownerIsv, getIsvManagedByCurrentUser());
     }
 
     /**
@@ -89,7 +89,7 @@ public class UserServiceHelper {
         if (!webSecurityIsEnabled) {
             return true;
         }
-        return Objects.equals(ownerCsp, getCurrentUserManageCsp());
+        return Objects.equals(ownerCsp, getCspManagedByCurrentUser());
     }
 
     /** Get the current user id. */
@@ -113,8 +113,8 @@ public class UserServiceHelper {
         return currentUserInfo;
     }
 
-    /** Get the serviceVendor managed by the current user . */
-    public String getCurrentUserManageIsv() {
+    /** Get the service vendor managed by the current user . */
+    public String getIsvManagedByCurrentUser() {
         if (!webSecurityIsEnabled) {
             return null;
         }
@@ -131,7 +131,7 @@ public class UserServiceHelper {
     }
 
     /** Get the csp managed by the current user. */
-    public Csp getCurrentUserManageCsp() {
+    public Csp getCspManagedByCurrentUser() {
         if (!webSecurityIsEnabled) {
             return null;
         }

--- a/modules/security/src/test/java/org/eclipse/xpanse/modules/security/UserServiceHelperTest.java
+++ b/modules/security/src/test/java/org/eclipse/xpanse/modules/security/UserServiceHelperTest.java
@@ -263,14 +263,14 @@ class UserServiceHelperTest {
         // Setup without auth
         setUpSecurityConfig(false, true);
         // Run the test
-        final String result = userServiceHelperUnderTest.getCurrentUserManageIsv();
+        final String result = userServiceHelperUnderTest.getIsvManagedByCurrentUser();
         // Verify the results
         assertThat(result).isNull();
 
         // Setup
         setUpSecurityConfig(true, true);
         // Run the test
-        final String result1 = userServiceHelperUnderTest.getCurrentUserManageIsv();
+        final String result1 = userServiceHelperUnderTest.getIsvManagedByCurrentUser();
         // Verify the results
         assertThat(result1).isNotNull();
         assertThat(result1).isEqualTo(isv);
@@ -284,14 +284,14 @@ class UserServiceHelperTest {
         // Setup without auth
         setUpSecurityConfig(false, true);
         // Run the test
-        final String result = userServiceHelperUnderTest.getCurrentUserManageIsv();
+        final String result = userServiceHelperUnderTest.getIsvManagedByCurrentUser();
         // Verify the results
         assertThat(result).isNull();
 
         // Setup
         setUpSecurityConfig(true, true);
         // Run the test
-        assertThatThrownBy(() -> userServiceHelperUnderTest.getCurrentUserManageIsv())
+        assertThatThrownBy(() -> userServiceHelperUnderTest.getIsvManagedByCurrentUser())
                 .isInstanceOf(UserNotLoggedInException.class);
     }
 
@@ -302,14 +302,14 @@ class UserServiceHelperTest {
         // Setup without auth
         setUpSecurityConfig(false, true);
         // Run the test
-        final Csp result = userServiceHelperUnderTest.getCurrentUserManageCsp();
+        final Csp result = userServiceHelperUnderTest.getCspManagedByCurrentUser();
         // Verify the results
         assertThat(result).isNull();
 
         // Setup
         setUpSecurityConfig(true, true);
         // Run the test
-        final Csp result1 = userServiceHelperUnderTest.getCurrentUserManageCsp();
+        final Csp result1 = userServiceHelperUnderTest.getCspManagedByCurrentUser();
         // Verify the results
         assertThat(result1).isNotNull();
         assertThat(result1).isEqualTo(csp);
@@ -323,14 +323,14 @@ class UserServiceHelperTest {
         // Setup without auth
         setUpSecurityConfig(false, true);
         // Run the test
-        final Csp result = userServiceHelperUnderTest.getCurrentUserManageCsp();
+        final Csp result = userServiceHelperUnderTest.getCspManagedByCurrentUser();
         // Verify the results
         assertThat(result).isNull();
 
         // Setup
         setUpSecurityConfig(true, true);
         // Run the test
-        assertThatThrownBy(() -> userServiceHelperUnderTest.getCurrentUserManageCsp())
+        assertThatThrownBy(() -> userServiceHelperUnderTest.getCspManagedByCurrentUser())
                 .isInstanceOf(UserNotLoggedInException.class);
     }
 }

--- a/modules/servicetemplate/src/main/java/org/eclipse/xpanse/modules/servicetemplate/ServiceTemplateManage.java
+++ b/modules/servicetemplate/src/main/java/org/eclipse/xpanse/modules/servicetemplate/ServiceTemplateManage.java
@@ -308,7 +308,7 @@ public class ServiceTemplateManage {
         if (!userServiceHelper.isAuthEnable()) {
             newServiceTemplate.setServiceVendor(ocl.getServiceVendor());
         } else {
-            String userManageIsv = userServiceHelper.getCurrentUserManageIsv();
+            String userManageIsv = userServiceHelper.getIsvManagedByCurrentUser();
             if (StringUtils.isNotEmpty(userManageIsv)
                     && !StringUtils.equals(ocl.getServiceVendor(), userManageIsv)) {
                 String errorMsg =
@@ -824,7 +824,7 @@ public class ServiceTemplateManage {
 
     private void fillParamFromUserMetadata(ServiceTemplateQueryModel query) {
         if (Objects.nonNull(query.getCheckServiceVendor()) && query.getCheckServiceVendor()) {
-            String serviceVendor = userServiceHelper.getCurrentUserManageIsv();
+            String serviceVendor = userServiceHelper.getIsvManagedByCurrentUser();
             query.setServiceVendor(serviceVendor);
         }
     }

--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
         <semver4j.version>5.5.0</semver4j.version>
         <github-api.version>1.326</github-api.version>
         <springdoc.openapi.plugin.version>1.4</springdoc.openapi.plugin.version>
-        <swagger.parser.version>2.1.24</swagger.parser.version>
+        <swagger.parser.version>2.1.25</swagger.parser.version>
         <swagger.core.v3.version>2.2.28</swagger.core.v3.version>
         <hcl4j.version>0.9.7</hcl4j.version>
         <jackson.datatype.jsr310.version>2.18.2</jackson.datatype.jsr310.version>

--- a/runtime/src/test/java/org/eclipse/xpanse/runtime/IsvCloudCredentialsApiTest.java
+++ b/runtime/src/test/java/org/eclipse/xpanse/runtime/IsvCloudCredentialsApiTest.java
@@ -43,6 +43,7 @@ class IsvCloudCredentialsApiTest extends ApisTestCommon {
     private final String site = "Chinese Mainland";
     private final String credentialName = "AK_SK";
     private final CredentialType credentialType = CredentialType.VARIABLES;
+    private final String managedIsv = "ISV-A";
 
     @Test
     @WithJwt(file = "jwt_isv.json")
@@ -60,6 +61,7 @@ class IsvCloudCredentialsApiTest extends ApisTestCommon {
         createCredential.setSite(site);
         createCredential.setType(credentialType);
         createCredential.setName(credentialName);
+        createCredential.setUserId(managedIsv);
         createCredential.setDescription("description");
         List<CredentialVariable> credentialVariables = new ArrayList<>();
         credentialVariables.add(


### PR DESCRIPTION
Fixed https://github.com/eclipse-xpanse/xpanse/issues/2308

ISV user ISV-A add credential with key which contains managed isv by user:
![chrome_laWrXxC8Fo](https://github.com/user-attachments/assets/270bf246-8237-4e3e-9ef6-c89e49173c8a)
ISV users manage other isv could not view the created credential anymore:
![image](https://github.com/user-attachments/assets/c63848b3-20a6-490a-9471-3cfac951409a)

