### PR TITLE
#2379 Make healthcheck only for admin users and create new service for all users

### DIFF
--- a/modules/api/src/main/java/org/eclipse/xpanse/api/controllers/AdminServicesApi.java
+++ b/modules/api/src/main/java/org/eclipse/xpanse/api/controllers/AdminServicesApi.java
@@ -18,6 +18,10 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.eclipse.xpanse.api.config.AuditApiRequest;
 import org.eclipse.xpanse.modules.cache.RedisCacheConfig;
@@ -83,11 +87,11 @@ public class AdminServicesApi {
      */
     @Tag(name = "Admin", description = "APIs for administrating Xpanse")
     @Operation(description = "Check health of API service and backend systems.")
-    @GetMapping(value = "/health", produces = MediaType.APPLICATION_JSON_VALUE)
+    @GetMapping(value = "/health/stack", produces = MediaType.APPLICATION_JSON_VALUE)
     @ResponseStatus(HttpStatus.OK)
-    @Secured({ROLE_ADMIN, ROLE_CSP, ROLE_ISV, ROLE_USER})
+    @Secured({ROLE_ADMIN})
     @AuditApiRequest(enabled = false)
-    public SystemStatus healthCheck() {
+    public SystemStatus stackHealthStatus() {
         SystemStatus systemStatus = new SystemStatus();
         systemStatus.setHealthStatus(HealthStatus.OK);
         List<BackendSystemStatus> backendSystemStatuses = getBackendSystemStatuses();
@@ -95,6 +99,22 @@ public class AdminServicesApi {
             systemStatus.setBackendSystemStatuses(backendSystemStatuses);
         }
         return systemStatus;
+    }
+
+    /**
+     * List supported backend systems.
+     *
+     * @return Returns list of backend systems {name,healthstatus}.
+     */
+    @Tag(name = "Admin", description = "APIs for administrating Xpanse")
+    @Operation(description = "Get name and status of backend systems")
+    @GetMapping(value = "/health", produces = MediaType.APPLICATION_JSON_VALUE)
+    @ResponseStatus(HttpStatus.OK)
+    @Secured({ROLE_ADMIN, ROLE_CSP, ROLE_ISV, ROLE_USER})
+    @AuditApiRequest(enabled = false)
+    public List<BackendSystemHealthInfo> healthCheck() {
+
+        return getSystemNameAndHealthInfo();
     }
 
     /**
@@ -120,9 +140,7 @@ public class AdminServicesApi {
      * @return list of system status.
      */
     private List<BackendSystemStatus> getBackendSystemStatuses() {
-        List<BackendSystemStatus> systemStatuses = checkHealthOfAllBackendSystems();
-        systemStatuses.forEach(this::processShownFields);
-        return systemStatuses;
+        return checkHealthOfAllBackendSystems();
     }
 
     private List<BackendSystemStatus> checkHealthOfAllBackendSystems() {
@@ -190,11 +208,78 @@ public class AdminServicesApi {
         return backendSystemStatuses;
     }
 
-    private void processShownFields(BackendSystemStatus backendSystemStatus) {
-        boolean userHasRoleAdmin = userServiceHelper.currentUserHasRole(ROLE_ADMIN);
-        if (!userHasRoleAdmin) {
-            backendSystemStatus.setEndpoint(null);
-            backendSystemStatus.setDetails(null);
+    private List<BackendSystemHealthInfo> getSystemNameAndHealthInfo(){
+        List<BackendSystemHealthInfo> backendSystemHealthInfos=new ArrayList<>();
+        for (BackendSystemType type : BackendSystemType.values()) {
+            if (type == BackendSystemType.IDENTITY_PROVIDER) {
+                IdentityProviderService identityProviderService =
+                        identityProviderManager.getActiveIdentityProviderService();
+                if (Objects.nonNull(identityProviderService)) {
+                    BackendSystemStatus identityProviderStatus =
+                            identityProviderService.getIdentityProviderStatus();
+                    if (Objects.nonNull(identityProviderStatus)) {
+                        backendSystemHealthInfos.add(BackendSystemHealthInfo.builder()
+                                .healthStatus(identityProviderStatus.getHealthStatus()).name(identityProviderStatus.getName()).build());
+                    }
+                }
+            }
+            if (type == BackendSystemType.DATABASE) {
+                BackendSystemStatus databaseStatus = databaseManager.getDatabaseStatus();
+                if (Objects.nonNull(databaseStatus)) {
+                    backendSystemHealthInfos.add(BackendSystemHealthInfo.builder()
+                            .healthStatus(databaseStatus.getHealthStatus()).name(databaseStatus.getName()).build());
+                }
+            }
+            if (Objects.nonNull(terraformBootManager) && type == BackendSystemType.TERRAFORM_BOOT) {
+                BackendSystemStatus terraformBootStatus =
+                        terraformBootManager.getTerraformBootStatus();
+                if (Objects.nonNull(terraformBootStatus)) {
+                   backendSystemHealthInfos.add(BackendSystemHealthInfo.builder()
+                           .healthStatus(terraformBootStatus.getHealthStatus()).name(terraformBootStatus.getName()).build());
+                }
+            }
+            if (Objects.nonNull(tofuMakerManager) && type == BackendSystemType.TOFU_MAKER) {
+                BackendSystemStatus openTofuMakerStatus = tofuMakerManager.getOpenTofuMakerStatus();
+                if (Objects.nonNull(openTofuMakerStatus)) {
+                    backendSystemHealthInfos.add(BackendSystemHealthInfo.builder()
+                            .healthStatus(openTofuMakerStatus.getHealthStatus()).name(openTofuMakerStatus.getName()).build());
+                }
+            }
+            if (type == BackendSystemType.POLICY_MAN) {
+                BackendSystemStatus policyManStatus = policyManager.getPolicyManStatus();
+                if (Objects.nonNull(policyManStatus)) {
+                    backendSystemHealthInfos.add(BackendSystemHealthInfo.builder()
+                            .healthStatus(policyManStatus.getHealthStatus()).name(policyManStatus.getName()).build());
+                }
+            }
+            if (type == BackendSystemType.CACHE_PROVIDER) {
+                if (Objects.nonNull(redisCacheConfig)) {
+                    BackendSystemStatus redisCacheStatus = redisCacheConfig.getRedisCacheStatus();
+                    if (Objects.nonNull(redisCacheStatus)) {
+                        backendSystemHealthInfos.add(BackendSystemHealthInfo.builder()
+                                .healthStatus(redisCacheStatus.getHealthStatus()).name(redisCacheStatus.getName()).build());
+                    }
+                } else {
+                    backendSystemHealthInfos.add(BackendSystemHealthInfo.builder()
+                            .healthStatus(HealthStatus.OK).name(CacheConstants.CACHE_PROVIDER_CAFFEINE).build());
+                }
+            }
+            if (type == BackendSystemType.OPEN_TELEMETRY_COLLECTOR) {
+                BackendSystemStatus otelExporterStatus =
+                        openTelemetryHealthCheck.getOpenTelemetryHealthStatus();
+                if (Objects.nonNull(otelExporterStatus)) {
+                    backendSystemHealthInfos.add(BackendSystemHealthInfo.builder()
+                            .healthStatus(otelExporterStatus.getHealthStatus()).name(otelExporterStatus.getName()).build());
+                }
+            }
         }
+        return backendSystemHealthInfos;
+    }
+
+
+    @Builder
+    static class BackendSystemHealthInfo{
+        String name;
+        HealthStatus healthStatus;
     }
 }

--- a/modules/policy/src/main/java/org/eclipse/xpanse/modules/policy/PolicyManager.java
+++ b/modules/policy/src/main/java/org/eclipse/xpanse/modules/policy/PolicyManager.java
@@ -18,6 +18,7 @@ import org.eclipse.xpanse.modules.policy.policyman.generated.api.PoliciesEvaluat
 import org.eclipse.xpanse.modules.policy.policyman.generated.api.PoliciesValidateApi;
 import org.eclipse.xpanse.modules.policy.policyman.generated.model.EvalCmdList;
 import org.eclipse.xpanse.modules.policy.policyman.generated.model.EvalResult;
+import org.eclipse.xpanse.modules.policy.policyman.generated.model.StackStatus;
 import org.eclipse.xpanse.modules.policy.policyman.generated.model.ValidatePolicyList;
 import org.eclipse.xpanse.modules.policy.policyman.generated.model.ValidateResponse;
 import org.springframework.beans.factory.annotation.Value;
@@ -49,10 +50,10 @@ public class PolicyManager {
         policyManStatus.setName(BackendSystemType.POLICY_MAN.toValue());
         policyManStatus.setEndpoint(policyManBaseUrl);
         try {
-            org.eclipse.xpanse.modules.policy.policyman.generated.model.SystemStatus
-                    policyManSystemStatus = adminApi.healthGet();
+            StackStatus
+                    policyManStackStatus = adminApi.healthGet();
             org.eclipse.xpanse.modules.policy.policyman.generated.model.HealthStatus healthStatus =
-                    policyManSystemStatus.getHealthStatus();
+                    policyManStackStatus.getHealthStatus();
             policyManStatus.setHealthStatus(HealthStatus.valueOf(healthStatus.getValue()));
         } catch (RestClientException e) {
             log.error("Get status of policy-man error:{}", e.getMessage());

--- a/modules/policy/src/main/java/org/eclipse/xpanse/modules/policy/policyman/generated/api/AdminApi.java
+++ b/modules/policy/src/main/java/org/eclipse/xpanse/modules/policy/policyman/generated/api/AdminApi.java
@@ -3,7 +3,7 @@ package org.eclipse.xpanse.modules.policy.policyman.generated.api;
 import java.util.Collections;
 import java.util.List;
 import org.eclipse.xpanse.modules.policy.policyman.generated.ApiClient;
-import org.eclipse.xpanse.modules.policy.policyman.generated.model.SystemStatus;
+import org.eclipse.xpanse.modules.policy.policyman.generated.model.StackStatus;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpHeaders;
@@ -51,7 +51,7 @@ public class AdminApi {
      * @return SystemStatus
      * @throws RestClientException if an error occurs while attempting to invoke the API
      */
-    public SystemStatus healthGet() throws RestClientException {
+    public StackStatus healthGet() throws RestClientException {
         return healthGetWithHttpInfo().getBody();
     }
 
@@ -69,7 +69,7 @@ public class AdminApi {
      * @return ResponseEntity&lt;SystemStatus&gt;
      * @throws RestClientException if an error occurs while attempting to invoke the API
      */
-    public ResponseEntity<SystemStatus> healthGetWithHttpInfo() throws RestClientException {
+    public ResponseEntity<StackStatus> healthGetWithHttpInfo() throws RestClientException {
         Object localVarPostBody = null;
 
         final MultiValueMap<String, String> localVarQueryParams =
@@ -88,8 +88,8 @@ public class AdminApi {
 
         String[] localVarAuthNames = new String[] {};
 
-        ParameterizedTypeReference<SystemStatus> localReturnType =
-                new ParameterizedTypeReference<SystemStatus>() {};
+        ParameterizedTypeReference<StackStatus> localReturnType =
+                new ParameterizedTypeReference<StackStatus>() {};
         return apiClient.invokeAPI(
                 "/health",
                 HttpMethod.GET,

--- a/modules/policy/src/main/java/org/eclipse/xpanse/modules/policy/policyman/generated/model/StackStatus.java
+++ b/modules/policy/src/main/java/org/eclipse/xpanse/modules/policy/policyman/generated/model/StackStatus.java
@@ -20,15 +20,15 @@ import jakarta.validation.constraints.*;
 import java.util.Objects;
 
 /** SystemStatus */
-@JsonPropertyOrder({SystemStatus.JSON_PROPERTY_HEALTH_STATUS})
+@JsonPropertyOrder({StackStatus.JSON_PROPERTY_HEALTH_STATUS})
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
-public class SystemStatus {
+public class StackStatus {
     public static final String JSON_PROPERTY_HEALTH_STATUS = "healthStatus";
     private HealthStatus healthStatus;
 
-    public SystemStatus() {}
+    public StackStatus() {}
 
-    public SystemStatus healthStatus(HealthStatus healthStatus) {
+    public StackStatus healthStatus(HealthStatus healthStatus) {
 
         this.healthStatus = healthStatus;
         return this;
@@ -62,8 +62,8 @@ public class SystemStatus {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        SystemStatus systemStatus = (SystemStatus) o;
-        return Objects.equals(this.healthStatus, systemStatus.healthStatus);
+        StackStatus stackStatus = (StackStatus) o;
+        return Objects.equals(this.healthStatus, stackStatus.healthStatus);
     }
 
     @Override

--- a/modules/policy/src/test/java/org/eclipse/xpanse/modules/policy/policyman/PolicyManagerTest.java
+++ b/modules/policy/src/test/java/org/eclipse/xpanse/modules/policy/policyman/PolicyManagerTest.java
@@ -14,7 +14,7 @@ import org.eclipse.xpanse.modules.policy.policyman.generated.api.PoliciesEvaluat
 import org.eclipse.xpanse.modules.policy.policyman.generated.api.PoliciesValidateApi;
 import org.eclipse.xpanse.modules.policy.policyman.generated.model.EvalCmdList;
 import org.eclipse.xpanse.modules.policy.policyman.generated.model.EvalResult;
-import org.eclipse.xpanse.modules.policy.policyman.generated.model.SystemStatus;
+import org.eclipse.xpanse.modules.policy.policyman.generated.model.StackStatus;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -49,10 +49,10 @@ class PolicyManagerTest {
         expectedResult.setEndpoint("endpoint");
 
         // Configure AdminApi.healthGet(...).
-        final SystemStatus systemStatus = new SystemStatus();
-        systemStatus.setHealthStatus(
+        final StackStatus stackStatus = new StackStatus();
+        stackStatus.setHealthStatus(
                 org.eclipse.xpanse.modules.policy.policyman.generated.model.HealthStatus.healthOK);
-        when(mockAdminApi.healthGet()).thenReturn(systemStatus);
+        when(mockAdminApi.healthGet()).thenReturn(stackStatus);
 
         // Run the test
         final BackendSystemStatus result = policyManagerUnderTest.getPolicyManStatus();


### PR DESCRIPTION
1. remove processShownFields method -
[xpanse/modules/api/src/main/java/org/eclipse/xpanse/api/controllers/AdminServicesApi.java](https://github.com/eclipse-xpanse/xpanse/blob/1f8d0a24f8d7b4d28a8426c069c0646fcd76ea74/modules/api/src/main/java/org/eclipse/xpanse/api/controllers/AdminServicesApi.java#L193)

Line 193 in [1f8d0a2](https://github.com/eclipse-xpanse/xpanse/commit/1f8d0a24f8d7b4d28a8426c069c0646fcd76ea74)

 private void processShownFields(BackendSystemStatus backendSystemStatus) { 

2. Allow healthCheck() method only for 'ADMIN' ROLE and rename method to stackHealthStatus() -> /xpanse/stack/health

3.Rename existing SystemStatus data model to -> StackStatus

4. create new method -> healthCheck() -> which returns only new SystemStatus data model which has only 'HealthStatus' as a property.

5. Allow new method to all roles - admin, user, isv and csp.