### PR TITLE
#2379 healthcheck admin only

### DIFF
--- a/modules/policy/src/main/java/org/eclipse/xpanse/modules/policy/PolicyManager.java
+++ b/modules/policy/src/main/java/org/eclipse/xpanse/modules/policy/PolicyManager.java
@@ -18,6 +18,7 @@ import org.eclipse.xpanse.modules.policy.policyman.generated.api.PoliciesEvaluat
 import org.eclipse.xpanse.modules.policy.policyman.generated.api.PoliciesValidateApi;
 import org.eclipse.xpanse.modules.policy.policyman.generated.model.EvalCmdList;
 import org.eclipse.xpanse.modules.policy.policyman.generated.model.EvalResult;
+import org.eclipse.xpanse.modules.policy.policyman.generated.model.StackStatus;
 import org.eclipse.xpanse.modules.policy.policyman.generated.model.ValidatePolicyList;
 import org.eclipse.xpanse.modules.policy.policyman.generated.model.ValidateResponse;
 import org.springframework.beans.factory.annotation.Value;
@@ -49,10 +50,9 @@ public class PolicyManager {
         policyManStatus.setName(BackendSystemType.POLICY_MAN.toValue());
         policyManStatus.setEndpoint(policyManBaseUrl);
         try {
-            org.eclipse.xpanse.modules.policy.policyman.generated.model.SystemStatus
-                    policyManSystemStatus = adminApi.healthGet();
+            StackStatus policyManStackStatus = adminApi.healthGet();
             org.eclipse.xpanse.modules.policy.policyman.generated.model.HealthStatus healthStatus =
-                    policyManSystemStatus.getHealthStatus();
+                    policyManStackStatus.getHealthStatus();
             policyManStatus.setHealthStatus(HealthStatus.valueOf(healthStatus.getValue()));
         } catch (RestClientException e) {
             log.error("Get status of policy-man error:{}", e.getMessage());

--- a/modules/policy/src/main/java/org/eclipse/xpanse/modules/policy/policyman/generated/api/AdminApi.java
+++ b/modules/policy/src/main/java/org/eclipse/xpanse/modules/policy/policyman/generated/api/AdminApi.java
@@ -3,7 +3,7 @@ package org.eclipse.xpanse.modules.policy.policyman.generated.api;
 import java.util.Collections;
 import java.util.List;
 import org.eclipse.xpanse.modules.policy.policyman.generated.ApiClient;
-import org.eclipse.xpanse.modules.policy.policyman.generated.model.SystemStatus;
+import org.eclipse.xpanse.modules.policy.policyman.generated.model.StackStatus;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpHeaders;
@@ -51,7 +51,7 @@ public class AdminApi {
      * @return SystemStatus
      * @throws RestClientException if an error occurs while attempting to invoke the API
      */
-    public SystemStatus healthGet() throws RestClientException {
+    public StackStatus healthGet() throws RestClientException {
         return healthGetWithHttpInfo().getBody();
     }
 
@@ -69,7 +69,7 @@ public class AdminApi {
      * @return ResponseEntity&lt;SystemStatus&gt;
      * @throws RestClientException if an error occurs while attempting to invoke the API
      */
-    public ResponseEntity<SystemStatus> healthGetWithHttpInfo() throws RestClientException {
+    public ResponseEntity<StackStatus> healthGetWithHttpInfo() throws RestClientException {
         Object localVarPostBody = null;
 
         final MultiValueMap<String, String> localVarQueryParams =
@@ -88,8 +88,8 @@ public class AdminApi {
 
         String[] localVarAuthNames = new String[] {};
 
-        ParameterizedTypeReference<SystemStatus> localReturnType =
-                new ParameterizedTypeReference<SystemStatus>() {};
+        ParameterizedTypeReference<StackStatus> localReturnType =
+                new ParameterizedTypeReference<StackStatus>() {};
         return apiClient.invokeAPI(
                 "/health",
                 HttpMethod.GET,

--- a/modules/policy/src/main/java/org/eclipse/xpanse/modules/policy/policyman/generated/model/StackStatus.java
+++ b/modules/policy/src/main/java/org/eclipse/xpanse/modules/policy/policyman/generated/model/StackStatus.java
@@ -20,15 +20,15 @@ import jakarta.validation.constraints.*;
 import java.util.Objects;
 
 /** SystemStatus */
-@JsonPropertyOrder({SystemStatus.JSON_PROPERTY_HEALTH_STATUS})
+@JsonPropertyOrder({StackStatus.JSON_PROPERTY_HEALTH_STATUS})
 @jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
-public class SystemStatus {
+public class StackStatus {
     public static final String JSON_PROPERTY_HEALTH_STATUS = "healthStatus";
     private HealthStatus healthStatus;
 
-    public SystemStatus() {}
+    public StackStatus() {}
 
-    public SystemStatus healthStatus(HealthStatus healthStatus) {
+    public StackStatus healthStatus(HealthStatus healthStatus) {
 
         this.healthStatus = healthStatus;
         return this;
@@ -62,8 +62,8 @@ public class SystemStatus {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        SystemStatus systemStatus = (SystemStatus) o;
-        return Objects.equals(this.healthStatus, systemStatus.healthStatus);
+        StackStatus stackStatus = (StackStatus) o;
+        return Objects.equals(this.healthStatus, stackStatus.healthStatus);
     }
 
     @Override

--- a/modules/policy/src/test/java/org/eclipse/xpanse/modules/policy/policyman/PolicyManagerTest.java
+++ b/modules/policy/src/test/java/org/eclipse/xpanse/modules/policy/policyman/PolicyManagerTest.java
@@ -14,7 +14,7 @@ import org.eclipse.xpanse.modules.policy.policyman.generated.api.PoliciesEvaluat
 import org.eclipse.xpanse.modules.policy.policyman.generated.api.PoliciesValidateApi;
 import org.eclipse.xpanse.modules.policy.policyman.generated.model.EvalCmdList;
 import org.eclipse.xpanse.modules.policy.policyman.generated.model.EvalResult;
-import org.eclipse.xpanse.modules.policy.policyman.generated.model.SystemStatus;
+import org.eclipse.xpanse.modules.policy.policyman.generated.model.StackStatus;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -49,10 +49,10 @@ class PolicyManagerTest {
         expectedResult.setEndpoint("endpoint");
 
         // Configure AdminApi.healthGet(...).
-        final SystemStatus systemStatus = new SystemStatus();
-        systemStatus.setHealthStatus(
+        final StackStatus stackStatus = new StackStatus();
+        stackStatus.setHealthStatus(
                 org.eclipse.xpanse.modules.policy.policyman.generated.model.HealthStatus.healthOK);
-        when(mockAdminApi.healthGet()).thenReturn(systemStatus);
+        when(mockAdminApi.healthGet()).thenReturn(stackStatus);
 
         // Run the test
         final BackendSystemStatus result = policyManagerUnderTest.getPolicyManStatus();


### PR DESCRIPTION
remove processShownFields method -
[xpanse/modules/api/src/main/java/org/eclipse/xpanse/api/controllers/AdminServicesApi.java](https://github.com/eclipse-xpanse/xpanse/blob/1f8d0a24f8d7b4d28a8426c069c0646fcd76ea74/modules/api/src/main/java/org/eclipse/xpanse/api/controllers/AdminServicesApi.java#L193)
Line 193 in [1f8d0a2](https://github.com/eclipse-xpanse/xpanse/commit/1f8d0a24f8d7b4d28a8426c069c0646fcd76ea74)

private void processShownFields(BackendSystemStatus backendSystemStatus) {

Allow healthCheck() method only for 'ADMIN' ROLE and rename method to stackHealthStatus() -> /xpanse/stack/health
3.Rename existing SystemStatus data model to -> StackStatus

create new method -> healthCheck() -> which returns only new SystemStatus data model which has only 'HealthStatus' as a property.

HealthCheck returns backendSystem Name,HealthStatus.
Allow new method to all roles - admin, user, isv and csp.

