### PR TITLE
Set updated time for Service Configuration Entity

### DIFF
--- a/modules/database/src/test/java/org/eclipse/xpanse/modules/database/serviceconfiguration/ServiceConfigurationEntityTest.java
+++ b/modules/database/src/test/java/org/eclipse/xpanse/modules/database/serviceconfiguration/ServiceConfigurationEntityTest.java
@@ -59,6 +59,14 @@ class ServiceConfigurationEntityTest {
     }
 
     @Test
+    void testUpdatedTimeGetterAndSetter() {
+        final OffsetDateTime createTime =
+                OffsetDateTime.of(LocalDateTime.of(2020, 1, 1, 0, 0, 0, 0), ZoneOffset.UTC);
+        test.setUpdatedTime(createTime);
+        assertThat(test.getUpdatedTime()).isEqualTo(createTime);
+    }
+
+    @Test
     void testLastModifiedTimeGetterAndSetter() {
         final OffsetDateTime updatedTime =
                 OffsetDateTime.of(LocalDateTime.of(2020, 1, 1, 0, 0, 0, 0), ZoneOffset.UTC);

--- a/modules/deployment/src/main/java/org/eclipse/xpanse/modules/deployment/DeployServiceEntityConverter.java
+++ b/modules/deployment/src/main/java/org/eclipse/xpanse/modules/deployment/DeployServiceEntityConverter.java
@@ -81,6 +81,7 @@ public class DeployServiceEntityConverter {
         ServiceConfigurationEntity entity = new ServiceConfigurationEntity();
         entity.setServiceDeploymentEntity(serviceDeploymentEntity);
         entity.setCreatedTime(OffsetDateTime.now());
+        entity.setUpdatedTime(OffsetDateTime.now());
         Map<String, Object> configuration = getServiceConfiguration(serviceDeploymentEntity);
         entity.setConfiguration(configuration);
         return entity;

--- a/modules/deployment/src/test/java/org/eclipse/xpanse/modules/deployment/ServiceDeploymentEntityConverterTest.java
+++ b/modules/deployment/src/test/java/org/eclipse/xpanse/modules/deployment/ServiceDeploymentEntityConverterTest.java
@@ -97,6 +97,7 @@ class ServiceDeploymentEntityConverterTest {
         assertEquals(
                 serviceDeploymentEntity, serviceConfigurationEntity.getServiceDeploymentEntity());
         assertNotNull(serviceConfigurationEntity.getCreatedTime());
+        assertNotNull(serviceConfigurationEntity.getUpdatedTime());
         assertNotNull(serviceConfigurationEntity.getConfiguration());
     }
 }


### PR DESCRIPTION
org.eclipse.xpanse.modules.deployment.DeployServiceEntityConverter#getInitialServiceConfiguration

Set updated time at time of creations.

fixes #2396