### PR TITLE
Feat/service objects manage

### DIFF
--- a/modules/api/src/main/java/org/eclipse/xpanse/api/config/ServiceTemplateEntityConverter.java
+++ b/modules/api/src/main/java/org/eclipse/xpanse/api/config/ServiceTemplateEntityConverter.java
@@ -59,6 +59,8 @@ public class ServiceTemplateEntityConverter {
                     serviceTemplateEntity.getOcl().getServiceConfigurationManage());
             serviceTemplateDetailVo.setServiceActions(
                     serviceTemplateEntity.getOcl().getServiceActions());
+            serviceTemplateDetailVo.setServiceObjects(
+                    serviceTemplateEntity.getOcl().getServiceObjects());
             return serviceTemplateDetailVo;
         }
         return null;
@@ -100,15 +102,15 @@ public class ServiceTemplateEntityConverter {
             userOrderableServiceVo.setServiceAvailabilityConfig(
                     serviceTemplateEntity.getOcl().getDeployment().getServiceAvailabilityConfig());
             userOrderableServiceVo.setEula(serviceTemplateEntity.getOcl().getEula());
+            userOrderableServiceVo.setServiceActions(
+                    serviceTemplateEntity.getOcl().getServiceActions());
+            userOrderableServiceVo.setServiceObjects(
+                    serviceTemplateEntity.getOcl().getServiceObjects());
             ServiceChangeManage serviceConfigurationManage =
                     serviceTemplateEntity.getOcl().getServiceConfigurationManage();
             if (Objects.nonNull(serviceConfigurationManage)) {
                 userOrderableServiceVo.setConfigurationParameters(
                         serviceConfigurationManage.getConfigurationParameters());
-            }
-            if (Objects.nonNull(serviceTemplateEntity.getOcl().getServiceActions())) {
-                userOrderableServiceVo.setServiceActions(
-                        serviceTemplateEntity.getOcl().getServiceActions());
             }
             return userOrderableServiceVo;
         }

--- a/modules/api/src/main/java/org/eclipse/xpanse/api/controllers/ServiceActionsApi.java
+++ b/modules/api/src/main/java/org/eclipse/xpanse/api/controllers/ServiceActionsApi.java
@@ -44,7 +44,7 @@ public class ServiceActionsApi {
 
     @Tag(name = "Service Actions", description = "APIs for Service Actions.")
     @PutMapping(value = "/services/action/{serviceId}", produces = MediaType.APPLICATION_JSON_VALUE)
-    @ResponseStatus(HttpStatus.OK)
+    @ResponseStatus(HttpStatus.ACCEPTED)
     @Operation(description = "Create Service Actions.")
     @AuditApiRequest(methodName = "getCspFromServiceId", paramTypes = UUID.class)
     public ServiceOrder createServiceAction(

--- a/modules/api/src/main/java/org/eclipse/xpanse/api/controllers/ServiceConfigurationApi.java
+++ b/modules/api/src/main/java/org/eclipse/xpanse/api/controllers/ServiceConfigurationApi.java
@@ -76,7 +76,7 @@ public class ServiceConfigurationApi {
      */
     @Tag(name = "ServiceConfiguration", description = "APIs for managing service's configuration.")
     @PutMapping(value = "/services/config/{serviceId}", produces = MediaType.APPLICATION_JSON_VALUE)
-    @ResponseStatus(HttpStatus.OK)
+    @ResponseStatus(HttpStatus.ACCEPTED)
     @Operation(
             description = "Update the service's configuration to the registered service template.")
     @AuditApiRequest(methodName = "getCspFromServiceId", paramTypes = UUID.class)

--- a/modules/api/src/main/java/org/eclipse/xpanse/api/controllers/ServiceObjectsApi.java
+++ b/modules/api/src/main/java/org/eclipse/xpanse/api/controllers/ServiceObjectsApi.java
@@ -1,0 +1,101 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * SPDX-FileCopyrightText: Huawei Inc.
+ *
+ */
+
+package org.eclipse.xpanse.api.controllers;
+
+import static org.eclipse.xpanse.modules.security.auth.common.RoleConstants.ROLE_ADMIN;
+import static org.eclipse.xpanse.modules.security.auth.common.RoleConstants.ROLE_USER;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.annotation.Resource;
+import jakarta.validation.Valid;
+import java.util.UUID;
+import lombok.extern.slf4j.Slf4j;
+import org.eclipse.xpanse.api.config.AuditApiRequest;
+import org.eclipse.xpanse.modules.deployment.ServiceObjectManager;
+import org.eclipse.xpanse.modules.models.service.order.ServiceOrder;
+import org.eclipse.xpanse.modules.models.serviceobject.ServiceObjectRequest;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.annotation.Secured;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+/** Service Objects Api. */
+@Slf4j
+@CrossOrigin
+@RestController
+@RequestMapping("/xpanse")
+@Secured({ROLE_ADMIN, ROLE_USER})
+@ConditionalOnProperty(name = "enable.agent.api.only", havingValue = "false", matchIfMissing = true)
+public class ServiceObjectsApi {
+
+    @Resource private ServiceObjectManager serviceObjectManager;
+
+    @Tag(name = "ServiceObjects", description = "APIs for managing service's objects.")
+    @PostMapping(
+            value = "/services/object/{serviceId}/{objectType}",
+            produces = MediaType.APPLICATION_JSON_VALUE)
+    @ResponseStatus(HttpStatus.ACCEPTED)
+    @Operation(description = "Create an order to create object for the service.")
+    @AuditApiRequest(methodName = "getCspFromServiceId", paramTypes = UUID.class)
+    public ServiceOrder createServiceObject(
+            @Parameter(name = "serviceId", description = "The id of the deployed service.")
+                    @PathVariable("serviceId")
+                    UUID serviceId,
+            @Parameter(name = "objectType", description = "The action type to the service object.")
+                    @PathVariable("objectType")
+                    String objectType,
+            @Valid @RequestBody ServiceObjectRequest request) {
+        request.setObjectType(objectType);
+        return serviceObjectManager.createOrderToCreateServiceObject(serviceId, request);
+    }
+
+    @Tag(name = "ServiceObjects", description = "APIs for managing service's objects.")
+    @PutMapping(
+            value = "/services/object/{serviceId}/{objectId}",
+            produces = MediaType.APPLICATION_JSON_VALUE)
+    @ResponseStatus(HttpStatus.ACCEPTED)
+    @Operation(description = "Create an order to update service object using object id.")
+    @AuditApiRequest(methodName = "getCspFromServiceId", paramTypes = UUID.class)
+    public ServiceOrder updateServiceObject(
+            @Parameter(name = "serviceId", description = "The id of the deployed service.")
+                    @PathVariable("serviceId")
+                    UUID serviceId,
+            @Parameter(name = "objectId", description = "The id of the service object.")
+                    @PathVariable("objectId")
+                    UUID objectId,
+            @Valid @RequestBody ServiceObjectRequest request) {
+        return serviceObjectManager.createOrderToUpdateServiceObject(serviceId, objectId, request);
+    }
+
+    @Tag(name = "ServiceObjects", description = "APIs for managing service's objects.")
+    @DeleteMapping(
+            value = "/services/object/{serviceId}/{objectId}",
+            produces = MediaType.APPLICATION_JSON_VALUE)
+    @ResponseStatus(HttpStatus.ACCEPTED)
+    @Operation(description = "Create an order to update service object using object id.")
+    @AuditApiRequest(methodName = "getCspFromServiceId", paramTypes = UUID.class)
+    public ServiceOrder deleteServiceObject(
+            @Parameter(name = "serviceId", description = "The id of the deployed service.")
+                    @PathVariable("serviceId")
+                    UUID serviceId,
+            @Parameter(name = "objectId", description = "The id of the service object.")
+                    @PathVariable("objectId")
+                    UUID objectId) {
+        return serviceObjectManager.createOrderToDeleteServiceObject(serviceId, objectId);
+    }
+}

--- a/modules/api/src/main/java/org/eclipse/xpanse/api/exceptions/handler/ServiceActionExceptionHandler.java
+++ b/modules/api/src/main/java/org/eclipse/xpanse/api/exceptions/handler/ServiceActionExceptionHandler.java
@@ -10,7 +10,8 @@ import static org.eclipse.xpanse.api.exceptions.handler.CommonExceptionHandler.g
 import lombok.extern.slf4j.Slf4j;
 import org.eclipse.xpanse.modules.models.response.ErrorResponse;
 import org.eclipse.xpanse.modules.models.response.ErrorType;
-import org.eclipse.xpanse.modules.models.serviceconfiguration.exceptions.ServiceActionTemplateInvalidException;
+import org.eclipse.xpanse.modules.models.serviceaction.exceptions.ServiceActionTemplateInvalidException;
+import org.eclipse.xpanse.modules.models.serviceconfiguration.exceptions.ServiceConfigurationInvalidException;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseBody;
@@ -29,5 +30,14 @@ public class ServiceActionExceptionHandler {
     public ErrorResponse handleServiceActionInvalidException(
             ServiceActionTemplateInvalidException ex) {
         return getErrorResponse(ErrorType.INVALID_SERVICE_ACTION, ex.getErrorReasons());
+    }
+
+    /** Exception handler for ServiceConfigurationNotValidException. */
+    @ExceptionHandler({ServiceConfigurationInvalidException.class})
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ResponseBody
+    public ErrorResponse handleServiceConfigurationInvalidException(
+            ServiceConfigurationInvalidException ex) {
+        return getErrorResponse(ErrorType.INVALID_SERVICE_CONFIGURATION, ex.getErrorReasons());
     }
 }

--- a/modules/api/src/main/java/org/eclipse/xpanse/api/exceptions/handler/ServiceConfigurationExceptionHandler.java
+++ b/modules/api/src/main/java/org/eclipse/xpanse/api/exceptions/handler/ServiceConfigurationExceptionHandler.java
@@ -12,7 +12,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.eclipse.xpanse.modules.models.response.ErrorResponse;
 import org.eclipse.xpanse.modules.models.response.ErrorType;
 import org.eclipse.xpanse.modules.models.servicechange.exceptions.ServiceChangeRequestEntityNotFoundException;
-import org.eclipse.xpanse.modules.models.serviceconfiguration.exceptions.ServiceActionChangeOrderAlreadyExistsException;
 import org.eclipse.xpanse.modules.models.serviceconfiguration.exceptions.ServiceConfigChangeOrderAlreadyExistsException;
 import org.eclipse.xpanse.modules.models.serviceconfiguration.exceptions.ServiceConfigurationInvalidException;
 import org.eclipse.xpanse.modules.models.serviceconfiguration.exceptions.ServiceConfigurationNotFoundException;
@@ -69,17 +68,6 @@ public class ServiceConfigurationExceptionHandler {
             ServiceConfigChangeOrderAlreadyExistsException ex) {
         return getErrorResponse(
                 ErrorType.SERVICE_CONFIG_CHANGE_ORDER_ALREADY_EXISTS,
-                Collections.singletonList(ex.getMessage()));
-    }
-
-    /** Exception handler for ServiceActionChangeOrderAlreadyExistsException. */
-    @ExceptionHandler({ServiceActionChangeOrderAlreadyExistsException.class})
-    @ResponseStatus(HttpStatus.BAD_REQUEST)
-    @ResponseBody
-    public ErrorResponse handleServiceActionChangeOrderAlreadyExistsException(
-            ServiceActionChangeOrderAlreadyExistsException ex) {
-        return getErrorResponse(
-                ErrorType.SERVICE_ACTION_CHANGE_ORDER_ALREADY_EXISTS,
                 Collections.singletonList(ex.getMessage()));
     }
 }

--- a/modules/api/src/main/java/org/eclipse/xpanse/api/exceptions/handler/ServiceObjectRequestExceptionHandler.java
+++ b/modules/api/src/main/java/org/eclipse/xpanse/api/exceptions/handler/ServiceObjectRequestExceptionHandler.java
@@ -1,0 +1,60 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * SPDX-FileCopyrightText: Huawei Inc.
+ */
+
+package org.eclipse.xpanse.api.exceptions.handler;
+
+import static org.eclipse.xpanse.api.exceptions.handler.CommonExceptionHandler.getErrorResponse;
+
+import java.util.Collections;
+import lombok.extern.slf4j.Slf4j;
+import org.eclipse.xpanse.modules.models.response.ErrorResponse;
+import org.eclipse.xpanse.modules.models.response.ErrorType;
+import org.eclipse.xpanse.modules.models.serviceobject.exceptions.ServiceObjectChangeOrderAlreadyExistsException;
+import org.eclipse.xpanse.modules.models.serviceobject.exceptions.ServiceObjectNotFoundException;
+import org.eclipse.xpanse.modules.models.serviceobject.exceptions.ServiceObjectRequestInvalidException;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+/** Exception handler related to service object. */
+@Slf4j
+@Order(Ordered.HIGHEST_PRECEDENCE)
+@RestControllerAdvice
+public class ServiceObjectRequestExceptionHandler {
+
+    /** Exception handler for ServiceObjectNotFoundException. */
+    @ExceptionHandler({ServiceObjectNotFoundException.class})
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ResponseBody
+    public ErrorResponse handleServiceObjectNotFoundException(ServiceObjectNotFoundException ex) {
+        return getErrorResponse(
+                ErrorType.SERVICE_OBJECT_NOT_FOUND, Collections.singletonList(ex.getMessage()));
+    }
+
+    /** Exception handler for ServiceObjectRequestInvalidException. */
+    @ExceptionHandler({ServiceObjectRequestInvalidException.class})
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ResponseBody
+    public ErrorResponse handleServiceObjectRequestInvalidException(
+            ServiceObjectRequestInvalidException ex) {
+        log.error("Service object request is invalid: {}", ex.getErrorReasons());
+        return getErrorResponse(ErrorType.INVALID_SERVICE_OBJECT_REQUEST, ex.getErrorReasons());
+    }
+
+    /** Exception handler for ServiceObjectManageOrderAlreadyExistsException. */
+    @ExceptionHandler({ServiceObjectChangeOrderAlreadyExistsException.class})
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ResponseBody
+    public ErrorResponse handleServiceObjectsChangeOrderAlreadyExistsException(
+            ServiceObjectChangeOrderAlreadyExistsException ex) {
+        return getErrorResponse(
+                ErrorType.SERVICE_OBJECT_CHANGE_ORDER_ALREADY_EXISTS,
+                Collections.singletonList(ex.getMessage()));
+    }
+}

--- a/modules/database/src/main/java/org/eclipse/xpanse/modules/database/CustomJpaRepository.java
+++ b/modules/database/src/main/java/org/eclipse/xpanse/modules/database/CustomJpaRepository.java
@@ -28,5 +28,7 @@ public interface CustomJpaRepository<T, ID> extends Repository<T, ID> {
 
     long count();
 
+    List<T> findAllById(Iterable<ID> ids);
+
     <S extends T> List<S> saveAll(Iterable<S> entities);
 }

--- a/modules/database/src/main/java/org/eclipse/xpanse/modules/database/servicechange/ServiceChangeRequestEntity.java
+++ b/modules/database/src/main/java/org/eclipse/xpanse/modules/database/servicechange/ServiceChangeRequestEntity.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import org.eclipse.xpanse.modules.database.common.CreatedModifiedTime;
 import org.eclipse.xpanse.modules.database.common.ObjectJsonConverter;
 import org.eclipse.xpanse.modules.database.service.ServiceDeploymentEntity;
@@ -35,6 +36,7 @@ import org.hibernate.annotations.OnDeleteAction;
 import org.hibernate.annotations.Type;
 
 /** ServiceChangeRequestEntity for persistence. */
+@EqualsAndHashCode(callSuper = true)
 @Table(name = "SERVICE_CHANGE_REQUEST")
 @Entity
 @Data
@@ -57,11 +59,13 @@ public class ServiceChangeRequestEntity extends CreatedModifiedTime implements S
     @OnDelete(action = OnDeleteAction.CASCADE)
     private ServiceDeploymentEntity serviceDeploymentEntity;
 
+    @Column(name = "RESOURCE_NAME", nullable = false)
     private String resourceName;
 
     @Column(name = "CHANGE_HANDLER", nullable = false)
     private String changeHandler;
 
+    @Column(name = "RESULT_MESSAGE")
     private String resultMessage;
 
     @Column(name = "PROPERTIES", columnDefinition = "json")

--- a/modules/database/src/main/java/org/eclipse/xpanse/modules/database/servicechange/ServiceChangeRequestQueryModel.java
+++ b/modules/database/src/main/java/org/eclipse/xpanse/modules/database/servicechange/ServiceChangeRequestQueryModel.java
@@ -7,15 +7,13 @@
 package org.eclipse.xpanse.modules.database.servicechange;
 
 import java.util.UUID;
-import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
-import lombok.NoArgsConstructor;
 import org.eclipse.xpanse.modules.models.servicechange.enums.ServiceChangeStatus;
 
 /** The query model for ServiceChangeRequestEntity. */
 @Data
-@AllArgsConstructor
-@NoArgsConstructor
+@Builder
 public class ServiceChangeRequestQueryModel {
 
     private UUID orderId;
@@ -24,7 +22,7 @@ public class ServiceChangeRequestQueryModel {
 
     private String resourceName;
 
-    private String configManager;
+    private String changeHandler;
 
     private ServiceChangeStatus status;
 }

--- a/modules/database/src/main/java/org/eclipse/xpanse/modules/database/servicechange/ServiceChangeRequestStorage.java
+++ b/modules/database/src/main/java/org/eclipse/xpanse/modules/database/servicechange/ServiceChangeRequestStorage.java
@@ -20,7 +20,7 @@ public interface ServiceChangeRequestStorage {
     ServiceChangeRequestEntity storeAndFlush(ServiceChangeRequestEntity serviceChangeRequestEntity);
 
     /** Batch add or update service change details data to database. */
-    <S extends ServiceChangeRequestEntity> List<S> saveAll(Iterable<S> entities);
+    <S extends ServiceChangeRequestEntity> void saveAll(Iterable<S> entities);
 
     /** Method to list database entry based ServiceChangeRequestEntity. */
     List<ServiceChangeRequestEntity> getServiceChangeRequestEntities(

--- a/modules/database/src/main/java/org/eclipse/xpanse/modules/database/serviceobject/DatabaseServiceObjectStorage.java
+++ b/modules/database/src/main/java/org/eclipse/xpanse/modules/database/serviceobject/DatabaseServiceObjectStorage.java
@@ -6,7 +6,10 @@
 
 package org.eclipse.xpanse.modules.database.serviceobject;
 
+import java.util.List;
+import java.util.Set;
 import java.util.UUID;
+import org.eclipse.xpanse.modules.models.serviceobject.exceptions.ServiceObjectNotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -35,6 +38,22 @@ public class DatabaseServiceObjectStorage implements ServiceObjectStorage {
 
     @Override
     public ServiceObjectEntity getEntityById(UUID objectId) {
-        return repository.findById(objectId).orElse(null);
+        return repository
+                .findById(objectId)
+                .orElseThrow(
+                        () ->
+                                new ServiceObjectNotFoundException(
+                                        String.format(
+                                                "Service object with id %s not found.", objectId)));
+    }
+
+    @Override
+    public List<ServiceObjectEntity> getEntitiesByIds(List<UUID> objectIds) {
+        return repository.findAllById(objectIds);
+    }
+
+    @Override
+    public Set<UUID> getObjectIdsByDependentObjectId(UUID dependentObjectId) {
+        return repository.findObjectIdsByDependentObjectId(dependentObjectId);
     }
 }

--- a/modules/database/src/main/java/org/eclipse/xpanse/modules/database/serviceobject/ServiceObjectEntity.java
+++ b/modules/database/src/main/java/org/eclipse/xpanse/modules/database/serviceobject/ServiceObjectEntity.java
@@ -17,7 +17,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
-import jakarta.persistence.OneToOne;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import java.io.Serial;
 import java.io.Serializable;
@@ -42,14 +42,14 @@ public class ServiceObjectEntity implements Serializable {
     @Column(name = "OBJECT_ID", nullable = false)
     private UUID objectId;
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "SERVICE_ID", nullable = false)
     private ServiceDeploymentEntity serviceDeploymentEntity;
 
-    @JoinColumn(name = "OBJECT_TYPE", nullable = false)
+    @Column(name = "OBJECT_TYPE", nullable = false)
     private String objectType;
 
-    @JoinColumn(name = "OBJECT_IDENTIFIER", nullable = false)
+    @Column(name = "OBJECT_IDENTIFIER_NAME", nullable = false)
     private String objectIdentifierName;
 
     @Column(name = "PROPERTIES", columnDefinition = "json", length = Integer.MAX_VALUE)

--- a/modules/database/src/main/java/org/eclipse/xpanse/modules/database/serviceobject/ServiceObjectRepository.java
+++ b/modules/database/src/main/java/org/eclipse/xpanse/modules/database/serviceobject/ServiceObjectRepository.java
@@ -6,13 +6,22 @@
 
 package org.eclipse.xpanse.modules.database.serviceobject;
 
+import java.util.Set;
 import java.util.UUID;
 import org.eclipse.xpanse.modules.database.CustomJpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 /** Interface to access default JPA methods. */
 @Repository
 public interface ServiceObjectRepository
         extends CustomJpaRepository<ServiceObjectEntity, UUID>,
-                JpaSpecificationExecutor<ServiceObjectEntity> {}
+                JpaSpecificationExecutor<ServiceObjectEntity> {
+
+    @Query(
+            "SELECT s.objectId FROM ServiceObjectEntity s JOIN s.dependentObjectIds d WHERE d ="
+                    + " :dependentObjectId")
+    Set<UUID> findObjectIdsByDependentObjectId(@Param("dependentObjectId") UUID dependentObjectId);
+}

--- a/modules/database/src/main/java/org/eclipse/xpanse/modules/database/serviceobject/ServiceObjectStorage.java
+++ b/modules/database/src/main/java/org/eclipse/xpanse/modules/database/serviceobject/ServiceObjectStorage.java
@@ -6,6 +6,8 @@
 
 package org.eclipse.xpanse.modules.database.serviceobject;
 
+import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 
 /** Interface for persist of ServiceObjectEntity. */
@@ -16,4 +18,8 @@ public interface ServiceObjectStorage {
     void delete(ServiceObjectEntity entity);
 
     ServiceObjectEntity getEntityById(UUID objectId);
+
+    List<ServiceObjectEntity> getEntitiesByIds(List<UUID> ids);
+
+    Set<UUID> getObjectIdsByDependentObjectId(UUID dependentObjectId);
 }

--- a/modules/database/src/main/java/org/eclipse/xpanse/modules/database/serviceorder/ServiceOrderEntity.java
+++ b/modules/database/src/main/java/org/eclipse/xpanse/modules/database/serviceorder/ServiceOrderEntity.java
@@ -28,7 +28,6 @@ import java.util.UUID;
 import lombok.Data;
 import org.eclipse.xpanse.modules.database.common.ObjectJsonConverter;
 import org.eclipse.xpanse.modules.database.service.ServiceDeploymentEntity;
-import org.eclipse.xpanse.modules.database.serviceobject.ServiceObjectEntity;
 import org.eclipse.xpanse.modules.models.response.ErrorResponse;
 import org.eclipse.xpanse.modules.models.service.enums.Handler;
 import org.eclipse.xpanse.modules.models.service.enums.OrderStatus;
@@ -56,10 +55,6 @@ public class ServiceOrderEntity implements Serializable {
     @JoinColumn(name = "SERVICE_ID", nullable = false)
     @OnDelete(action = OnDeleteAction.CASCADE)
     private ServiceDeploymentEntity serviceDeploymentEntity;
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "OBJECT_ID")
-    private ServiceObjectEntity serviceObjectEntity;
 
     @Column(name = "PARENT_ORDER_ID")
     private UUID parentOrderId;

--- a/modules/database/src/test/java/org/eclipse/xpanse/modules/database/serviceobject/DatabaseServiceObjectStorageTest.java
+++ b/modules/database/src/test/java/org/eclipse/xpanse/modules/database/serviceobject/DatabaseServiceObjectStorageTest.java
@@ -7,7 +7,7 @@
 package org.eclipse.xpanse.modules.database.serviceobject;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -15,6 +15,7 @@ import static org.mockito.Mockito.when;
 
 import java.util.Optional;
 import java.util.UUID;
+import org.eclipse.xpanse.modules.models.serviceobject.exceptions.ServiceObjectNotFoundException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -62,9 +63,6 @@ class DatabaseServiceObjectStorageTest {
 
     @Test
     void getEntityByIdShouldReturnNullWhenNotExists() {
-        when(repository.findById(objectId)).thenReturn(Optional.empty());
-        ServiceObjectEntity result = storage.getEntityById(objectId);
-        verify(repository, times(1)).findById(objectId);
-        assertNull(result);
+        assertThrows(ServiceObjectNotFoundException.class, () -> storage.getEntityById(objectId));
     }
 }

--- a/modules/database/src/test/java/org/eclipse/xpanse/modules/database/serviceorder/ServiceOrderEntityTest.java
+++ b/modules/database/src/test/java/org/eclipse/xpanse/modules/database/serviceorder/ServiceOrderEntityTest.java
@@ -46,7 +46,6 @@ class ServiceOrderEntityTest {
         test.setParentOrderId(uuid);
         test.setWorkflowId(uuid.toString());
         test.setServiceDeploymentEntity(mockServiceDeploymentEntity);
-        test.setServiceObjectEntity(serviceObjectEntity);
         test.setOriginalServiceId(uuid);
         test.setTaskType(taskType);
         test.setUserId(userId);
@@ -64,7 +63,6 @@ class ServiceOrderEntityTest {
         assertThat(test.getOrderId()).isEqualTo(uuid);
         assertThat(test.getParentOrderId()).isEqualTo(uuid);
         assertThat(test.getServiceDeploymentEntity()).isEqualTo(mockServiceDeploymentEntity);
-        assertThat(test.getServiceObjectEntity()).isEqualTo(serviceObjectEntity);
         assertThat(test.getOriginalServiceId()).isEqualTo(uuid);
         assertThat(test.getWorkflowId()).isEqualTo(uuid.toString());
         assertThat(test.getTaskType()).isEqualTo(taskType);
@@ -100,8 +98,6 @@ class ServiceOrderEntityTest {
                         + uuid
                         + ", serviceDeploymentEntity="
                         + mockServiceDeploymentEntity
-                        + ", serviceObjectEntity="
-                        + serviceObjectEntity
                         + ", parentOrderId="
                         + uuid
                         + ", workflowId="

--- a/modules/deployment/src/main/java/org/eclipse/xpanse/modules/deployment/SensitiveDataHandler.java
+++ b/modules/deployment/src/main/java/org/eclipse/xpanse/modules/deployment/SensitiveDataHandler.java
@@ -27,9 +27,11 @@ import org.springframework.util.CollectionUtils;
 @Component
 public class SensitiveDataHandler {
 
+    /** The value of sensitive data will be masked as "******". */
+    public static final String SENSITIVE_VALUE = "******";
+
     private static final String PROPERTIES_ALREADY_VIEWED = "is_already_viewed";
     private static final String REQUEST_PROPERTIES_FIELD = "serviceRequestProperties";
-    private static final String SENSITIVE_VALUE = "******";
 
     @Resource private SecretsManager secretsManager;
 

--- a/modules/deployment/src/main/java/org/eclipse/xpanse/modules/deployment/ServiceActionManager.java
+++ b/modules/deployment/src/main/java/org/eclipse/xpanse/modules/deployment/ServiceActionManager.java
@@ -29,7 +29,7 @@ import org.eclipse.xpanse.modules.models.service.order.enums.ServiceOrderType;
 import org.eclipse.xpanse.modules.models.service.utils.ServiceConfigurationVariablesJsonSchemaGenerator;
 import org.eclipse.xpanse.modules.models.service.utils.ServiceConfigurationVariablesJsonSchemaValidator;
 import org.eclipse.xpanse.modules.models.serviceaction.ServiceActionRequest;
-import org.eclipse.xpanse.modules.models.serviceconfiguration.exceptions.ServiceActionChangeOrderAlreadyExistsException;
+import org.eclipse.xpanse.modules.models.serviceaction.exceptions.ServiceActionChangeOrderAlreadyExistsException;
 import org.eclipse.xpanse.modules.models.serviceconfiguration.exceptions.ServiceConfigurationInvalidException;
 import org.eclipse.xpanse.modules.models.servicetemplate.Ocl;
 import org.eclipse.xpanse.modules.models.servicetemplate.ServiceAction;

--- a/modules/deployment/src/main/java/org/eclipse/xpanse/modules/deployment/ServiceChangeRequestsManager.java
+++ b/modules/deployment/src/main/java/org/eclipse/xpanse/modules/deployment/ServiceChangeRequestsManager.java
@@ -86,6 +86,10 @@ public class ServiceChangeRequestsManager {
                                                                 finalPropertiesToBeUsed,
                                                                 originalRequestProperties,
                                                                 serviceOrderEntity);
+                                                request.setResourceName(
+                                                        deployResourceList
+                                                                .getFirst()
+                                                                .getResourceName());
                                                 requests.add(request);
                                             } else {
                                                 deployResourceList.forEach(
@@ -131,12 +135,13 @@ public class ServiceChangeRequestsManager {
             ServiceChangeStatus status) {
         UUID uuidOrderId = StringUtils.isEmpty(orderId) ? null : UUID.fromString(orderId);
         ServiceChangeRequestQueryModel queryModel =
-                new ServiceChangeRequestQueryModel(
-                        uuidOrderId,
-                        UUID.fromString(serviceId),
-                        resourceName,
-                        changeHandler,
-                        status);
+                ServiceChangeRequestQueryModel.builder()
+                        .orderId(uuidOrderId)
+                        .serviceId(UUID.fromString(serviceId))
+                        .resourceName(resourceName)
+                        .changeHandler(changeHandler)
+                        .status(status)
+                        .build();
         List<ServiceChangeRequestEntity> requests =
                 serviceChangeRequestStorage.getServiceChangeRequestEntities(queryModel);
 

--- a/modules/deployment/src/main/java/org/eclipse/xpanse/modules/deployment/ServiceConfigurationManager.java
+++ b/modules/deployment/src/main/java/org/eclipse/xpanse/modules/deployment/ServiceConfigurationManager.java
@@ -243,7 +243,7 @@ public class ServiceConfigurationManager {
         ServiceTemplateEntity serviceTemplateEntity =
                 request.getServiceDeploymentEntity().getServiceTemplateEntity();
         if (Objects.isNull(serviceTemplateEntity)) {
-            String errMsg = String.format("Service template not found.");
+            String errMsg = "Service template not found.";
             log.error(errMsg);
             throw new ServiceTemplateNotRegistered(errMsg);
         }

--- a/modules/deployment/src/main/java/org/eclipse/xpanse/modules/deployment/ServiceDeploymentEntityHandler.java
+++ b/modules/deployment/src/main/java/org/eclipse/xpanse/modules/deployment/ServiceDeploymentEntityHandler.java
@@ -75,7 +75,10 @@ public class ServiceDeploymentEntityHandler {
                             SERVICE_ACTION,
                             SERVICE_START,
                             SERVICE_STOP,
-                            SERVICE_RESTART ->
+                            SERVICE_RESTART,
+                            OBJECT_CREATE,
+                            OBJECT_MODIFY,
+                            OBJECT_DELETE ->
                     state == ServiceDeploymentState.DEPLOY_SUCCESS
                             || state == ServiceDeploymentState.MODIFICATION_SUCCESSFUL
                             || state == ServiceDeploymentState.MODIFICATION_FAILED;

--- a/modules/deployment/src/main/java/org/eclipse/xpanse/modules/deployment/ServiceObjectManager.java
+++ b/modules/deployment/src/main/java/org/eclipse/xpanse/modules/deployment/ServiceObjectManager.java
@@ -1,0 +1,637 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * SPDX-FileCopyrightText: Huawei Inc.
+ *
+ */
+
+package org.eclipse.xpanse.modules.deployment;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.annotation.Resource;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.eclipse.xpanse.modules.database.service.ServiceDeploymentEntity;
+import org.eclipse.xpanse.modules.database.servicechange.ServiceChangeRequestEntity;
+import org.eclipse.xpanse.modules.database.serviceobject.ServiceObjectEntity;
+import org.eclipse.xpanse.modules.database.serviceobject.ServiceObjectStorage;
+import org.eclipse.xpanse.modules.database.serviceorder.ServiceOrderEntity;
+import org.eclipse.xpanse.modules.database.serviceorder.ServiceOrderStorage;
+import org.eclipse.xpanse.modules.database.servicetemplate.ServiceTemplateEntity;
+import org.eclipse.xpanse.modules.models.common.enums.UserOperation;
+import org.eclipse.xpanse.modules.models.common.exceptions.UnsupportedEnumValueException;
+import org.eclipse.xpanse.modules.models.service.deployment.DeployResource;
+import org.eclipse.xpanse.modules.models.service.enums.Handler;
+import org.eclipse.xpanse.modules.models.service.enums.OrderStatus;
+import org.eclipse.xpanse.modules.models.service.order.ServiceOrder;
+import org.eclipse.xpanse.modules.models.service.order.enums.ServiceOrderType;
+import org.eclipse.xpanse.modules.models.service.utils.ServiceObjectVariablesJsonSchemaGenerator;
+import org.eclipse.xpanse.modules.models.service.utils.ServiceObjectVariablesJsonSchemaValidator;
+import org.eclipse.xpanse.modules.models.serviceconfiguration.exceptions.ServiceConfigurationInvalidException;
+import org.eclipse.xpanse.modules.models.serviceobject.ServiceObjectRequest;
+import org.eclipse.xpanse.modules.models.serviceobject.exceptions.ServiceObjectChangeOrderAlreadyExistsException;
+import org.eclipse.xpanse.modules.models.serviceobject.exceptions.ServiceObjectNotFoundException;
+import org.eclipse.xpanse.modules.models.serviceobject.exceptions.ServiceObjectRequestInvalidException;
+import org.eclipse.xpanse.modules.models.servicetemplate.ObjectManage;
+import org.eclipse.xpanse.modules.models.servicetemplate.ObjectParameter;
+import org.eclipse.xpanse.modules.models.servicetemplate.ServiceChangeScript;
+import org.eclipse.xpanse.modules.models.servicetemplate.ServiceObject;
+import org.eclipse.xpanse.modules.models.servicetemplate.enums.ObjectActionType;
+import org.eclipse.xpanse.modules.models.servicetemplate.enums.SensitiveScope;
+import org.eclipse.xpanse.modules.models.servicetemplate.utils.JsonObjectSchema;
+import org.eclipse.xpanse.modules.security.auth.UserServiceHelper;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.stereotype.Component;
+import org.springframework.util.CollectionUtils;
+
+/** Bean to manage service objects. */
+@Slf4j
+@Component
+public class ServiceObjectManager {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Resource private UserServiceHelper userServiceHelper;
+
+    @Resource private ServiceDeploymentEntityHandler serviceDeploymentEntityHandler;
+
+    @Resource private DeployService deployService;
+
+    @Resource private ServiceChangeRequestsManager serviceChangeRequestsManager;
+
+    @Resource
+    private ServiceObjectVariablesJsonSchemaValidator serviceObjectVariablesJsonSchemaValidator;
+
+    @Resource
+    private ServiceObjectVariablesJsonSchemaGenerator serviceObjectVariablesJsonSchemaGenerator;
+
+    @Resource private ServiceObjectStorage serviceObjectStorage;
+
+    @Resource private ServiceOrderStorage serviceOrderStorage;
+
+    /** create service action. */
+    public ServiceOrder createOrderToCreateServiceObject(
+            UUID serviceId, ServiceObjectRequest request) {
+        try {
+            ServiceDeploymentEntity serviceDeploymentEntity =
+                    serviceDeploymentEntityHandler.getServiceDeploymentEntity(serviceId);
+            checkPermission(serviceDeploymentEntity, UserOperation.CREATE_SERVICE_OBJECT);
+            serviceDeploymentEntityHandler.validateServiceDeploymentStateForOrderType(
+                    serviceDeploymentEntity, ServiceOrderType.OBJECT_CREATE);
+            checkIfAnyOrderForSameObjectIsPending(
+                    serviceDeploymentEntity.getServiceOrders(), request);
+            ServiceTemplateEntity serviceTemplateEntity =
+                    serviceDeploymentEntity.getServiceTemplateEntity();
+            List<ServiceObject> serviceObjects = serviceTemplateEntity.getOcl().getServiceObjects();
+            ObjectManage objectManageConfiguration =
+                    findServiceObjectManageConfigurationByRequest(
+                            serviceObjects, request, ObjectActionType.CREATE);
+            validateServiceObjectRequestWithRequiredParameters(
+                    request, objectManageConfiguration.getObjectParameters());
+            return createServiceOrderForServiceObjectRequest(
+                    serviceDeploymentEntity,
+                    null,
+                    request,
+                    ServiceOrderType.OBJECT_CREATE,
+                    objectManageConfiguration);
+        } catch (ServiceConfigurationInvalidException e) {
+            String errorMsg =
+                    String.format("Change service configuration error, %s", e.getErrorReasons());
+            log.error(errorMsg);
+            throw e;
+        }
+    }
+
+    /** Create order to update the service object. */
+    public ServiceOrder createOrderToUpdateServiceObject(
+            UUID serviceId, UUID objectId, ServiceObjectRequest request) {
+        try {
+            ServiceDeploymentEntity serviceDeploymentEntity =
+                    serviceDeploymentEntityHandler.getServiceDeploymentEntity(serviceId);
+            checkPermission(serviceDeploymentEntity, UserOperation.UPDATE_SERVICE_OBJECT);
+            serviceDeploymentEntityHandler.validateServiceDeploymentStateForOrderType(
+                    serviceDeploymentEntity, ServiceOrderType.OBJECT_MODIFY);
+            ServiceObjectEntity serviceObjectEntity = serviceObjectStorage.getEntityById(objectId);
+            if (serviceId != serviceObjectEntity.getServiceDeploymentEntity().getId()) {
+                String errorMsg =
+                        String.format(
+                                "Request service object with id %s not belonging to the service"
+                                        + " with id %s.",
+                                objectId, serviceId);
+                log.error(errorMsg);
+                throw new ServiceObjectRequestInvalidException(List.of(errorMsg));
+            }
+            request.setObjectId(objectId);
+            request.setObjectType(serviceObjectEntity.getObjectType());
+            checkIfAnyOrderForSameObjectIsPending(
+                    serviceDeploymentEntity.getServiceOrders(), request);
+            // find service object configuration by object type and action type
+            ServiceTemplateEntity serviceTemplateEntity =
+                    serviceDeploymentEntity.getServiceTemplateEntity();
+            List<ServiceObject> serviceObjectConfigurations =
+                    serviceTemplateEntity.getOcl().getServiceObjects();
+            ObjectManage objectManage =
+                    findServiceObjectManageConfigurationByRequest(
+                            serviceObjectConfigurations, request, ObjectActionType.UPDATE);
+            validateServiceObjectRequestWithRequiredParameters(
+                    request, objectManage.getObjectParameters());
+            updateServiceObjectWithRequest(serviceObjectEntity, request);
+            return createServiceOrderForServiceObjectRequest(
+                    serviceDeploymentEntity,
+                    serviceObjectEntity,
+                    request,
+                    ServiceOrderType.OBJECT_MODIFY,
+                    objectManage);
+        } catch (ServiceConfigurationInvalidException e) {
+            String errorMsg =
+                    String.format("Change service configuration error, %s", e.getErrorReasons());
+            log.error(errorMsg);
+            throw e;
+        }
+    }
+
+    /** Create order to delete the service object. */
+    public ServiceOrder createOrderToDeleteServiceObject(UUID serviceId, UUID objectId) {
+        try {
+            ServiceDeploymentEntity serviceDeploymentEntity =
+                    serviceDeploymentEntityHandler.getServiceDeploymentEntity(serviceId);
+            checkPermission(serviceDeploymentEntity, UserOperation.DELETE_SERVICE_OBJECT);
+            serviceDeploymentEntityHandler.validateServiceDeploymentStateForOrderType(
+                    serviceDeploymentEntity, ServiceOrderType.OBJECT_DELETE);
+            ServiceObjectEntity serviceObjectEntity = serviceObjectStorage.getEntityById(objectId);
+            if (serviceId != serviceObjectEntity.getServiceDeploymentEntity().getId()) {
+                String errorMsg =
+                        String.format(
+                                "Request service object with id %s not belonging to the service"
+                                        + " with id %s.",
+                                objectId, serviceId);
+                log.error(errorMsg);
+                throw new ServiceObjectRequestInvalidException(List.of(errorMsg));
+            }
+            Set<UUID> objectIdsDependentOnObjectId =
+                    serviceObjectStorage.getObjectIdsByDependentObjectId(objectId);
+            if (!objectIdsDependentOnObjectId.isEmpty()) {
+                String errorMsg =
+                        String.format(
+                                "Service object with id %s is the dependent of other service"
+                                        + " objects with ids %s.",
+                                objectId, objectIdsDependentOnObjectId);
+                log.error(errorMsg);
+                throw new ServiceObjectRequestInvalidException(List.of(errorMsg));
+            }
+            ServiceObjectRequest request = new ServiceObjectRequest();
+            request.setObjectId(objectId);
+            request.setObjectType(serviceObjectEntity.getObjectType());
+            request.setObjectIdentifier(serviceObjectEntity.getObjectIdentifierName());
+            checkIfAnyOrderForSameObjectIsPending(
+                    serviceDeploymentEntity.getServiceOrders(), request);
+            // find service object configuration by object type and action type
+            ServiceTemplateEntity serviceTemplateEntity =
+                    serviceDeploymentEntity.getServiceTemplateEntity();
+            List<ServiceObject> serviceObjectConfigurations =
+                    serviceTemplateEntity.getOcl().getServiceObjects();
+            ObjectManage objectManageConfiguration =
+                    findServiceObjectManageConfigurationByRequest(
+                            serviceObjectConfigurations, request, ObjectActionType.DELETE);
+            validateServiceObjectRequestWithRequiredParameters(
+                    request, objectManageConfiguration.getObjectParameters());
+            return createServiceOrderForServiceObjectRequest(
+                    serviceDeploymentEntity,
+                    serviceObjectEntity,
+                    request,
+                    ServiceOrderType.OBJECT_DELETE,
+                    objectManageConfiguration);
+        } catch (ServiceConfigurationInvalidException e) {
+            String errorMsg =
+                    String.format("Change service configuration error, %s", e.getErrorReasons());
+            log.error(errorMsg);
+            throw e;
+        }
+    }
+
+    /**
+     * Returns the specific service object management script from service template. This is called
+     * when the agent requests for pending requests
+     */
+    public Optional<ServiceChangeScript> getServiceObjectManageScript(
+            ServiceChangeRequestEntity serviceChangeRequestEntity) {
+        try {
+            ServiceTemplateEntity serviceTemplateEntity =
+                    serviceChangeRequestEntity
+                            .getServiceDeploymentEntity()
+                            .getServiceTemplateEntity();
+            // get object type from the original request stored in the service order table.
+            ServiceObjectRequest serviceObjectRequest =
+                    objectMapper.readValue(
+                            objectMapper.writeValueAsString(
+                                    serviceChangeRequestEntity
+                                            .getServiceOrderEntity()
+                                            .getRequestBody()),
+                            ServiceObjectRequest.class);
+            Optional<ServiceObject> serviceObjectOptional =
+                    serviceTemplateEntity.getOcl().getServiceObjects().stream()
+                            .filter(
+                                    serviceObject ->
+                                            serviceObject
+                                                    .getType()
+                                                    .equals(serviceObjectRequest.getObjectType()))
+                            .findFirst();
+
+            if (serviceObjectOptional.isEmpty()) {
+                String errorMsg =
+                        String.format(
+                                "Service object with type %s not found in service template.",
+                                serviceObjectRequest.getObjectType());
+                log.error(errorMsg);
+                throw new ServiceObjectRequestInvalidException(List.of(errorMsg));
+            }
+
+            ObjectActionType requestedActionType =
+                    getRequestedActionType(serviceChangeRequestEntity);
+            Optional<ObjectManage> objectManageOptional =
+                    serviceObjectOptional.get().getObjectsManage().stream()
+                            .filter(
+                                    objectManage ->
+                                            requestedActionType
+                                                    == objectManage.getObjectActionType())
+                            .findFirst();
+            return objectManageOptional.map(ObjectManage::getObjectHandlerScript);
+        } catch (JsonProcessingException e) {
+            log.error(e.getMessage(), e);
+            throw new ServiceObjectRequestInvalidException(
+                    List.of("Cannot process service object request body."));
+        }
+    }
+
+    /** updates object data after the configuration change request is processed successfully. */
+    public void updateServiceObjectInDatabase(
+            ServiceChangeRequestEntity request, ServiceOrderEntity serviceOrder) {
+        try {
+            log.info(
+                    "Updating service object for service ID {}",
+                    request.getServiceDeploymentEntity().getId());
+            ServiceObjectRequest serviceObjectRequest =
+                    objectMapper.readValue(
+                            objectMapper.writeValueAsString(serviceOrder.getRequestBody()),
+                            ServiceObjectRequest.class);
+            ServiceTemplateEntity serviceTemplate =
+                    request.getServiceDeploymentEntity().getServiceTemplateEntity();
+            List<ServiceObject> serviceObjectConfigurations =
+                    serviceTemplate.getOcl().getServiceObjects();
+            ObjectActionType objectActionType = getRequestedActionType(request);
+            ObjectManage objectManageConfiguration =
+                    findServiceObjectManageConfigurationByRequest(
+                            serviceObjectConfigurations, serviceObjectRequest, objectActionType);
+            maskSecretParametersInDatabase(
+                    objectManageConfiguration.getObjectParameters(),
+                    serviceObjectRequest,
+                    serviceOrder);
+            if (ServiceOrderType.OBJECT_CREATE == serviceOrder.getTaskType()) {
+                addServiceObjectEntity(request.getServiceDeploymentEntity(), serviceObjectRequest);
+                log.info(
+                        "Service object created for service ID {}",
+                        request.getServiceDeploymentEntity().getId());
+            } else if (ServiceOrderType.OBJECT_MODIFY == serviceOrder.getTaskType()) {
+                updateServiceObjectEntity(serviceObjectRequest);
+                log.info(
+                        "Updated service object {} for service ID {}",
+                        serviceObjectRequest.getObjectId(),
+                        request.getServiceDeploymentEntity().getId());
+            } else if (ServiceOrderType.OBJECT_DELETE == serviceOrder.getTaskType()) {
+                deleteServiceObjectEntity(serviceObjectRequest.getObjectId());
+                log.info(
+                        "Deleted service object {} for service ID {}",
+                        serviceObjectRequest.getObjectId(),
+                        request.getServiceDeploymentEntity().getId());
+            }
+            serviceOrderStorage.storeAndFlush(serviceOrder);
+        } catch (JsonProcessingException e) {
+            log.error(e.getMessage(), e);
+        }
+    }
+
+    private void maskSecretParametersInDatabase(
+            List<ObjectParameter> objectParameters,
+            ServiceObjectRequest serviceObjectRequest,
+            ServiceOrderEntity serviceOrder) {
+        Set<String> secretParameters =
+                objectParameters.stream()
+                        .filter(parameter -> parameter.getSensitiveScope() != SensitiveScope.NONE)
+                        .map(ObjectParameter::getName)
+                        .collect(Collectors.toSet());
+        if (CollectionUtils.isEmpty(secretParameters)) {
+            return;
+        }
+
+        if (!CollectionUtils.isEmpty(serviceObjectRequest.getServiceObjectParameters())) {
+            serviceObjectRequest
+                    .getServiceObjectParameters()
+                    .forEach(
+                            (key, value) -> {
+                                if (secretParameters.contains(key)) {
+                                    serviceObjectRequest
+                                            .getServiceObjectParameters()
+                                            .put(key, SensitiveDataHandler.SENSITIVE_VALUE);
+                                }
+                            });
+        }
+
+        if (Objects.nonNull(serviceOrder.getRequestBody())) {
+            serviceOrder
+                    .getRequestBody()
+                    .put(
+                            "serviceObjectParameters",
+                            serviceObjectRequest.getServiceObjectParameters());
+        }
+    }
+
+    private void addServiceObjectEntity(
+            ServiceDeploymentEntity serviceDeploymentEntity, ServiceObjectRequest request) {
+        ServiceObjectEntity serviceObjectEntity = new ServiceObjectEntity();
+        serviceObjectEntity.setServiceDeploymentEntity(serviceDeploymentEntity);
+        serviceObjectEntity.setObjectType(request.getObjectType());
+        serviceObjectEntity.setObjectIdentifierName(request.getObjectIdentifier());
+        serviceObjectEntity.setProperties(request.getServiceObjectParameters());
+        if (Objects.nonNull(request.getLinkedObjects())) {
+            serviceObjectEntity.setDependentObjectIds(new HashSet<>(request.getLinkedObjects()));
+        }
+        serviceObjectStorage.storeAndFlush(serviceObjectEntity);
+    }
+
+    private void updateServiceObjectEntity(ServiceObjectRequest request) {
+        ServiceObjectEntity serviceObjectEntity =
+                serviceObjectStorage.getEntityById(request.getObjectId());
+        serviceObjectEntity.setObjectType(request.getObjectType());
+        serviceObjectEntity.setObjectIdentifierName(request.getObjectIdentifier());
+        serviceObjectEntity.setProperties(request.getServiceObjectParameters());
+        if (Objects.nonNull(request.getLinkedObjects())) {
+            serviceObjectEntity.setDependentObjectIds(new HashSet<>(request.getLinkedObjects()));
+        }
+        serviceObjectStorage.storeAndFlush(serviceObjectEntity);
+    }
+
+    private void deleteServiceObjectEntity(UUID objectId) {
+        ServiceObjectEntity serviceObjectEntity = serviceObjectStorage.getEntityById(objectId);
+        serviceObjectStorage.delete(serviceObjectEntity);
+    }
+
+    private ObjectActionType getRequestedActionType(
+            ServiceChangeRequestEntity serviceChangeRequestEntity) {
+        ServiceOrderType serviceOrderType =
+                serviceChangeRequestEntity.getServiceOrderEntity().getTaskType();
+        return switch (serviceOrderType) {
+            case OBJECT_CREATE -> ObjectActionType.CREATE;
+            case OBJECT_MODIFY -> ObjectActionType.UPDATE;
+            case OBJECT_DELETE -> ObjectActionType.DELETE;
+            default ->
+                    throw new UnsupportedEnumValueException(
+                            String.format(
+                                    "ServiceOrderType value %s is not supported.",
+                                    serviceOrderType));
+        };
+    }
+
+    /**
+     * Find matched service object configuration in service template by request.
+     *
+     * @return matched service object configuration.
+     */
+    private ObjectManage findServiceObjectManageConfigurationByRequest(
+            List<ServiceObject> serviceObjects,
+            ServiceObjectRequest request,
+            ObjectActionType objectActionType) {
+        Optional<ServiceObject> serviceObjectOptional =
+                serviceObjects.stream()
+                        .filter(
+                                serviceObject ->
+                                        StringUtils.equals(
+                                                request.getObjectType(), serviceObject.getType()))
+                        .findFirst();
+        if (serviceObjectOptional.isEmpty()) {
+            String errMsg =
+                    String.format(
+                            "Could not find any service object configuration with object type %s"
+                                    + " for the service",
+                            request.getObjectType());
+            log.error(errMsg);
+            throw new ServiceObjectRequestInvalidException(List.of(errMsg));
+        }
+        Optional<ObjectManage> objectManageOptional =
+                serviceObjectOptional.get().getObjectsManage().stream()
+                        .filter(
+                                objectManage ->
+                                        objectActionType == objectManage.getObjectActionType())
+                        .findAny();
+        if (objectManageOptional.isEmpty()) {
+            String errMsg =
+                    String.format(
+                            "Could not find any defined service object manage configuration with"
+                                    + " action type %s for the service",
+                            objectActionType);
+            log.error(errMsg);
+            throw new ServiceObjectRequestInvalidException(List.of(errMsg));
+        }
+        return objectManageOptional.get();
+    }
+
+    /** Validate service object request with required parameters. */
+    private void validateServiceObjectRequestWithRequiredParameters(
+            ServiceObjectRequest request, List<ObjectParameter> objectParameters) {
+        if (Objects.isNull(request.getServiceObjectParameters()) || objectParameters.isEmpty()) {
+            return;
+        }
+        JsonObjectSchema jsonObjectSchema =
+                serviceObjectVariablesJsonSchemaGenerator.buildJsonSchemaOfServiceObjectParameters(
+                        objectParameters);
+        serviceObjectVariablesJsonSchemaValidator.validateServiceObjectParameters(
+                request.getServiceObjectParameters(), jsonObjectSchema);
+
+        checkLinkedObjects(request);
+    }
+
+    private void checkPermission(
+            ServiceDeploymentEntity deployedService, UserOperation userOperation) {
+        boolean currentUserIsOwner =
+                userServiceHelper.currentUserIsOwner(deployedService.getUserId());
+        if (!currentUserIsOwner) {
+            String errorMsg =
+                    String.format(
+                            "No permission to %s owned by other users.", userOperation.toValue());
+            log.error(errorMsg);
+            throw new AccessDeniedException(errorMsg);
+        }
+    }
+
+    private void checkIfAnyOrderForSameObjectIsPending(
+            List<ServiceOrderEntity> serviceOrders, ServiceObjectRequest request) {
+        List<UUID> pendingOrderIds =
+                serviceOrders.stream()
+                        .filter(serviceOrder -> isPendingOrderForSameObject(serviceOrder, request))
+                        .map(ServiceOrderEntity::getOrderId)
+                        .toList();
+        if (!CollectionUtils.isEmpty(pendingOrderIds)) {
+            throw new ServiceObjectChangeOrderAlreadyExistsException(
+                    String.format(
+                            "There is already a pending Object manage order. Order ID - %s",
+                            pendingOrderIds.getFirst().toString()));
+        }
+    }
+
+    private void checkLinkedObjects(ServiceObjectRequest request) {
+        if (CollectionUtils.isEmpty(request.getLinkedObjects())) {
+            return;
+        }
+        List<ServiceObjectEntity> linkedObjects =
+                serviceObjectStorage.getEntitiesByIds(request.getLinkedObjects());
+        List<UUID> existingObjectIds =
+                linkedObjects.stream().map(ServiceObjectEntity::getObjectId).toList();
+        Set<UUID> notFoundObjectIds = new HashSet<>();
+        for (UUID linkedObjectId : request.getLinkedObjects()) {
+            if (!existingObjectIds.contains(linkedObjectId)) {
+                notFoundObjectIds.add(linkedObjectId);
+            }
+        }
+        if (!CollectionUtils.isEmpty(notFoundObjectIds)) {
+            String errMsg =
+                    String.format(
+                            "Could not find service objects with linked object ids %s",
+                            notFoundObjectIds);
+            log.error(errMsg);
+            throw new ServiceObjectNotFoundException(errMsg);
+        }
+    }
+
+    private boolean isPendingOrderForSameObject(
+            ServiceOrderEntity serviceOrder, ServiceObjectRequest request) {
+        return (ServiceOrderType.OBJECT_CREATE == serviceOrder.getTaskType()
+                        || ServiceOrderType.OBJECT_MODIFY == serviceOrder.getTaskType()
+                        || ServiceOrderType.OBJECT_DELETE == serviceOrder.getTaskType())
+                && (OrderStatus.CREATED == serviceOrder.getOrderStatus()
+                        || OrderStatus.IN_PROGRESS == serviceOrder.getOrderStatus())
+                && orderHasSameObjectTypeAndIdentifierWithRequest(serviceOrder, request);
+    }
+
+    private boolean orderHasSameObjectTypeAndIdentifierWithRequest(
+            ServiceOrderEntity serviceOrder, ServiceObjectRequest request) {
+        ServiceObjectRequest storedServiceObjectRequest =
+                objectMapper.convertValue(
+                        serviceOrder.getRequestBody(), ServiceObjectRequest.class);
+        return StringUtils.equals(
+                        storedServiceObjectRequest.getObjectType(), request.getObjectType())
+                && StringUtils.equals(
+                        storedServiceObjectRequest.getObjectIdentifier(),
+                        request.getObjectIdentifier());
+    }
+
+    private void updateServiceObjectWithRequest(
+            ServiceObjectEntity serviceObjectEntity, ServiceObjectRequest serviceObjectRequest) {
+        if (!CollectionUtils.isEmpty(serviceObjectRequest.getLinkedObjects())) {
+            serviceObjectEntity.setDependentObjectIds(
+                    new HashSet<>(serviceObjectRequest.getLinkedObjects()));
+            serviceObjectStorage.storeAndFlush(serviceObjectEntity);
+        }
+    }
+
+    private ServiceOrder createServiceOrderForServiceObjectRequest(
+            ServiceDeploymentEntity serviceDeployment,
+            ServiceObjectEntity serviceObjectEntity,
+            ServiceObjectRequest serviceObjectRequest,
+            ServiceOrderType orderType,
+            ObjectManage objectManage) {
+        Map<String, List<DeployResource>> deployResourceMap =
+                deployService
+                        .listResourcesOfDeployedService(serviceDeployment.getId(), null)
+                        .stream()
+                        .collect(Collectors.groupingBy(DeployResource::getGroupName));
+        ServiceChangeScript serviceChangeScript = objectManage.getObjectHandlerScript();
+        List<ObjectParameter> objectParameters = objectManage.getObjectParameters();
+        Map<String, Object> originalProperties = serviceObjectRequest.getServiceObjectParameters();
+        Map<String, Object> finalPropertiesToBeUsed =
+                fillMissingParametersWithStoredPropertiesOrDefaultValues(
+                        originalProperties, serviceObjectEntity, objectParameters);
+        UUID orderId =
+                serviceChangeRequestsManager.createServiceOrderAndQueueServiceChangeRequests(
+                        serviceDeployment,
+                        serviceObjectRequest,
+                        serviceObjectRequest.getServiceObjectParameters(),
+                        finalPropertiesToBeUsed,
+                        deployResourceMap,
+                        List.of(serviceChangeScript),
+                        orderType,
+                        Handler.AGENT);
+        return new ServiceOrder(orderId, serviceDeployment.getId());
+    }
+
+    /**
+     * Fill missing parameters in request with stored properties in object or default values in
+     * configuration.
+     */
+    private Map<String, Object> fillMissingParametersWithStoredPropertiesOrDefaultValues(
+            Map<String, Object> requestMap,
+            ServiceObjectEntity serviceObjectEntity,
+            List<ObjectParameter> objectParameters) {
+        Map<String, Object> updatedParametersRequest = new HashMap<>();
+        if (!CollectionUtils.isEmpty(requestMap)) {
+            updatedParametersRequest.putAll(requestMap);
+        }
+        Set<String> missingRequiredParameters =
+                objectParameters.stream()
+                        .filter(
+                                objectParameter ->
+                                        objectParameter.getIsMandatory()
+                                                && !updatedParametersRequest.containsKey(
+                                                        objectParameter.getName()))
+                        .map(ObjectParameter::getName)
+                        .collect(Collectors.toSet());
+        if (CollectionUtils.isEmpty(missingRequiredParameters)) {
+            return updatedParametersRequest;
+        }
+        Map<String, Object> storedProperties = new HashMap<>();
+        if (Objects.nonNull(serviceObjectEntity)
+                && !CollectionUtils.isEmpty(serviceObjectEntity.getProperties())) {
+            storedProperties.putAll(serviceObjectEntity.getProperties());
+        }
+        for (String requiredParameter : missingRequiredParameters) {
+            if (!updatedParametersRequest.containsKey(requiredParameter)) {
+                // fill with stored properties if exist
+                if (storedProperties.containsKey(requiredParameter)) {
+                    updatedParametersRequest.put(
+                            requiredParameter, storedProperties.get(requiredParameter));
+                    log.info(
+                            "The parameter {} is missing in request, use the stored value {}.",
+                            requiredParameter,
+                            serviceObjectEntity.getProperties().get(requiredParameter));
+
+                } else {
+                    Optional<ObjectParameter> objectParameterOptional =
+                            objectParameters.stream()
+                                    .filter(
+                                            objectParameter ->
+                                                    objectParameter
+                                                            .getName()
+                                                            .equals(requiredParameter))
+                                    .findFirst();
+                    if (objectParameterOptional.isPresent()) {
+                        ObjectParameter objectParameter = objectParameterOptional.get();
+                        updatedParametersRequest.put(
+                                requiredParameter, objectParameter.getExample());
+                        log.info(
+                                "The parameter {} is missing in request, use the default value {}.",
+                                requiredParameter,
+                                objectParameter.getExample());
+                    }
+                }
+            }
+        }
+        return updatedParametersRequest;
+    }
+}

--- a/modules/deployment/src/main/java/org/eclipse/xpanse/modules/deployment/ServiceOrderManager.java
+++ b/modules/deployment/src/main/java/org/eclipse/xpanse/modules/deployment/ServiceOrderManager.java
@@ -9,6 +9,7 @@ package org.eclipse.xpanse.modules.deployment;
 import static org.eclipse.xpanse.modules.async.TaskConfiguration.ASYNC_EXECUTOR_NAME;
 import static org.eclipse.xpanse.modules.security.auth.common.RoleConstants.ROLE_ADMIN;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.annotation.Resource;
@@ -49,7 +50,8 @@ import org.springframework.web.context.request.async.DeferredResult;
 @Component
 public class ServiceOrderManager {
 
-    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final ObjectMapper objectMapper =
+            new ObjectMapper().setSerializationInclusion(JsonInclude.Include.NON_NULL);
     @Resource private ServiceOrderStorage serviceOrderStorage;
     @Resource private ServiceDeploymentStorage serviceDeploymentStorage;
     @Resource private UserServiceHelper userServiceHelper;

--- a/modules/deployment/src/main/java/org/eclipse/xpanse/modules/deployment/deployers/terraform/resources/TfStateResourceInstance.java
+++ b/modules/deployment/src/main/java/org/eclipse/xpanse/modules/deployment/deployers/terraform/resources/TfStateResourceInstance.java
@@ -15,5 +15,7 @@ import lombok.Data;
 @Data
 public class TfStateResourceInstance {
 
-    public Map<String, Object> attributes;
+    private String type;
+
+    private Map<String, Object> attributes;
 }

--- a/modules/models/src/main/java/org/eclipse/xpanse/modules/models/common/enums/UserOperation.java
+++ b/modules/models/src/main/java/org/eclipse/xpanse/modules/models/common/enums/UserOperation.java
@@ -54,6 +54,11 @@ public enum UserOperation {
     CHANGE_SERVICE_CONFIGURATION("change the configuration of the service"),
     CHANGE_SERVICE_LOCK_CONFIGURATION("change the lock configuration of the service"),
 
+    // Operations for service objects.
+    CREATE_SERVICE_OBJECT("create object for the service"),
+    UPDATE_SERVICE_OBJECT("update the object of the service"),
+    DELETE_SERVICE_OBJECT("delete the object of the service"),
+
     // Operations for service orders.
     VIEW_ORDER_DETAILS_OF_SERVICE("view order details of the service"),
     VIEW_ORDERS_OF_SERVICE("view orders of the service"),

--- a/modules/models/src/main/java/org/eclipse/xpanse/modules/models/response/ErrorType.java
+++ b/modules/models/src/main/java/org/eclipse/xpanse/modules/models/response/ErrorType.java
@@ -84,7 +84,10 @@ public enum ErrorType {
     INVALID_SERVICE_ACTION("Service Action Invalid"),
     SERVICE_CHANGE_FAILED("Service Change Request Failed"),
     SERVICE_CONFIG_CHANGE_ORDER_ALREADY_EXISTS("Service Configuration Change Order Already Exists"),
-    SERVICE_ACTION_CHANGE_ORDER_ALREADY_EXISTS("Service Action Change Order Already Exists");
+    SERVICE_ACTION_CHANGE_ORDER_ALREADY_EXISTS("Service Action Change Order Already Exists"),
+    INVALID_SERVICE_OBJECT_REQUEST("Invalid Service Object Request"),
+    SERVICE_OBJECT_NOT_FOUND("Service Object Not Found"),
+    SERVICE_OBJECT_CHANGE_ORDER_ALREADY_EXISTS("Service Object Change Order Already Exists");
 
     private final String value;
 

--- a/modules/models/src/main/java/org/eclipse/xpanse/modules/models/service/enums/DeployResourceKind.java
+++ b/modules/models/src/main/java/org/eclipse/xpanse/modules/models/service/enums/DeployResourceKind.java
@@ -14,6 +14,7 @@ import org.eclipse.xpanse.modules.models.common.exceptions.UnsupportedEnumValueE
 /** The kind of the Resources. */
 public enum DeployResourceKind {
     VM("vm", null),
+    RDS("rds", null),
     CONTAINER("container", null),
     PUBLIC_IP("publicIP", null),
     VPC("vpc", null),

--- a/modules/models/src/main/java/org/eclipse/xpanse/modules/models/service/order/enums/ServiceOrderType.java
+++ b/modules/models/src/main/java/org/eclipse/xpanse/modules/models/service/order/enums/ServiceOrderType.java
@@ -25,7 +25,10 @@ public enum ServiceOrderType {
     PURGE("purge"),
     SERVICE_START("serviceStart"),
     SERVICE_STOP("serviceStop"),
-    SERVICE_RESTART("serviceRestart");
+    SERVICE_RESTART("serviceRestart"),
+    OBJECT_CREATE("objectCreate"),
+    OBJECT_MODIFY("objectModify"),
+    OBJECT_DELETE("objectDelete");
 
     private final String type;
 

--- a/modules/models/src/main/java/org/eclipse/xpanse/modules/models/service/utils/ServiceObjectVariablesJsonSchemaGenerator.java
+++ b/modules/models/src/main/java/org/eclipse/xpanse/modules/models/service/utils/ServiceObjectVariablesJsonSchemaGenerator.java
@@ -1,0 +1,102 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * SPDX-FileCopyrightText: Huawei Inc.
+ *
+ */
+
+package org.eclipse.xpanse.modules.models.service.utils;
+
+import com.networknt.schema.JsonMetaSchema;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import lombok.extern.slf4j.Slf4j;
+import org.eclipse.xpanse.modules.models.servicetemplate.ObjectParameter;
+import org.eclipse.xpanse.modules.models.servicetemplate.exceptions.InvalidValueSchemaException;
+import org.eclipse.xpanse.modules.models.servicetemplate.utils.JsonObjectSchema;
+import org.springframework.stereotype.Component;
+import org.springframework.util.CollectionUtils;
+
+/** The Class is used to generate a JSONSchema for service object parameter. */
+@Slf4j
+@Component
+public class ServiceObjectVariablesJsonSchemaGenerator {
+
+    private static final String VARIABLE_TYPE_KEY = "type";
+    private static final String VARIABLE_DESCRIPTION_KEY = "description";
+    private static final String VARIABLE_EXAMPLE_KEY = "examples";
+
+    /** Generate a JSONSchema for service object parameter. */
+    public JsonObjectSchema buildJsonSchemaOfServiceObjectParameters(
+            List<ObjectParameter> objectParameters) {
+        JsonObjectSchema jsonObjectSchema = new JsonObjectSchema();
+        List<String> requiredList = new ArrayList<>();
+        Map<String, Map<String, Object>> serviceObjectParametersJsonSchemaProperties =
+                new HashMap<>();
+        objectParameters.forEach(
+                objectParameter -> {
+                    Map<String, Object> validationProperties =
+                            getValidationPropertiesOfObjectParameter(objectParameter, requiredList);
+                    if (!CollectionUtils.isEmpty(validationProperties)) {
+                        serviceObjectParametersJsonSchemaProperties.put(
+                                objectParameter.getName(), validationProperties);
+                    }
+                });
+        jsonObjectSchema.setRequired(requiredList);
+        jsonObjectSchema.setProperties(serviceObjectParametersJsonSchemaProperties);
+        jsonObjectSchema.setAdditionalProperties(false);
+        validateSchemaDefinition(jsonObjectSchema);
+        return jsonObjectSchema;
+    }
+
+    private Map<String, Object> getValidationPropertiesOfObjectParameter(
+            ObjectParameter objectParameter, List<String> requiredList) {
+        Map<String, Object> validationProperties = new HashMap<>();
+
+        if (!CollectionUtils.isEmpty(objectParameter.getValueSchema())) {
+            validationProperties.putAll(objectParameter.getValueSchema());
+        }
+
+        if (Objects.nonNull(objectParameter.getDataType())) {
+            validationProperties.put(VARIABLE_TYPE_KEY, objectParameter.getDataType().toValue());
+        }
+
+        if (Objects.nonNull(objectParameter.getDescription())) {
+            validationProperties.put(VARIABLE_DESCRIPTION_KEY, objectParameter.getDescription());
+        }
+
+        if (Objects.nonNull(objectParameter.getExample())) {
+            validationProperties.put(VARIABLE_EXAMPLE_KEY, objectParameter.getExample());
+        }
+
+        if (Boolean.TRUE.equals(objectParameter.getIsMandatory())) {
+            requiredList.add(objectParameter.getName());
+        }
+        return validationProperties;
+    }
+
+    private void validateSchemaDefinition(JsonObjectSchema jsonObjectSchema) {
+        Set<String> allowedKeys = JsonMetaSchema.getV202012().getKeywords().keySet();
+        List<String> invalidKeys = new ArrayList<>();
+        jsonObjectSchema
+                .getProperties()
+                .forEach(
+                        (inputVariable, variableValueSchema) ->
+                                variableValueSchema.forEach(
+                                        (schemaDefKey, schemaDefValue) -> {
+                                            if (!allowedKeys.contains(schemaDefKey)) {
+                                                invalidKeys.add(
+                                                        String.format(
+                                                                "Value schema key %s in input"
+                                                                        + " variable %s is invalid",
+                                                                schemaDefKey, inputVariable));
+                                            }
+                                        }));
+        if (!invalidKeys.isEmpty()) {
+            throw new InvalidValueSchemaException(invalidKeys);
+        }
+    }
+}

--- a/modules/models/src/main/java/org/eclipse/xpanse/modules/models/service/utils/ServiceObjectVariablesJsonSchemaValidator.java
+++ b/modules/models/src/main/java/org/eclipse/xpanse/modules/models/service/utils/ServiceObjectVariablesJsonSchemaValidator.java
@@ -1,0 +1,62 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * SPDX-FileCopyrightText: Huawei Inc.
+ *
+ */
+
+package org.eclipse.xpanse.modules.models.service.utils;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.networknt.schema.JsonSchema;
+import com.networknt.schema.JsonSchemaFactory;
+import com.networknt.schema.SpecVersion;
+import com.networknt.schema.ValidationMessage;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import lombok.extern.slf4j.Slf4j;
+import org.eclipse.xpanse.modules.models.serviceobject.exceptions.ServiceObjectRequestInvalidException;
+import org.eclipse.xpanse.modules.models.servicetemplate.utils.JsonObjectSchema;
+import org.springframework.stereotype.Component;
+import org.springframework.util.CollectionUtils;
+
+/** The class is used to validate service object parameter. */
+@Slf4j
+@Component
+public class ServiceObjectVariablesJsonSchemaValidator {
+    private final ObjectMapper jsonMapper = new ObjectMapper();
+
+    /** Validate service object parameters. */
+    public void validateServiceObjectParameters(
+            Map<String, Object> updateObjectParameters, JsonObjectSchema jsonObjectSchema) {
+        try {
+            if (Objects.isNull(jsonObjectSchema)) {
+                return;
+            }
+            String jsonObjectSchemaString = jsonMapper.writeValueAsString(jsonObjectSchema);
+            Locale.setDefault(Locale.ENGLISH);
+            JsonSchemaFactory factory =
+                    JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V202012);
+            JsonSchema schema = factory.getSchema(jsonObjectSchemaString);
+            String propertyJson = jsonMapper.writeValueAsString(updateObjectParameters);
+            JsonNode jsonNode = jsonMapper.readTree(propertyJson);
+            Set<ValidationMessage> validate = schema.validate(jsonNode);
+            if (!CollectionUtils.isEmpty(validate)) {
+                List<String> errors = new ArrayList<>();
+                for (ValidationMessage validationMessage : validate) {
+                    errors.add(validationMessage.getMessage().substring(3));
+                }
+                throw new ServiceObjectRequestInvalidException(errors);
+            }
+        } catch (JsonProcessingException e) {
+            List<String> errors = new ArrayList<>();
+            errors.add(e.getMessage());
+            throw new ServiceObjectRequestInvalidException(errors);
+        }
+    }
+}

--- a/modules/models/src/main/java/org/eclipse/xpanse/modules/models/serviceaction/exceptions/ServiceActionChangeOrderAlreadyExistsException.java
+++ b/modules/models/src/main/java/org/eclipse/xpanse/modules/models/serviceaction/exceptions/ServiceActionChangeOrderAlreadyExistsException.java
@@ -3,7 +3,7 @@
  * SPDX-FileCopyrightText: Huawei Inc.
  */
 
-package org.eclipse.xpanse.modules.models.serviceconfiguration.exceptions;
+package org.eclipse.xpanse.modules.models.serviceaction.exceptions;
 
 import lombok.Data;
 import lombok.EqualsAndHashCode;

--- a/modules/models/src/main/java/org/eclipse/xpanse/modules/models/serviceaction/exceptions/ServiceActionTemplateInvalidException.java
+++ b/modules/models/src/main/java/org/eclipse/xpanse/modules/models/serviceaction/exceptions/ServiceActionTemplateInvalidException.java
@@ -3,7 +3,7 @@
  * SPDX-FileCopyrightText: Huawei Inc.
  */
 
-package org.eclipse.xpanse.modules.models.serviceconfiguration.exceptions;
+package org.eclipse.xpanse.modules.models.serviceaction.exceptions;
 
 import java.util.List;
 import lombok.Data;

--- a/modules/models/src/main/java/org/eclipse/xpanse/modules/models/serviceobject/ServiceObjectRequest.java
+++ b/modules/models/src/main/java/org/eclipse/xpanse/modules/models/serviceobject/ServiceObjectRequest.java
@@ -1,0 +1,36 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * SPDX-FileCopyrightText: Huawei Inc.
+ */
+
+package org.eclipse.xpanse.modules.models.serviceobject;
+
+import io.swagger.v3.oas.annotations.Hidden;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import lombok.Data;
+
+/** Service Object Request Model. */
+@Data
+public class ServiceObjectRequest {
+
+    @NotNull
+    @Size(min = 1)
+    @Schema(description = "The name of service object identifier.")
+    private String objectIdentifier;
+
+    @Schema(description = "The collection of dependent object IDs.")
+    private List<UUID> linkedObjects;
+
+    @NotNull
+    @Size(min = 1)
+    @Schema(description = "The collection of service object parameter.")
+    private Map<String, Object> serviceObjectParameters;
+
+    @Hidden private UUID objectId;
+    @Hidden private String objectType;
+}

--- a/modules/models/src/main/java/org/eclipse/xpanse/modules/models/serviceobject/exceptions/ServiceObjectChangeOrderAlreadyExistsException.java
+++ b/modules/models/src/main/java/org/eclipse/xpanse/modules/models/serviceobject/exceptions/ServiceObjectChangeOrderAlreadyExistsException.java
@@ -1,0 +1,18 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * SPDX-FileCopyrightText: Huawei Inc.
+ */
+
+package org.eclipse.xpanse.modules.models.serviceobject.exceptions;
+
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+/** Exception thrown when service object manage order already exists. */
+@EqualsAndHashCode(callSuper = true)
+@Data
+public class ServiceObjectChangeOrderAlreadyExistsException extends RuntimeException {
+    public ServiceObjectChangeOrderAlreadyExistsException(String message) {
+        super(message);
+    }
+}

--- a/modules/models/src/main/java/org/eclipse/xpanse/modules/models/serviceobject/exceptions/ServiceObjectNotFoundException.java
+++ b/modules/models/src/main/java/org/eclipse/xpanse/modules/models/serviceobject/exceptions/ServiceObjectNotFoundException.java
@@ -1,0 +1,13 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * SPDX-FileCopyrightText: Huawei Inc.
+ */
+
+package org.eclipse.xpanse.modules.models.serviceobject.exceptions;
+
+/** Exception thrown when service configuration not found. */
+public class ServiceObjectNotFoundException extends RuntimeException {
+    public ServiceObjectNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/modules/models/src/main/java/org/eclipse/xpanse/modules/models/serviceobject/exceptions/ServiceObjectRequestInvalidException.java
+++ b/modules/models/src/main/java/org/eclipse/xpanse/modules/models/serviceobject/exceptions/ServiceObjectRequestInvalidException.java
@@ -1,0 +1,22 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * SPDX-FileCopyrightText: Huawei Inc.
+ */
+
+package org.eclipse.xpanse.modules.models.serviceobject.exceptions;
+
+import java.util.List;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+/** Exception thrown when service configuration is invalid. */
+@EqualsAndHashCode(callSuper = true)
+@Data
+public class ServiceObjectRequestInvalidException extends RuntimeException {
+
+    private final List<String> errorReasons;
+
+    public ServiceObjectRequestInvalidException(List<String> errorReasons) {
+        this.errorReasons = errorReasons;
+    }
+}

--- a/modules/models/src/main/java/org/eclipse/xpanse/modules/models/servicetemplate/ObjectParameter.java
+++ b/modules/models/src/main/java/org/eclipse/xpanse/modules/models/servicetemplate/ObjectParameter.java
@@ -40,7 +40,7 @@ public class ObjectParameter implements Serializable {
     private String description;
 
     @Schema(description = "The example value of the service object  parameter")
-    private String example;
+    private Object example;
 
     @Schema(
             description =

--- a/modules/models/src/main/java/org/eclipse/xpanse/modules/models/servicetemplate/ServiceObject.java
+++ b/modules/models/src/main/java/org/eclipse/xpanse/modules/models/servicetemplate/ServiceObject.java
@@ -26,8 +26,8 @@ public class ServiceObject implements Serializable {
     @Serial private static final long serialVersionUID = 240913796673021261L;
 
     @NotNull
-    @Schema(description = "the name of service object.")
-    private String name;
+    @Schema(description = "the type of service object.")
+    private String type;
 
     @NotNull
     @Schema(description = "the identifier of service object.")

--- a/modules/models/src/main/java/org/eclipse/xpanse/modules/models/servicetemplate/view/ServiceTemplateDetailVo.java
+++ b/modules/models/src/main/java/org/eclipse/xpanse/modules/models/servicetemplate/view/ServiceTemplateDetailVo.java
@@ -28,6 +28,7 @@ import org.eclipse.xpanse.modules.models.servicetemplate.OutputVariable;
 import org.eclipse.xpanse.modules.models.servicetemplate.Region;
 import org.eclipse.xpanse.modules.models.servicetemplate.ServiceAction;
 import org.eclipse.xpanse.modules.models.servicetemplate.ServiceChangeManage;
+import org.eclipse.xpanse.modules.models.servicetemplate.ServiceObject;
 import org.eclipse.xpanse.modules.models.servicetemplate.ServiceProviderContactDetails;
 import org.eclipse.xpanse.modules.models.servicetemplate.enums.ServiceHostingType;
 import org.eclipse.xpanse.modules.models.servicetemplate.enums.ServiceTemplateRegistrationState;
@@ -149,4 +150,7 @@ public class ServiceTemplateDetailVo extends RepresentationModel<ServiceTemplate
 
     @Schema(description = "manage service action.")
     private List<ServiceAction> serviceActions;
+
+    @Schema(description = "manage service object.")
+    private List<ServiceObject> serviceObjects;
 }

--- a/modules/models/src/main/java/org/eclipse/xpanse/modules/models/servicetemplate/view/UserOrderableServiceVo.java
+++ b/modules/models/src/main/java/org/eclipse/xpanse/modules/models/servicetemplate/view/UserOrderableServiceVo.java
@@ -24,6 +24,7 @@ import org.eclipse.xpanse.modules.models.servicetemplate.OutputVariable;
 import org.eclipse.xpanse.modules.models.servicetemplate.Region;
 import org.eclipse.xpanse.modules.models.servicetemplate.ServiceAction;
 import org.eclipse.xpanse.modules.models.servicetemplate.ServiceChangeParameter;
+import org.eclipse.xpanse.modules.models.servicetemplate.ServiceObject;
 import org.eclipse.xpanse.modules.models.servicetemplate.ServiceProviderContactDetails;
 import org.eclipse.xpanse.modules.models.servicetemplate.enums.ServiceHostingType;
 import org.hibernate.validator.constraints.UniqueElements;
@@ -121,4 +122,7 @@ public class UserOrderableServiceVo extends RepresentationModel<UserOrderableSer
     @UniqueElements
     @Schema(description = "manage service action.")
     private List<ServiceAction> serviceActions;
+
+    @Schema(description = "manage service object.")
+    private List<ServiceObject> serviceObjects;
 }

--- a/modules/models/src/test/java/org/eclipse/xpanse/modules/models/servicetemplate/ObjectParameterTest.java
+++ b/modules/models/src/test/java/org/eclipse/xpanse/modules/models/servicetemplate/ObjectParameterTest.java
@@ -22,7 +22,7 @@ public class ObjectParameterTest {
     private final String name = "test";
     private final VariableDataType dataType = VariableDataType.STRING;
     private final String description = "description";
-    private final String example = "example";
+    private final Object example = "example";
     private final Map<String, Object> valueSchema = Map.of();
     private final SensitiveScope sensitiveScope = SensitiveScope.ALWAYS;
     private final Boolean isMandatory = Boolean.TRUE;

--- a/modules/models/src/test/java/org/eclipse/xpanse/modules/models/servicetemplate/ServiceObjectTest.java
+++ b/modules/models/src/test/java/org/eclipse/xpanse/modules/models/servicetemplate/ServiceObjectTest.java
@@ -19,7 +19,7 @@ import org.springframework.beans.BeanUtils;
 /** Test of ServiceObject. */
 public class ServiceObjectTest {
 
-    private final String name = "uaser";
+    private final String type = "uaser";
     private final ConfigurationManagerTool handlerType = ConfigurationManagerTool.ANSIBLE;
     @Mock private ObjectIdentifier objectIdentifier;
     @Mock private List<ObjectManage> objectsManage;
@@ -29,7 +29,7 @@ public class ServiceObjectTest {
     @BeforeEach
     void setUp() {
         serviceObject = new ServiceObject();
-        serviceObject.setName(name);
+        serviceObject.setType(type);
         serviceObject.setObjectIdentifier(objectIdentifier);
         serviceObject.setHandlerType(handlerType);
         serviceObject.setObjectsManage(objectsManage);
@@ -37,7 +37,7 @@ public class ServiceObjectTest {
 
     @Test
     void testGetters() {
-        assertEquals(name, serviceObject.getName());
+        assertEquals(type, serviceObject.getType());
         assertEquals(objectIdentifier, serviceObject.getObjectIdentifier());
         assertEquals(handlerType, serviceObject.getHandlerType());
         assertEquals(objectsManage, serviceObject.getObjectsManage());
@@ -62,8 +62,8 @@ public class ServiceObjectTest {
     void testToString() {
         String expectedString =
                 "ServiceObject("
-                        + "name="
-                        + name
+                        + "type="
+                        + type
                         + ", objectIdentifier="
                         + objectIdentifier
                         + ", handlerType="

--- a/modules/models/src/test/java/org/eclipse/xpanse/modules/models/servicetemplate/view/ServiceTemplateDetailVoTest.java
+++ b/modules/models/src/test/java/org/eclipse/xpanse/modules/models/servicetemplate/view/ServiceTemplateDetailVoTest.java
@@ -22,6 +22,7 @@ import org.eclipse.xpanse.modules.models.servicetemplate.OutputVariable;
 import org.eclipse.xpanse.modules.models.servicetemplate.Region;
 import org.eclipse.xpanse.modules.models.servicetemplate.ServiceAction;
 import org.eclipse.xpanse.modules.models.servicetemplate.ServiceChangeManage;
+import org.eclipse.xpanse.modules.models.servicetemplate.ServiceObject;
 import org.eclipse.xpanse.modules.models.servicetemplate.ServiceProviderContactDetails;
 import org.eclipse.xpanse.modules.models.servicetemplate.enums.ServiceHostingType;
 import org.eclipse.xpanse.modules.models.servicetemplate.enums.ServiceTemplateRegistrationState;
@@ -58,6 +59,7 @@ class ServiceTemplateDetailVoTest {
     @Mock private FlavorsWithPrice flavors;
     @Mock private Billing billing;
     @Mock private List<ServiceAction> serviceActions;
+    @Mock private List<ServiceObject> serviceObjects;
 
     private ServiceTemplateDetailVo test;
 
@@ -88,6 +90,7 @@ class ServiceTemplateDetailVoTest {
         test.setEula(eula);
         test.setServiceConfigurationManage(serviceConfigurationManage);
         test.setServiceActions(serviceActions);
+        test.setServiceObjects(serviceObjects);
     }
 
     @Test
@@ -114,6 +117,7 @@ class ServiceTemplateDetailVoTest {
         assertEquals(serviceProviderContactDetails, test.getServiceProviderContactDetails());
         assertEquals(eula, test.getEula());
         assertEquals(serviceConfigurationManage, test.getServiceConfigurationManage());
+        assertEquals(serviceActions, test.getServiceActions());
     }
 
     @Test
@@ -181,6 +185,8 @@ class ServiceTemplateDetailVoTest {
                         + serviceConfigurationManage
                         + ", serviceActions="
                         + serviceActions
+                        + ", serviceObjects="
+                        + serviceObjects
                         + ")";
 
         assertEquals(expectedToString, test.toString());

--- a/modules/models/src/test/java/org/eclipse/xpanse/modules/models/servicetemplate/view/UserOrderableServiceVoTest.java
+++ b/modules/models/src/test/java/org/eclipse/xpanse/modules/models/servicetemplate/view/UserOrderableServiceVoTest.java
@@ -16,6 +16,7 @@ import org.eclipse.xpanse.modules.models.servicetemplate.OutputVariable;
 import org.eclipse.xpanse.modules.models.servicetemplate.Region;
 import org.eclipse.xpanse.modules.models.servicetemplate.ServiceAction;
 import org.eclipse.xpanse.modules.models.servicetemplate.ServiceChangeParameter;
+import org.eclipse.xpanse.modules.models.servicetemplate.ServiceObject;
 import org.eclipse.xpanse.modules.models.servicetemplate.ServiceProviderContactDetails;
 import org.eclipse.xpanse.modules.models.servicetemplate.enums.ServiceHostingType;
 import org.junit.jupiter.api.BeforeEach;
@@ -47,6 +48,7 @@ class UserOrderableServiceVoTest {
     @Mock private ServiceProviderContactDetails mockServiceProviderContactDetails;
     @Mock private List<AvailabilityZoneConfig> mockServiceAvailabilityConfig;
     @Mock private List<ServiceAction> mockServiceActions;
+    @Mock private List<ServiceObject> mockServiceObjects;
 
     private UserOrderableServiceVo test;
 
@@ -72,6 +74,7 @@ class UserOrderableServiceVoTest {
         test.setEula(eula);
         test.setConfigurationParameters(configurationParameters);
         test.setServiceActions(mockServiceActions);
+        test.setServiceObjects(mockServiceObjects);
     }
 
     @Test
@@ -96,6 +99,7 @@ class UserOrderableServiceVoTest {
         assertThat(test.getEula()).isEqualTo(eula);
         assertThat(test.getConfigurationParameters()).isEqualTo(configurationParameters);
         assertThat(test.getServiceActions()).isEqualTo(mockServiceActions);
+        assertThat(test.getServiceObjects()).isEqualTo(mockServiceObjects);
     }
 
     @Test
@@ -154,6 +158,8 @@ class UserOrderableServiceVoTest {
                         + configurationParameters
                         + ", serviceActions="
                         + mockServiceActions
+                        + ", serviceObjects="
+                        + mockServiceObjects
                         + ")";
         assertEquals(expectedToString, test.toString());
     }

--- a/modules/servicetemplate/src/main/java/org/eclipse/xpanse/modules/servicetemplate/utils/ServiceActionTemplateValidator.java
+++ b/modules/servicetemplate/src/main/java/org/eclipse/xpanse/modules/servicetemplate/utils/ServiceActionTemplateValidator.java
@@ -17,7 +17,7 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.eclipse.xpanse.modules.deployment.utils.DeploymentScriptsHelper;
-import org.eclipse.xpanse.modules.models.serviceconfiguration.exceptions.ServiceActionTemplateInvalidException;
+import org.eclipse.xpanse.modules.models.serviceaction.exceptions.ServiceActionTemplateInvalidException;
 import org.eclipse.xpanse.modules.models.servicetemplate.Ocl;
 import org.eclipse.xpanse.modules.models.servicetemplate.ServiceAction;
 import org.eclipse.xpanse.modules.models.servicetemplate.ServiceChangeParameter;

--- a/plugins/huaweicloud/src/main/java/org/eclipse/xpanse/plugins/huaweicloud/resourcehandler/HuaweiCloudTerraformResourceHandler.java
+++ b/plugins/huaweicloud/src/main/java/org/eclipse/xpanse/plugins/huaweicloud/resourcehandler/HuaweiCloudTerraformResourceHandler.java
@@ -58,25 +58,29 @@ public class HuaweiCloudTerraformResourceHandler implements DeployResourceHandle
             Set<String> supportTypes =
                     HuaweiCloudTerraformResourceProperties.getTerraformResourceTypes();
             for (TfStateResource tfStateResource : tfState.getResources()) {
-                if (!supportTypes.contains(tfStateResource.getType())) {
+                if (supportTypes.contains(tfStateResource.getType())) {
+                    DeployResourceProperties deployResourceProperties =
+                            HuaweiCloudTerraformResourceProperties.getDeployResourceProperties(
+                                    tfStateResource.getType());
+                    for (TfStateResourceInstance instance : tfStateResource.getInstances()) {
+                        DeployResource deployResource = new DeployResource();
+                        deployResource.setGroupType(tfStateResource.getType());
+                        deployResource.setGroupName(tfStateResource.getName());
+                        deployResource.setResourceKind(deployResourceProperties.getResourceKind());
+                        TfResourceTransUtils.fillDeployResource(
+                                instance,
+                                deployResource,
+                                deployResourceProperties.getResourceProperties());
+                        deployResourceList.add(deployResource);
+                    }
                     log.info(
-                            "The resource type {} is unsupported to parse.",
+                            "Parse tf resource with type {} to deployed resource with type {}",
+                            tfStateResource.getType(),
+                            deployResourceProperties.getResourceKind());
+                } else {
+                    log.warn(
+                            "The tf resource type {} is unsupported to parse.",
                             tfStateResource.getType());
-                    continue;
-                }
-                DeployResourceProperties deployResourceProperties =
-                        HuaweiCloudTerraformResourceProperties.getDeployResourceProperties(
-                                tfStateResource.getType());
-                for (TfStateResourceInstance instance : tfStateResource.getInstances()) {
-                    DeployResource deployResource = new DeployResource();
-                    deployResource.setGroupType(tfStateResource.getType());
-                    deployResource.setGroupName(tfStateResource.getName());
-                    deployResource.setResourceKind(deployResourceProperties.getResourceKind());
-                    TfResourceTransUtils.fillDeployResource(
-                            instance,
-                            deployResource,
-                            deployResourceProperties.getResourceProperties());
-                    deployResourceList.add(deployResource);
                 }
             }
         }

--- a/plugins/huaweicloud/src/main/java/org/eclipse/xpanse/plugins/huaweicloud/resourcehandler/HuaweiCloudTerraformResourceProperties.java
+++ b/plugins/huaweicloud/src/main/java/org/eclipse/xpanse/plugins/huaweicloud/resourcehandler/HuaweiCloudTerraformResourceProperties.java
@@ -23,6 +23,7 @@ public enum HuaweiCloudTerraformResourceProperties {
     HUAWEI_CLOUD_KEYPAIR_PROPERTIES("huaweicloud_kps_keypair", new HuaweiKeyPairProperties()),
     HUAWEI_CLOUD_SECURITY_GROUP_PROPERTIES(
             "huaweicloud_networking_secgroup", new HuaweiSecurityGroupProperties()),
+    HUAWEI_CLOUD_RDS_PROPERTIES("huaweicloud_rds_instance", new HuaweiRdsProperties()),
     HUAWEI_CLOUD_SECURITY_GROUP_RULE_PROPERTIES(
             "huaweicloud_networking_secgroup_rule", new HuaweiSecurityGroupRuleProperties());
 
@@ -78,6 +79,26 @@ public enum HuaweiCloudTerraformResourceProperties {
             map.put("image_id", "image_id");
             map.put("image_name", "image_name");
             map.put("region", "region");
+            return map;
+        }
+    }
+
+    /** Huawei cloud rds properties. */
+    static class HuaweiRdsProperties extends DeployResourceProperties {
+
+        @Override
+        public DeployResourceKind getResourceKind() {
+            return DeployResourceKind.RDS;
+        }
+
+        @Override
+        public Map<String, String> getResourceProperties() {
+            Map<String, String> map = new HashMap<>();
+            map.put("ip", "fixed_ip");
+            map.put("name", "name");
+            map.put("nodes", "nodes");
+            map.put("region", "region");
+            map.put("db", "db");
             return map;
         }
     }

--- a/plugins/huaweicloud/src/test/java/org/eclipse/xpanse/plugins/huaweicloud/resourcehandler/HuaweiCloudTerraformResourcePropertiesTest.java
+++ b/plugins/huaweicloud/src/test/java/org/eclipse/xpanse/plugins/huaweicloud/resourcehandler/HuaweiCloudTerraformResourcePropertiesTest.java
@@ -104,6 +104,7 @@ class HuaweiCloudTerraformResourcePropertiesTest {
         Set<String> exceptedTypes =
                 Set.of(
                         "huaweicloud_compute_instance",
+                        "huaweicloud_rds_instance",
                         "huaweicloud_evs_volume",
                         "huaweicloud_vpc_subnet",
                         "huaweicloud_networking_secgroup_rule",

--- a/runtime/src/test/java/org/eclipse/xpanse/runtime/database/mysql/DeploymentWithMysqlTest.java
+++ b/runtime/src/test/java/org/eclipse/xpanse/runtime/database/mysql/DeploymentWithMysqlTest.java
@@ -39,7 +39,6 @@ import org.eclipse.xpanse.modules.models.service.order.ServiceOrderDetails;
 import org.eclipse.xpanse.modules.models.service.order.ServiceOrderStatusUpdate;
 import org.eclipse.xpanse.modules.models.service.order.enums.ServiceOrderType;
 import org.eclipse.xpanse.modules.models.service.order.exceptions.ServiceOrderNotFound;
-import org.eclipse.xpanse.modules.models.service.utils.ServiceInputVariablesJsonSchemaGenerator;
 import org.eclipse.xpanse.modules.models.service.view.DeployedServiceDetails;
 import org.eclipse.xpanse.modules.models.servicetemplate.Ocl;
 import org.eclipse.xpanse.modules.models.servicetemplate.enums.ServiceTemplateRegistrationState;
@@ -70,10 +69,6 @@ class DeploymentWithMysqlTest extends AbstractMysqlIntegrationTest {
     @Resource private UserCloudCredentialsApi userCloudCredentialsApi;
     @Resource private ServiceOrderManageApi serviceOrderManageApi;
     @Resource private ServiceTemplateApi serviceTemplateApi;
-
-    @Resource
-    private ServiceInputVariablesJsonSchemaGenerator serviceInputVariablesJsonSchemaGenerator;
-
     @Resource private OclLoader oclLoader;
     @Resource private ServicePortingApi servicePortingApi;
     @Resource private ServiceTemplateStorage serviceTemplateStorage;


### PR DESCRIPTION
**Fixed https://github.com/eclipse-xpanse/xpanse/issues/2490**
**Based on https://github.com/eclipse-xpanse/xpanse-samples/pull/22**
**New APIs for service objects management:**
![image](https://github.com/user-attachments/assets/a66027f1-0218-4e38-80b3-74ed8b383799)
Deploy service `mysql-01` with template `rds-mysql`successfully:
![image](https://github.com/user-attachments/assets/c9bd52e0-c633-419d-97e3-6f15ba6e7d47)
**Request ro Create Object database**
Call API to create object with type `database` for service `mysql-01`, then there is a service order with type `OBJECT_CREATE` and a service change request with resource_name `rds-tf-e1c139cb` for the service:
![image](https://github.com/user-attachments/assets/140725e1-06e5-43ef-9739-e1292d8718c8)

**Fixed https://github.com/eclipse-xpanse/xpanse/issues/2491**
**Agent get pending change and send result**
Agent called API to get the pending change request of service `mysql-01`:
![image](https://github.com/user-attachments/assets/c5eea7b7-ab05-43b2-87e0-859e5538e447)
Skip the agent execute scripts, send the result by xpanse API, after processing the change result, the service object will be created in table service_object and the service order and the change request will be completed:
![image](https://github.com/user-attachments/assets/829056c9-f7a3-4a21-b6c9-c6486220bd5a)

**Request to Create Object user**
Create user linked to database for service `mysql-01`  with secret paramters, The agent can get a pending request:
![image](https://github.com/user-attachments/assets/1e93a1e9-37c5-4f61-8ace-2c8c9be3e3a4)
Send successful result of the request to create user, the new data with type user will be stored in table service_object:
![image](https://github.com/user-attachments/assets/42173177-e7a5-4fe4-ad82-48c8984bd036)
**Request to Update Object user**
Update object `user`, data in service_order and service_change_request:
![image](https://github.com/user-attachments/assets/8b68bb4e-bd91-470d-9c41-406cca035751)
Agent send successful result of the change request to update object `user`, the object 'user' will be updated:
![image](https://github.com/user-attachments/assets/4500c181-db49-465c-9ecd-deb4176044ad)

**Request to Delete Object database**
Test API  `deleteServiceObject` with object type 'database', return error message:
![image](https://github.com/user-attachments/assets/3f58113b-331d-4053-be79-9ad7923b55d5)
**Request ro Delete Object database**
Test API  `deleteServiceObject` with object type 'user', new order and change will be created in db:
![image](https://github.com/user-attachments/assets/e7edddf0-3927-4705-b6c4-81e4dd795325)
Agent send successful result of the change request to delete object `user`, the object 'user' will be deleted:
![image](https://github.com/user-attachments/assets/b09d0dc4-4724-4bd5-ad92-475ba99a43dd)



